### PR TITLE
feat: add audio comprehension reviews

### DIFF
--- a/backend/src/audio/audio.controller.ts
+++ b/backend/src/audio/audio.controller.ts
@@ -21,6 +21,7 @@ export class AudioController {
             res.set({
                 'Content-Type': 'audio/mpeg',
                 'Content-Length': audioBuffer.length,
+                'Cache-Control': 'public, max-age=31536000',
             });
 
             res.send(audioBuffer);

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -681,6 +681,129 @@ export class GeminiService implements OnModuleInit {
     }
   }
 
+  async generateClozeSentence(targetVocab: string, sentence: string): Promise<string> {
+    // Strip inline furigana (format: 漢字[ふりがな]) before sending to the AI and using in fallbacks.
+    const cleanSentence = sentence.replace(/\[[^\]]*\]/g, '');
+
+    const systemPrompt = `You are an expert Japanese morphological analysis assistant specializing in cloze generation for SRS language learning flashcards.
+
+**Task:**
+Given a target vocabulary word in dictionary form and a context sentence that uses it (possibly conjugated or inflected), produce a cloze-deleted version of the sentence by replacing the occurrence of the target word with [_____].
+
+**Rules:**
+1. Identify the surface form: locate the token(s) in the sentence that represent the conjugated or inflected occurrence of the target vocabulary.
+2. Replace the ENTIRE conjugated word form — including its conjugation endings and any directly fused auxiliary verbs — with [_____]. This covers:
+   - All verb conjugations: plain/polite, past/non-past, negative, potential, causative, passive (食べる → 食べた, 食べます, 食べません, 食べられる, etc.)
+   - Te-form auxiliary constructions attached to the stem (食べている, 食べてみる, 食べてしまった → the entire compound is the target's occurrence)
+   - Suru-verb nominals used verbally (勉強する → 勉強しました → replace the whole 勉強しました)
+   - I-adjective conjugations (大きい → 大きかった, 大きくない → the whole conjugated form)
+   - Na-adjective citation form WITHOUT the connector な (有名な歌手 → replace only 有名, leaving な intact: [_____]な歌手)
+3. Preserve ALL other characters in the sentence EXACTLY. Do NOT rewrite, paraphrase, reorder, simplify, or otherwise alter any part of the sentence outside the blank.
+4. If the target word appears more than once, replace ONLY the first occurrence.
+5. If the target word is embedded in a morphologically related compound that has a distinct meaning (e.g., target: 食べる but sentence contains 大食い), do NOT replace it — these are different lexical items. Scan only for direct inflectional derivatives.
+6. If no occurrence can be confidently identified even after morphological analysis, replace the longest token in the sentence that shares the most morphemes with the target word. Never return the sentence unchanged.
+7. The placeholder MUST be written as exactly: [_____] — one opening bracket, five underscores, one closing bracket. No other format is acceptable.
+8. Do NOT add Romaji, parenthetical notes, translations, or any annotation to the output.
+9. Do NOT output any text before or after the JSON object. Do NOT use markdown code blocks or backticks.
+
+**Examples:**
+Vocabulary: "食べる"
+Sentence: "朝ごはんにパンを食べました。"
+Output: { "clozeSentence": "朝ごはんにパンを[_____]。" }
+
+Vocabulary: "行く"
+Sentence: "明日、学校に行きます。"
+Output: { "clozeSentence": "明日、学校に[_____]。" }
+
+Vocabulary: "食べる"
+Sentence: "毎日、野菜を食べています。"
+Output: { "clozeSentence": "毎日、野菜を[_____]。" }
+
+Vocabulary: "勉強する"
+Sentence: "毎日日本語を勉強しています。"
+Output: { "clozeSentence": "毎日日本語を[_____]。" }
+
+Vocabulary: "有名"
+Sentence: "彼は有名な歌手です。"
+Output: { "clozeSentence": "彼は[_____]な歌手です。" }
+
+Vocabulary: "大きい"
+Sentence: "その犬はとても大きかったです。"
+Output: { "clozeSentence": "その犬はとても[_____]。" }`;
+
+    const userMessage = `Vocabulary: "${targetVocab}"\nSentence: "${cleanSentence}"`;
+
+    const schema = {
+      type: 'OBJECT',
+      properties: {
+        clozeSentence: { type: 'STRING' }
+      },
+      required: ['clozeSentence']
+    };
+
+    const initialLogData: ApiLog = {
+      timestamp: Timestamp.now(),
+      route: '/reviews/generate-cloze',
+      status: 'pending',
+      modelUsed: this.modelName,
+      requestData: {
+        userMessage,
+        content: targetVocab,
+        topic: targetVocab,
+      },
+    };
+
+    const logRef = await this.apilogService.startLog(initialLogData);
+    const startTime = performance.now();
+    let errorOccurred = false;
+    let capturedError: any;
+    let aiJsonText: string | undefined;
+    let parsedJson: any;
+
+    try {
+      const response = await this.client.models.generateContent({
+        model: this.modelName,
+        contents: [{ parts: [{ text: userMessage }] }],
+        config: {
+          responseMimeType: 'application/json',
+          responseSchema: schema,
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          temperature: 0.1,
+        },
+      });
+
+      aiJsonText = response.text;
+      if (!aiJsonText) return cleanSentence.replace(targetVocab, '[_____]');
+
+      parsedJson = JSON.parse(aiJsonText);
+      return parsedJson.clozeSentence || cleanSentence.replace(targetVocab, '[_____]');
+    } catch (error: any) {
+      errorOccurred = true;
+      capturedError = error;
+      this.logger.error('Failed to generate cloze sentence', error);
+      return cleanSentence.replace(targetVocab, '[_____]');
+    } finally {
+      if (logRef) {
+        const endTime = performance.now();
+        const durationMs = endTime - startTime;
+        const updateData: any = { durationMs };
+        if (errorOccurred) {
+          updateData.status = 'error';
+          updateData.errorData = { message: capturedError?.message || 'Unknown error' };
+        } else {
+          updateData.status = 'success';
+          updateData.responseData = {
+            rawText: aiJsonText,
+            parsedJson,
+          };
+        }
+        this.apilogService.completeLog(logRef, updateData).catch(err =>
+          console.error('Failed to update cloze log', err)
+        );
+      }
+    }
+  }
+
   async deleteContextCache(name: string): Promise<void> {
     try {
       await this.client.caches.delete({ name });

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -270,6 +270,23 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 continue;
             }
 
+            let modifiedData: any = undefined;
+            if (data) {
+                modifiedData = { ...data };
+            }
+
+            if (key === 'audio' && modifiedData?.contextExample) {
+                try {
+                    const ku = await this.knowledgeUnitsService.findOne(uid, targetKuId);
+                    if (ku && ku.content) {
+                        const clozeSentence = await this.geminiService.generateClozeSentence(ku.content, modifiedData.contextExample.sentence);
+                        modifiedData.clozeSentence = clozeSentence;
+                    }
+                } catch (err) {
+                    this.logger.error(`Failed to generate cloze for audio facet ${kuId}`, err);
+                }
+            }
+
             // --- Create the Facet (Batch) ---
             // Now we just create the facet pointing to whichever ID we resolved (Vocab or Kanji)
             const newFacetRef = this.db.collection(REVIEW_FACETS_COLLECTION).doc();
@@ -281,6 +298,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 createdAt: now,
                 history: [],
                 userId: uid,
+                ...(modifiedData ? { data: modifiedData } : {}),
             });
 
             count++;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -319,7 +319,8 @@ export type FacetType =
   | "AI-Generated-Question"
   | "Reading-to-Content"
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
-  | "Kanji-Component-Reading"; // e.g., "食" -> "ショク"
+  | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
+  | "audio";
 
 export interface ReviewFacet {
   id: string;
@@ -336,6 +337,7 @@ export interface ReviewFacet {
   }>;
   currentQuestionId?: string;
   questionAttempts?: number;
+  data?: any;
 }
 
 /**

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -232,6 +232,16 @@ export default function LearnItemPage() {
             },
           };
         }
+        if (key === "audio" && lesson.type === "Vocab") {
+          const vocabLesson = lesson as VocabLesson;
+          const ex = vocabLesson.context_examples && vocabLesson.context_examples.length > 0
+            ? vocabLesson.context_examples[Math.floor(Math.random() * vocabLesson.context_examples.length)]
+            : null;
+          return {
+            key: key,
+            data: ex ? { contextExample: ex } : undefined,
+          };
+        }
         return { key: key };
       });
 
@@ -328,6 +338,20 @@ export default function LearnItemPage() {
                 />
                 <span className="ml-3 text-lg text-gray-900 dark:text-white">
                   Reading
+                </span>
+              </label>
+            )}
+
+            {lesson.type === "Vocab" && (lesson as VocabLesson).context_examples && (lesson as VocabLesson).context_examples!.length > 0 && (
+              <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                  checked={!!selectedFacets["audio"]}
+                  onChange={() => handleCheckboxChange("audio")}
+                />
+                <span className="ml-3 text-lg text-gray-900 dark:text-white">
+                  Audio Comprehension
                 </span>
               </label>
             )}

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -58,6 +58,39 @@ export default function ReviewPage() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editingKu, setEditingKu] = useState<KnowledgeUnit | null>(null);
 
+  // --- Audio State ---
+  const audioCache = useRef<Record<string, string>>({});
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const fetchAndPlayAudio = async (text: string) => {
+    if (audioCache.current[text]) {
+      if (audioRef.current) {
+        audioRef.current.src = audioCache.current[text];
+        audioRef.current.play();
+      }
+      return;
+    }
+    
+    try {
+      const response = await apiFetch("/api/audio/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      if (response.ok) {
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        audioCache.current[text] = url;
+        if (audioRef.current) {
+          audioRef.current.src = url;
+          audioRef.current.play();
+        }
+      }
+    } catch (e) {
+      console.error("Failed to play audio", e);
+    }
+  };
+
   const currentItem = reviewQueue[currentIndex];
 
   const reviewCount = reviewQueue.length;
@@ -149,6 +182,13 @@ export default function ReviewPage() {
 
   // --- Effect to handle current item changes ---
   useEffect(() => {
+    if (currentItem && currentItem.facet.facetType === "audio") {
+      // Small timeout to let UI mount
+      setTimeout(() => {
+        fetchAndPlayAudio(currentItem.ku.data?.reading || currentItem.ku.content);
+      }, 50);
+    }
+
     if (
       currentItem &&
       currentItem.facet.facetType === "AI-Generated-Question"
@@ -541,6 +581,8 @@ export default function ReviewPage() {
   const getQuestion = (item: ReviewItem): string | null => {
     const { ku, facet } = item;
     switch (facet.facetType) {
+      case "audio":
+        return facet.data?.clozeSentence || facet.data?.contextExample?.sentence || "Context not found";
       case "AI-Generated-Question":
         return dynamicQuestion; // Returns null if loading
       case "Content-to-Definition":
@@ -573,6 +615,8 @@ export default function ReviewPage() {
       case "Definition-to-Content":
       case "Reading-to-Content":
         return "Vocab/Kanji";
+      case "audio":
+        return "Audio Comprehension";
       default:
         return "...";
     }
@@ -619,7 +663,7 @@ export default function ReviewPage() {
     if (ku.type === "Vocab") {
       // --- VOCAB LOGIC ---
       const lesson = item.lesson as VocabLesson | undefined;
-      if (facet.facetType === "Content-to-Definition") {
+      if (facet.facetType === "Content-to-Definition" || facet.facetType === "audio") {
         // Collect all potential definition strings
         const rawDefinitions: string[] = [];
 
@@ -642,6 +686,10 @@ export default function ReviewPage() {
               .filter((def) => def.length > 0),
           ),
         );
+
+        if (facet.facetType === "audio") {
+          return uniqueDefinitions;
+        }
 
         console.log(
           "Expected answers for Content-to-Definition:",
@@ -789,10 +837,26 @@ export default function ReviewPage() {
 
               {/* Main Question Text */}
               <p
-                className={`${currentItem.facet.facetType === "AI-Generated-Question" || currentItem.facet.facetType === "Definition-to-Content" ? "text-2xl" : "text-5xl"} font-bold text-white break-words`}
+                className={`${currentItem.facet.facetType === "AI-Generated-Question" || currentItem.facet.facetType === "Definition-to-Content" || currentItem.facet.facetType === "audio" ? "text-2xl" : "text-5xl"} font-bold text-white break-words`}
               >
                 {questionText || "[Question not loaded]"}
               </p>
+
+              {currentItem.facet.facetType === "audio" && (
+                <div className="mt-6 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => fetchAndPlayAudio(currentItem.ku.data?.reading || currentItem.ku.content)}
+                    className="flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 rounded-full text-white font-semibold transition-transform transform active:scale-95 shadow-md"
+                  >
+                    <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M4.018 14L14.41 9 4.018 4v10z"></path>
+                    </svg>
+                    Play Audio
+                  </button>
+                  <audio ref={audioRef} style={{ display: 'none' }} />
+                </div>
+              )}
             </>
           )}
         </div>
@@ -819,9 +883,11 @@ export default function ReviewPage() {
               }
             }}
             placeholder={
-              getQuestionType(currentItem) === "Definition"
-                ? "Type your answer..."
-                : "回答を入力して..."
+              isJapaneseInput(currentItem)
+                ? "回答を入力して..."
+                : currentItem.facet.facetType === "audio"
+                  ? "Type the English meaning..."
+                  : "Type your answer..."
             }
             disabled={answerState !== "unanswered" || isDynamicLoading}
             className="w-full p-4 bg-gray-700 border-2 border-gray-600 text-white text-xl rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-800 disabled:text-gray-500"
@@ -906,6 +972,21 @@ export default function ReviewPage() {
               <span className="font-semibold">Correct answer:</span>{" "}
               {getExpectedAnswer(currentItem).join(" / ")}
             </p>
+          )}
+          {currentItem.facet.facetType === "audio" && (
+            <div className="mb-4">
+              <p className="text-lg text-gray-200">
+                <span className="font-semibold">Word:</span>{" "}
+                <span className="text-2xl font-bold text-white">{currentItem.ku.content}</span>
+                {currentItem.ku.data?.reading && currentItem.ku.data.reading !== currentItem.ku.content && (
+                  <span className="ml-2 text-gray-300">({currentItem.ku.data.reading})</span>
+                )}
+              </p>
+              <p className="text-lg text-gray-200 mt-2">
+                <span className="font-semibold">In context:</span>{" "}
+                {currentItem.facet.data?.contextExample?.sentence}
+              </p>
+            </div>
           )}
           {aiExplanation === "No answer provided." ? (
             <p className="text-lg text-gray-200 italic">{aiExplanation}</p>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -306,7 +306,8 @@ export type FacetType =
   | "AI-Generated-Question"
   | "Reading-to-Content"
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
-  | "Kanji-Component-Reading"; // e.g., "食" -> "ショク"
+  | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
+  | "audio";
 
 export interface ReviewFacet {
   id: string;
@@ -323,6 +324,7 @@ export interface ReviewFacet {
   }>;
   currentQuestionId?: string;
   questionAttempts?: number;
+  data?: any;
 }
 
 /**


### PR DESCRIPTION
## Summary           
                                                                                                                                                    
  Introduces an **Audio Comprehension** review facet (`audio`) for vocabulary items. When reviewing, the user hears the target word spoken aloud,   
  sees a cloze-deleted context sentence as a visual anchor to disambiguate homophones, and types the English meaning.
                                                                                                                                                    
  ## Changes      

  ### Types (`backend/src/types/index.ts`, `frontend/src/types/index.ts`)                                                                           
  - Added `"audio"` to the `FacetType` union.
  - Added `data?: any` field to `ReviewFacet` to carry facet-specific payload (cloze sentence and source context example).                          
                                                                                                                                                    
  ### Backend: Facet Generation (`backend/src/reviews/reviews.service.ts`)
  - When an `audio` facet is created, a randomly selected `contextExample` from the vocab lesson is attached to the facet record.                   
  - The AI is called synchronously at creation time to produce a pre-computed `clozeSentence` (the context sentence with the target word replaced by
   `[_____]`), handling conjugated/inflected forms correctly. This is stored alongside the raw `contextExample` on the Firestore document.          
                                                                                                                                                    
  ### Backend: Cloze Generation (`backend/src/gemini/gemini.service.ts`)                                                                            
  - Added `generateClozeSentence(targetVocab, sentence)` to `GeminiService`.
  - Furigana annotations (`漢字[ふりがな]`) are stripped from the sentence with a regex before the API call, making the pre-processing deterministic
   rather than relying on the AI to do it.                                                                                                          
  - The prompt gives the model a named expert role, 9 numbered rules covering all major conjugation classes (te-form auxiliaries, suru-verb         
  compounds, i/na-adjective inflections, compound word disambiguation), and 6 worked examples with real Japanese content.                           
  - API call and response are logged to `ApilogService` via the standard `startLog`/`completeLog` pattern used by all other methods in the service.
                                                                                                                                                    
  ### Backend: Audio Response Headers (`backend/src/audio/audio.controller.ts`)                                                                     
  - Added `Cache-Control: public, max-age=31536000` to the `/api/audio/speak` response to allow HTTP-level caching.                                 
                                                                                                                                                    
  ### Frontend: Facet Selection (`frontend/src/app/learn/[kuId]/page.tsx`)                                                                          
  - Added **Audio Comprehension** checkbox to the facet selection screen. Only shown for Vocab KUs that have at least one context example. Selecting
   it picks a random context example and sends it with the facet creation request.                                                                  
                  
  ### Frontend: Review Session (`frontend/src/app/review/page.tsx`)                                                                                 
  - **Audio playback**: `fetchAndPlayAudio` fetches audio from `POST /api/audio/speak`, stores the resulting Blob as a `URL.createObjectURL` in a
  `useRef` cache keyed by text, and replays from cache on repeated clicks — preventing duplicate API calls within a session.                        
  - **TTS input**: uses `ku.data.reading` (kana) instead of `ku.content` (kanji) to avoid ambiguous readings being mispronounced by the TTS engine
  (e.g. `何時` being read as `いつ` instead of `なんじ`).                                                                                           
  - **Card rendering**: hides the target word; displays the cloze sentence at reduced font size; shows a prominent Play Audio button with a speaker
  icon; auto-plays audio on card mount.                                                                                                             
  - **Input placeholder**: fixed a dead condition (`getQuestionType === "Definition"` never matched) and replaced it with `isJapaneseInput()` logic,
   with a specific `"Type the English meaning..."` placeholder for audio facets.                                                                    
  - **Answer evaluation**: audio facets are validated against the full set of definitions (same path as `Content-to-Definition`).
  - **Post-answer reveal**: displays the target word prominently with its reading in parentheses, and the full original context sentence beneath it.
                                                                                       