### PR TITLE
Feat: Persist Lessons in Dedicated Collection

### DIFF
--- a/src/app/learn/[kuId]/page.tsx
+++ b/src/app/learn/[kuId]/page.tsx
@@ -64,10 +64,9 @@ export default function LearnItemPage() {
         }
 
         const lessonData = await lessonResponse.json();
-        // console.log("Received lesson data:", lessonData);
+        console.log("Received lesson data:", lessonData);
         setLesson(lessonData as Lesson); 
-      } catch (err: any)
- {
+      } catch (err: any) {
         setError(err.message || "An unknown error occurred");
       } finally {
         setIsLoading(false);
@@ -335,6 +334,14 @@ export default function LearnItemPage() {
 
   // --- Main Render ---
   return (
+    <>
+      {/* --- DEBUGGING LOG --- */}
+      {console.log('[Render Debug]', { 
+        isLoading, 
+        hasError: !!error, 
+        lessonType: lesson?.type,
+        hasLesson: !!lesson 
+      })}
     <main className="container mx-auto max-w-4xl p-8">
       <header className="mb-8">
         <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-2 break-all">
@@ -362,6 +369,6 @@ export default function LearnItemPage() {
       )}
 
     </main>
+    </>
   );
 }
-

--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -1,4 +1,5 @@
 // This file is safe to import on both client and server.
 export const KNOWLEDGE_UNITS_COLLECTION = 'knowledge-units';
 export const REVIEW_FACETS_COLLECTION = 'review-facets';
+export const LESSONS_COLLECTION = 'lessons';
 export const API_LOGS_COLLECTION = 'api-logs';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface ApiLog {
 }
 
 export interface VocabLesson {
+  kuId?: string;
   type: 'Vocab';
   vocab: string;
   meaning_explanation: string;
@@ -36,6 +37,7 @@ export interface VocabLesson {
 }
 
 export interface KanjiLesson {
+  kuId?: string;
   type: 'Kanji';
   kanji: string;
   meaning: string;
@@ -71,7 +73,6 @@ export interface KnowledgeUnit {
   status: 'learning' | 'reviewing';
   facet_count: number;
   history?: any[]; // Or define a proper history type
-  lessonCache?: Lesson; // <-- ADD THIS CACHE FIELD
 }
 
 export type FacetType =


### PR DESCRIPTION
This PR refactors the lesson generation and storage mechanism. 

It introduces a new 'lessons' Firestore collection to persist generated lessons, decoupling them from the Knowledge Unit documents. This allows lessons to be re-reviewed and provides a more robust data model.

Changes include:
- Added 'lessons' collection to Firestore config
- Removed 'lessonCache' from the KnowledgeUnit type
- Refactored the '/api/generate-lesson' endpoint to use the new collection
- Added 'kuId' to the lesson object for referential integrity