### PR TITLE
Feat: Defer Component Kanji Facet Creation

### DIFF
--- a/src/app/api/evaluate-answer/route.ts
+++ b/src/app/api/evaluate-answer/route.ts
@@ -5,7 +5,7 @@ import { API_LOGS_COLLECTION } from '@/lib/firebase-config'; // Import collectio
 import { ApiLog } from '@/types'; // Import the log type
 import { performance } from 'perf_hooks'; // For timing
 
-const MODEL_NAME = process.env.MODEL_GEMINI_PRO || 'gemini-2.5-flash'
+const MODEL_NAME = process.env.MODEL_GEMINI_FLASH || 'gemini-2.5-flash'
 
 export async function POST(request: Request) {
   logger.info('--- POST /api/evaluate-answer ---');
@@ -67,7 +67,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
       },
     };
     logRef = await db.collection(API_LOGS_COLLECTION).add(initialLogData);
-    logger.debug(`Created initial log entry: ${logRef.id}`);
+    // logger.debug(`Created initial log entry: ${logRef.id}`);
     // --- End Log ---
 
     const apiKey = process.env.GEMINI_API_KEY;

--- a/src/app/api/generate-lesson/route.ts
+++ b/src/app/api/generate-lesson/route.ts
@@ -68,16 +68,30 @@ export async function POST(request: Request) {
     // --- END CACHE CHECK ---
 
     logger.info(`Cache miss. Generating new lesson for KU ${kuId}`);
-    let systemPrompt: string;
     let jsonSchema: any;
     let userMessage: string;
 
     // 2. Select prompt based on KU type
     if (ku.type === 'Kanji') {
-      systemPrompt = KANJI_SYSTEM_PROMPT;
-      jsonSchema = { /* ... Kanji schema ... */ };
-      // TODO this does things the weird way. It did work for Vocab but it shouldn't have
-      userMessage = `Generate a lesson for this Kanji: ${JSON.stringify(ku)}`;
+      const KANJI_USER_PROMPT = `You are an expert Japanese tutor. You will be asked to generate a lesson for the Kanji: ${ku.content}. The lesson should be in English. Where you want to use Japanese text for examples, explanations, meanings and readings do so but do not include Romaji. Don't over think things when determining readings. You MUST return ONLY a valid JSON object with this schema:
+      { 
+        "type": "Kanji",
+        "kanji": "The kanji character",
+        "meaning": "The core meaning(s), as a string.",
+        "reading_onyomi": [
+          { "reading": "Onyomi reading (Katakana)", "example": "Example word (kana)" }
+        ],
+        "reading_kunyomi": [
+          { "reading": "Kunyomi reading (Hiragana)", "example": "Example word (kana)" }
+        ],
+        "radicals": [
+          { "radical": "Radical character", "meaning": "Radical meaning" }
+        ],
+        "mnemonic_meaning": "A short, creative mnemonic for remembering the meaning.",
+        "mnemonic_reading": "A short, creative mnemonic for remembering the main onyomi."
+      }
+      Do not add any text before or after the JSON object.`;
+      userMessage = KANJI_USER_PROMPT;
     } else if (ku.type === 'Vocab' || ku.type === 'Concept' || ku.type === 'Grammar') {
       const VOCAB_USER_PROMPT = `You are an expert Japanese tutor. You will be asked to generate a lesson for the Japanese word: ${ku.content}.  
       The lesson should be in English. Where you want to use Japanese text for examples, explanations, meanings and readings do so but do not include Romaji. 

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -280,9 +280,15 @@ export default function ReviewPage() {
     
     // --- KANJI COMPONENT LOGIC ---
     if (facet.facetType === 'Kanji-Component-Meaning') {
-      return ku.data?.definition || '';
+      const lesson = item.lesson as KanjiLesson | undefined;
+      return lesson?.meaning || ku.data?.definition || '';
     }
     if (facet.facetType === 'Kanji-Component-Reading') {
+      const lesson = item.lesson as KanjiLesson | undefined;
+      const onyomi = lesson?.reading_onyomi?.map(r => r.reading) || [];
+      if (onyomi.length > 0) {
+        return onyomi.join(', ');
+      }
       return ku.data?.onyomi || '';
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,7 @@ export interface ReviewFacet {
 export interface ReviewItem {
   facet: ReviewFacet;
   ku: KnowledgeUnit;
+  lesson?: Lesson;
 }
 
 // This represents the structure of our old db.json


### PR DESCRIPTION
This PR implements a significant change to the learning flow for component Kanji, addressing several bugs and improving the user experience.

**Key Changes:**

1.  **Deferred Facet Creation:** When a user selects a component Kanji from a Vocab lesson, the system no longer creates review facets immediately. Instead, it creates a new 'Kanji' Knowledge Unit with a 'learning' status. This new KU then appears in the main learning queue.
2.  **Data Persistence:** The new Kanji KU is now created with the correct meaning and reading data, which is extracted from the parent Vocab lesson. This fixes a bug where component Kanji were being created with placeholder ('...') data.
3.  **Robust Review Data:** The review queue API ('/api/review-facets') now pre-fetches all necessary lesson data for due items. This ensures that the correct answers are always available during a review session, fixing a bug where component Kanji reviews were failing.
4.  **API Stability:** Fixed a critical 500 error in the review facets API caused by incompatible 'firebase-admin' imports ('Timestamp', 'FieldPath') in the Next.js edge environment. The queries have been refactored to be more robust.
5.  **Kanji Lesson Rendering:** Fixed a bug where Kanji lessons were not rendering correctly due to a race condition in the component's state updates.

This new flow ensures that users address each component Kanji as a distinct learning item, preventing duplicate facets and providing a more structured learning path.