### PR TITLE
Feat: Add Review Lesson Link and Conditionally Hide Facets

### DIFF
--- a/src/app/learn/[kuId]/page.tsx
+++ b/src/app/learn/[kuId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from 'react'; // <-- Import useRef
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { KnowledgeUnit, FacetType, Lesson, VocabLesson, KanjiLesson } from '@/types';
 import { db } from '@/lib/firebase-client';
 import { doc, getDoc } from 'firebase/firestore';
@@ -332,6 +332,9 @@ export default function LearnItemPage() {
   );
 
 
+  const searchParams = useSearchParams();
+  const source = searchParams.get('source');
+
   // --- Main Render ---
   return (
     <>
@@ -340,7 +343,8 @@ export default function LearnItemPage() {
         isLoading, 
         hasError: !!error, 
         lessonType: lesson?.type,
-        hasLesson: !!lesson 
+        hasLesson: !!lesson,
+        source: source
       })}
     <main className="container mx-auto max-w-4xl p-8">
       <header className="mb-8">
@@ -361,7 +365,7 @@ export default function LearnItemPage() {
       {lesson && lesson.type === 'Vocab' && renderVocabLesson(lesson as VocabLesson)}
       {lesson && lesson.type === 'Kanji' && renderKanjiLesson(lesson as KanjiLesson)}
 
-      {!isLoading && !error && lesson && (
+      {!isLoading && !error && lesson && source !== 'review' && (
           <>
               {/* {console.log("Render conditions met, lesson object:", lesson)} */}
               {renderFacetChecklist()}

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -405,6 +405,17 @@ export default function ReviewPage() {
             <span className="font-semibold">AI:</span> {aiExplanation}
           </p>
 
+          {answerState === 'incorrect' && currentItem && (
+            <div className="mt-4">
+              <Link
+                href={`/learn/${currentItem.ku.id}?source=review`}
+                className="inline-block px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700"
+              >
+                Review lesson on {currentItem.ku.content}
+              </Link>
+            </div>
+          )}
+
           <button
             onClick={goToNextItem}
             className="mt-6 w-full px-6 py-3 bg-gray-600 text-white font-semibold rounded-md shadow-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-gray-800"


### PR DESCRIPTION
This PR introduces two related features to improve the user experience during reviews:

1.  **Review Lesson Link:** When a user answers a review question incorrectly, a link is now displayed in the feedback section. This link, formatted as 'Review lesson on [KU Content]', takes the user directly to the lesson page for that item, allowing for quick material review.

2.  **Conditional Facet Selection:** To prevent users from accidentally creating duplicate review facets when revisiting a lesson from a review, the facet selection checklist and 'Start Learning' button are now hidden. This is controlled by a '?source=review' query parameter added to the review lesson link.

These changes create a smoother, more intuitive loop for users who need to refresh their memory on a topic they're struggling with.