### PR TITLE
feat: implement user auth and signin

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -25,3 +25,7 @@
 
 ## Project Run State
 - Ensure the backend (`yarn start:dev` on port 3500) and frontend (`yarn dev` on port 3000) are running simultaneously when verifying tasks.
+
+## Project maintenance
+
+- Once you've completed a task, update the `ARCHITECTURE.md` and `AGENT_INSTRUCTIONS.md` files to reflect the changes you've made. In Architecture.md, update the "Migration History" section to include the changes you've made.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,10 +11,20 @@ The application is built on a split architectural model:
 - **Database**: Firebase Firestore.
 - **AI Brain**: Google Gemini via `@google/genai` (used extensively in the `/backend/src/gemini` and `/backend/src/lessons` modules).
 
+**Note**: We've failed so far in attempts to convert the app into a monorepo. Eventually we will need to complete this task
+
 ## Design Principles
 1. **Separation of Concerns**: The frontend is strictly a view layer containing UI components, React state, and data-fetching hooks. The backend is the definitive source of truth and the only service allowed to connect directly to the database.
 2. **AI-First Generation**: Content is dynamically generated using the current model (Gemini 3.0 Flash Preview) instead of relying on pre-authored datasets. Knowledge Units (KUs), lessons, and review-facets are distinct entity types, each having its own document, and are assembled just-in-time.
 3. **Database Workflow**: For local development, the backend handles all database interactions. You can optionally use the Firestore Emulator (`localhost:8080`) for testing.
+
+## Data and Types
+
+### Types
+Backend and Frontend are effectively separate components that communicate via REST API.  Aim is to one day convert to a monorepo. Each component has it's own type definitions file located in `<component>/src/types/index.ts`, they should basically be the same but can get our of sync. The types have developed over time on the basis that there is a single user using the system. Plumbing for users has been added but is not actually used in anyway other than to provide a default auth token for use in authenticating calls to the backend. We tried to separate the "Global" data from user specific data but the AI made some poor choices.
+
+### Data
+Basic Vocab data was extracted from Wanikani and then boiled down to non-proprietary data including content/slug, reading, meaning and wanikani level. These data have been bulk added to the `knowledge-units` collection in Firestore.
 
 ## Component Responsibilities
 
@@ -42,5 +52,183 @@ The application is built on a split architectural model:
   - Backend: Runs on `http://localhost:3500` (`yarn start:dev` inside `/backend`)
   - Firestore Emulator (Optional for testing): Runs on `http://localhost:8080` (usually launched via root `firebase emulators:start`)
 
+## ToDo
+
+### Manage page
+- Add JLPT badges and Wanikani level badges to the listings for each Vocab
+- Add a way to filter by JLPT level and Wanikani level
+- **Meta requirement**: The manage page should eventually be just and admin function and not a list of the Vocab the User has in their learning or review queues or in their overall user context (if we go down that route). This requires a lot of other work to be done first.
+
+### Users
+- (Given) Global KU data is stored in the `knowledge-units` collection in Firestore and accessed via the `knowledge-units` service.
+- (ToDo)User KU data **should be** metadata that references global KU data (not replicates). It should be stored in users/{uid}/user-kus
+- (ToDo) We need to fully implement users and provide a way for users to sign up and log in.
+  - When a new user logs in for the first time they'll start with a clean slate. Once we have this condition in place we can start to implement a way to add KUs to a user's learning queue using Scenarios and other tools.
+
+## User Management, Authentication & Multi-Tenancy
+
+This section documents the current implementation of auth and user scoping so that agents completing the Users ToDo items have a clear baseline to build from.
+
+### Current State Summary
+
+Authentication plumbing exists end-to-end but the system effectively operates as **single-tenant** today because the only real user in development is the hardcoded `user_default`. Firebase anonymous auth is wired up on the frontend and real Firebase ID tokens are passed to the backend, but the backend guard silently falls back to `user_default` on any failure or missing token in dev mode.
+
+---
+
+### Authentication Flow
+
+**Frontend → Backend token handoff**
+
+1. `frontend/src/providers/AuthProvider.tsx` — wraps the app. On mount, `onAuthStateChanged` fires; if no session exists it calls `signInAnonymously()`. The resulting Firebase `User` object is stored in React Context.
+2. `frontend/src/lib/firebase-client.ts` — initialises the Firebase Web SDK (project `gen-lang-client-0878434798`, env vars `NEXT_PUBLIC_FIREBASE_API_KEY` / `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`). In development it connects to the Firestore Emulator at `localhost:8080`.
+3. `frontend/src/lib/api-client.ts` — thin `fetch` wrapper. Before every request it calls `auth.authStateReady()` then `auth.currentUser.getIdToken()` and injects the result as `Authorization: Bearer <token>`. Failures are caught and logged but the request still proceeds (without a token).
+
+**Backend token validation**
+
+`backend/src/auth/firebase-auth.guard.ts` implements `FirebaseAuthGuard`:
+
+- **Development (`NODE_ENV !== 'production'`):**
+  - No `Authorization` header → sets `request.user = { uid: 'user_default' }`, returns `true`.
+  - Token present but `admin.auth().verifyIdToken()` throws → sets `request.user = { uid: 'user_default' }`, returns `true`.
+  - Token valid → sets `request.user = decodedToken` (real Firebase UID).
+- **Production (`NODE_ENV === 'production'`):**
+  - No header → throws `UnauthorizedException`.
+  - Invalid token → throws `UnauthorizedException`.
+  - Valid token → sets `request.user = decodedToken`.
+
+`backend/src/auth/user-id.decorator.ts` — `@UserId()` param decorator that reads `request.user?.uid`. Used on every protected controller method.
+
+**Hardcoded default user**
+
+`backend/src/lib/constants.ts` exports `CURRENT_USER_ID = 'user_default'`. The string `'user_default'` is also used directly in the guard. All Firestore documents written during local development will have `userId: 'user_default'`.
+
+---
+
+### Guard Coverage
+
+Every controller applies `@UseGuards(FirebaseAuthGuard)` at the class level:
+- `auth.controller.ts`, `user.controller.ts`, `knowledge-units.controller.ts`, `reviews.controller.ts`, `lessons.controller.ts`, `questions.controller.ts`, `stats.controller.ts`, `scenarios.controller.ts`, `kanji.controller.ts`
+
+All service methods accept `uid: string` as their first parameter and use it for Firestore scoping (see below).
+
+---
+
+### Firestore Multi-Tenancy Pattern
+
+The database uses **flat top-level collections** (not Firestore sub-collections per user). Tenancy isolation is enforced by a `userId` field on every document, not by collection path.
+
+**Query scoping** — every `findAll`-style query adds `.where('userId', '==', uid)`:
+- `knowledge-units.service.ts` line 23
+- `reviews.service.ts` line 64, 328, 378
+- `lessons.service.ts` line 196, 231
+- `stats.service.ts` line 21, 27, 33
+- `scenarios.service.ts` line 42
+
+**Ownership verification** — every `findOne`/`update`/`delete` method re-checks `doc.data().userId !== uid` and throws `NotFoundException` on mismatch:
+- `knowledge-units.service.ts` line 353
+- `knowledge-units.service.ts` line 187 (update)
+- `scenarios.service.ts` line 64
+
+**Write operations** always include `userId: uid` in the document payload.
+
+**Exception — `api-logs` collection** is written without a `userId` field and is not scoped per user.
+
+---
+
+### Firestore Collection Map
+
+| Collection | Scoped by userId? | Notes |
+|---|---|---|
+| `knowledge-units` | Yes (field) | All vocab KUs live here; `userId` field set on every doc |
+| `review-facets` | Yes (field) | SRS state per KU facet |
+| `lessons` | Yes (field) | AI-generated lesson documents |
+| `questions` | Yes (field) | Question documents |
+| `scenarios` | Yes (field) | Roleplay scenario state |
+| `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION).doc(uid)` |
+| `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
+| `api-logs` | **No** | Centralised logging; no user field |
+
+---
+
+### Key Types
+
+- **`UserRoot`** (`backend/src/types/index.ts` ~line 34) — stored at `users/{uid}`. Contains `stats`, `tutorContext`, and `preferences` (e.g. `dailyMaxNew`).
+- **`KnowledgeUnit`** (~line 205) — has `userId` field (marked `@deprecated` as part of future migration to a separate `user-kus` sub-collection). `data` bag holds `jlptLevel`, `wanikaniLevel`, `reading`, `meaning`.
+- **`UserKnowledgeUnit`** (~line 235) — intended future shape: user metadata (`status`, `personalNotes`, `facet_count`) pointing at a global KU via `kuId`. **Not yet used in queries.**
+- **`ReviewFacet`** (~line 261) — bridges to `KnowledgeUnit` via `kuId`; carries `srsStage` (0–8) and `nextReviewAt`.
+- **`UserQuestionState`** (~line 290) — bridges to a global `Question` via `questionId`; tracks answer history per user.
+
+---
+
+### Environment Variables
+
+**Backend (`backend/.env`)**
+```
+GOOGLE_CLOUD_PROJECT=gen-lang-client-0878434798   # Firebase project
+FIRESTORE_DB=aisrs-japanese-dev                    # Named Firestore database
+NODE_ENV                                           # 'production' enables strict auth
+```
+
+**Frontend (`frontend/.env.local`)**
+```
+NEXT_PUBLIC_FIREBASE_API_KEY=...
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=gen-lang-client-0878434798.firebaseapp.com
+```
+
+---
+
+### What Needs to Be Done (Implementation Guide for Agents)
+
+The following work is required to complete proper multi-user support. Each item builds on the previous.
+
+**1. Replace anonymous auth with real sign-up / sign-in**
+- Frontend: add email/password (or Google OAuth) sign-in UI. The `AuthProvider` already handles `onAuthStateChanged`; swap `signInAnonymously()` for the chosen provider.
+- Backend: no changes needed — the guard already calls `admin.auth().verifyIdToken()` correctly for real users.
+
+**2. User creation on first login**
+- When a new UID is seen for the first time, create a `users/{uid}` document (default `UserRoot`) and seed any required initial state.
+- This can live in the `UsersService` (`backend/src/users/user.service.ts`) called from an `onAuthStateChanged` or a dedicated `/users/init` endpoint.
+
+**3. Migrate KU user-data to `users/{uid}/user-kus`**
+- Currently all KU data (including user-specific fields like `status`, `personalNotes`, `facet_count`) is stored in the flat `knowledge-units` collection with a `userId` field.
+- Target: split into a **global** `knowledge-units` collection (content, reading, meaning, jlptLevel, wanikaniLevel — no `userId`) and a **per-user** sub-collection `users/{uid}/user-kus` (status, personalNotes, facet_count, kuId pointer).
+- The `UserKnowledgeUnit` type already captures this intended shape.
+- Update `KnowledgeUnitsService` to join the two on reads and write to the correct collection on creates/updates.
+
+**4. Harden the dev guard bypass**
+- The current fallback to `user_default` on any token failure in dev mode is useful but should log a warning so it is obvious when a real token is being silently dropped.
+- Consider making the default UID configurable via env var (`DEFAULT_DEV_UID`) so individual developers can test with their own UID against a shared emulator.
+
+**5. Scope `api-logs` by user (optional)**
+- Add `userId` field to log documents so per-user activity can be audited.
+
 ## Migration History
+
+**Note**: This section is very much outdated but should be used to summarize the history of the project. 
+
 Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...`) that directly connected to a `db.json` and then migrated to Firestore. Those legacy Next.js API endpoints are now deprecated and moved into the `legacy-api/` directory (or removed). The backend is strictly the `/backend` folder.
+
+**Multi-tenant auth implementation (2026-04)**
+
+- Replaced anonymous Firebase sign-in with **passwordless email-link authentication** (`sendSignInLinkToEmail` / `signInWithEmailLink`).
+- Added `frontend/src/app/login/page.tsx` — email-only "Send Sign-in Link" form. Shows a confirmation screen after the link is sent. No header rendered on this page.
+- Added `frontend/src/app/auth/callback/page.tsx` — landing page for the Firebase email link. Calls `isSignInWithEmailLink` + `signInWithEmailLink` to complete auth. Handles cross-device sign-in (prompts for email if localStorage is empty on a different device).
+- Rewrote `frontend/src/providers/AuthProvider.tsx`:
+  - `onAuthStateChanged` drives routing. Public paths (`/login`, `/auth/callback`) are accessible without auth; all other routes redirect to `/login`.
+  - On successful auth, calls `GET /api/users/me` (idempotent find-or-create) to initialise the `users/{uid}` document.
+  - Exposes `signOut()` via `AuthContext`.
+- Updated `frontend/src/components/Header.tsx`:
+  - Returns `null` when `user` is not set, so no nav chrome appears on public pages.
+  - Stats are only fetched after a user is confirmed.
+  - Displays truncated user email and a "Sign out" button.
+- The backend `FirebaseAuthGuard` dev-mode fallback is extended: when no Bearer token is present it now reads the `X-Dev-User-Id` request header (if set) before falling back to `user_default`. This lets the frontend dev bypass target a specific UID.
+- **Dev workflow**: to run the frontend against existing Firestore data without signing in, pass both env vars at start time:
+  ```
+  NEXT_PUBLIC_DEV_SKIP_AUTH=true NEXT_PUBLIC_DEV_USER_ID=<uid> yarn dev
+  ```
+  Omit `NEXT_PUBLIC_DEV_USER_ID` to fall back to `user_default`.
+- **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
+  1. Authentication → Sign-in method → **Email/Password** enabled.
+  2. Authentication → Sign-in method → **Email link (passwordless sign-in)** enabled (sub-toggle under Email/Password).
+  3. Authentication → Settings → Authorized domains — ensure `localhost` is listed (removed by default in projects created after 2025-04-28).
+  4. **Public-facing name** (controls the app name shown in auth emails): this field only becomes accessible in the Firebase Console once a third-party auth provider (e.g. Google Sign-In) is enabled. Enable Google Sign-In, set the name to `AIGENKI`, then disable Google Sign-In again if passwordless-only is preferred.

--- a/backend/src/auth/firebase-auth.guard.ts
+++ b/backend/src/auth/firebase-auth.guard.ts
@@ -12,8 +12,11 @@ export class FirebaseAuthGuard implements CanActivate {
     // Local dev bypass logic
     if (process.env.NODE_ENV !== 'production') {
       if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        this.logger.warn('Local dev mode: No Bearer token found. Bypassing auth and injecting user_default.');
-        request.user = { uid: 'user_default' };
+        // Allow frontend dev bypass to specify an explicit UID via header.
+        // Falls back to user_default when the header is absent.
+        const devUid = request.headers['x-dev-user-id'] || 'user_default';
+        this.logger.warn(`Local dev mode: No Bearer token found. Injecting uid: ${devUid}`);
+        request.user = { uid: devUid };
         return true;
       }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -235,7 +235,7 @@ export interface KnowledgeUnit {
 export interface UserKnowledgeUnit {
   id: string;
   userId: string;
-  kuId: string; // Bridges to GlobalKnowledgeUnit.id
+  kuId: string; // Bridges to KnowledgeUnit.id
   personalNotes: string;
   userNotes?: string;
   createdAt: Timestamp;

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  isSignInWithEmailLink,
+  signInWithEmailLink,
+  AuthError,
+} from "firebase/auth";
+import { auth } from "@/lib/firebase-client";
+import { useRouter } from "next/navigation";
+import { EMAIL_FOR_SIGN_IN_KEY } from "@/app/login/page";
+
+type Status = "checking" | "needs-email" | "signing-in" | "error";
+
+export default function AuthCallbackPage() {
+  const [status, setStatus] = useState<Status>("checking");
+  const [error, setError] = useState<string | null>(null);
+  // Cross-device: user opened the link on a different device and localStorage is empty
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const router = useRouter();
+
+  const completeSignIn = async (email: string) => {
+    setStatus("signing-in");
+    try {
+      await signInWithEmailLink(auth, email, window.location.href);
+      window.localStorage.removeItem(EMAIL_FOR_SIGN_IN_KEY);
+      // onAuthStateChanged in AuthProvider fires → calls /api/users/me → redirects to /
+    } catch (err) {
+      setError(getErrorMessage((err as AuthError).code));
+      setStatus("error");
+    }
+  };
+
+  useEffect(() => {
+    if (!isSignInWithEmailLink(auth, window.location.href)) {
+      // Not a valid sign-in link — send back to the login page
+      router.replace("/login");
+      return;
+    }
+
+    const stored = window.localStorage.getItem(EMAIL_FOR_SIGN_IN_KEY);
+    if (stored) {
+      completeSignIn(stored);
+    } else {
+      // Cross-device sign-in: ask the user to confirm their email
+      setStatus("needs-email");
+    }
+    // completeSignIn only uses window.location.href which is stable on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleConfirm = (e: React.FormEvent) => {
+    e.preventDefault();
+    completeSignIn(confirmEmail);
+  };
+
+  /* ── Spinner while checking / signing in ───────────────────────────── */
+  if (status === "checking" || status === "signing-in") {
+    return (
+      <div className="min-h-screen bg-shodo-paper flex items-center justify-center">
+        <p className="animate-pulse text-shodo-ink/50 text-sm">
+          Signing you in…
+        </p>
+      </div>
+    );
+  }
+
+  /* ── Cross-device: confirm email ────────────────────────────────────── */
+  if (status === "needs-email") {
+    return (
+      <div className="min-h-screen bg-shodo-paper flex items-center justify-center p-4">
+        <div className="w-full max-w-sm">
+          <div className="text-center mb-8">
+            <h1 className="text-4xl font-bold text-shodo-ink tracking-tight">
+              AIGENKI
+            </h1>
+          </div>
+          <p className="text-shodo-ink/70 text-sm mb-4">
+            Confirm your email address to complete sign-in.
+          </p>
+          <form onSubmit={handleConfirm} className="space-y-4">
+            <input
+              type="email"
+              value={confirmEmail}
+              onChange={(e) => setConfirmEmail(e.target.value)}
+              required
+              autoFocus
+              autoComplete="email"
+              placeholder="you@example.com"
+              className="w-full px-3 py-2 border border-shodo-ink/20 rounded-md bg-shodo-paper text-shodo-ink placeholder-shodo-ink/30 focus:outline-none focus:ring-1 focus:ring-shodo-ink/40 text-sm"
+            />
+            <button
+              type="submit"
+              className="w-full py-2 px-4 bg-shodo-ink text-shodo-paper rounded-md font-medium text-sm hover:bg-shodo-ink/85 transition-colors duration-200"
+            >
+              Confirm
+            </button>
+          </form>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Error state ────────────────────────────────────────────────────── */
+  return (
+    <div className="min-h-screen bg-shodo-paper flex items-center justify-center p-4">
+      <div className="w-full max-w-sm text-center space-y-4">
+        <h1 className="text-4xl font-bold text-shodo-ink tracking-tight">
+          AIGENKI
+        </h1>
+        <p className="text-shodo-ink/70 text-sm">{error}</p>
+        <a
+          href="/login"
+          className="inline-block text-sm text-shodo-ink/50 hover:text-shodo-ink transition-colors duration-200 underline underline-offset-2"
+        >
+          Back to sign-in
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function getErrorMessage(code: string): string {
+  switch (code) {
+    case "auth/expired-action-code":
+      return "This sign-in link has expired. Please request a new one.";
+    case "auth/invalid-action-code":
+      return "This sign-in link is invalid or has already been used.";
+    case "auth/invalid-email":
+      return "The email address doesn't match. Please try again.";
+    case "auth/too-many-requests":
+      return "Too many attempts. Please try again later.";
+    default:
+      return "Sign-in failed. Please request a new link.";
+  }
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { sendSignInLinkToEmail, AuthError } from "firebase/auth";
+import { auth } from "@/lib/firebase-client";
+
+export const EMAIL_FOR_SIGN_IN_KEY = "emailForSignIn";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "sent">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const actionCodeSettings = {
+      // Firebase redirects back to this URL after the user clicks the link.
+      url: `${window.location.origin}/auth/callback`,
+      handleCodeInApp: true,
+    };
+
+    try {
+      await sendSignInLinkToEmail(auth, email, actionCodeSettings);
+      // Store the email so the callback page can retrieve it on the same device
+      // and avoid prompting the user again.
+      window.localStorage.setItem(EMAIL_FOR_SIGN_IN_KEY, email);
+      setStatus("sent");
+    } catch (err) {
+      setError(getErrorMessage((err as AuthError).code));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (status === "sent") {
+    return (
+      <div className="min-h-screen bg-shodo-paper flex items-center justify-center p-4">
+        <div className="w-full max-w-sm text-center">
+          <h1 className="text-4xl font-bold text-shodo-ink tracking-tight mb-8">
+            AIGENKI
+          </h1>
+          <div className="border border-shodo-ink/20 rounded-lg p-6 space-y-3">
+            <p className="text-shodo-ink font-medium">Check your email</p>
+            <p className="text-shodo-ink/60 text-sm">
+              We sent a sign-in link to{" "}
+              <span className="font-medium text-shodo-ink">{email}</span>
+            </p>
+            <p className="text-shodo-ink/40 text-xs">
+              Click the link in the email to sign in. You can close this tab.
+            </p>
+          </div>
+          <button
+            onClick={() => {
+              setStatus("idle");
+              setError(null);
+            }}
+            className="mt-5 text-sm text-shodo-ink/40 hover:text-shodo-ink/70 transition-colors duration-200"
+          >
+            Use a different email
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-shodo-paper flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        {/* Logo */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-shodo-ink tracking-tight">
+            AIGENKI
+          </h1>
+          <p className="text-shodo-ink/50 mt-2 text-sm">
+            AI-Powered Japanese Learning
+          </p>
+        </div>
+
+        <form onSubmit={handleSend} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-shodo-ink/70 mb-1"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+              autoComplete="email"
+              placeholder="you@example.com"
+              className="w-full px-3 py-2 border border-shodo-ink/20 rounded-md bg-shodo-paper text-shodo-ink placeholder-shodo-ink/30 focus:outline-none focus:ring-1 focus:ring-shodo-ink/40 text-sm"
+            />
+          </div>
+
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-2 px-4 bg-shodo-ink text-shodo-paper rounded-md font-medium text-sm hover:bg-shodo-ink/85 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Sending..." : "Send Sign-in Link"}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-shodo-ink/30 mt-6">
+          No password required — we&apos;ll email you a link.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function getErrorMessage(code: string): string {
+  switch (code) {
+    case "auth/invalid-email":
+      return "Invalid email address.";
+    case "auth/operation-not-allowed":
+      return "Email link sign-in is not enabled. Please contact support.";
+    case "auth/too-many-requests":
+      return "Too many attempts. Please try again later.";
+    default:
+      return "Something went wrong. Please try again.";
+  }
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,17 +3,16 @@
 import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "@/lib/api-client";
+import { useAuth } from "@/providers/AuthProvider";
 
 /**
- * A simple navigation header that displays stats.
- * Now with a listener to refresh stats dynamically.
+ * Global navigation header.
+ * Hidden entirely when there is no authenticated user (e.g. on the login page).
  */
 export default function Header() {
+  const { user, signOut } = useAuth();
   const [stats, setStats] = useState({ learnCount: 0, reviewsDue: 0 });
 
-  // Wrap fetchStats in useCallback so it's a stable function
-  // and can be safely used in useEffect dependency arrays.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchStats = useCallback(async () => {
     try {
       const response = await apiFetch("/api/stats");
@@ -24,52 +23,34 @@ export default function Header() {
     } catch (error) {
       console.error("Failed to fetch stats:", error);
     }
-  }, []); // Empty dependency array, this function never needs to change.
+  }, []);
 
-  // Effect to fetch stats on initial mount
   useEffect(() => {
-    fetchStats();
-  }, [fetchStats]);
+    if (user) fetchStats();
+  }, [user, fetchStats]);
 
-  // Effect to listen for our custom 'refreshStats' event
   useEffect(() => {
-    // We define a handler function to be clear
-    const handleRefreshStats = () => {
-      fetchStats();
-    };
-
+    const handleRefreshStats = () => fetchStats();
     window.addEventListener("refreshStats", handleRefreshStats);
-
-    // Clean up the listener when the component unmounts
-    return () => {
-      window.removeEventListener("refreshStats", handleRefreshStats);
-    };
-  }, [fetchStats]); // Depend on fetchStats
+    return () => window.removeEventListener("refreshStats", handleRefreshStats);
+  }, [fetchStats]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        fetchStats();
-      }
+      if (document.visibilityState === "visible") fetchStats();
     };
-
     document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
+    return () =>
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
   }, [fetchStats]);
 
-  // Effect to manage Furigana visibility and persistence
+  // Furigana toggle
   const [showFurigana, setShowFurigana] = useState(false);
 
   useEffect(() => {
-    // Load preference from localStorage
     const saved = localStorage.getItem("furiganaVisible");
     const isVisible = saved === "true";
     setShowFurigana(isVisible);
-
-    // Apply initial class
     if (isVisible) {
       document.documentElement.setAttribute("data-furigana", "true");
     } else {
@@ -81,7 +62,6 @@ export default function Header() {
     const newState = !showFurigana;
     setShowFurigana(newState);
     localStorage.setItem("furiganaVisible", String(newState));
-
     if (newState) {
       document.documentElement.setAttribute("data-furigana", "true");
     } else {
@@ -89,10 +69,8 @@ export default function Header() {
     }
   }, [showFurigana]);
 
-  // Effect for Keyboard Shortcut (Alt+F)
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Check for Alt+F (Option+F on Mac)
       if (
         event.altKey &&
         (event.key === "f" || event.key === "F" || event.code === "KeyF")
@@ -101,10 +79,12 @@ export default function Header() {
         toggleFurigana();
       }
     };
-
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [toggleFurigana]);
+
+  // Don't render the nav chrome on the login page or before the user is known.
+  if (!user) return null;
 
   return (
     <header className="bg-shodo-paper border-b border-shodo-ink/10 shadow-sm sticky top-0 z-10">
@@ -153,7 +133,7 @@ export default function Header() {
         {/* Separator */}
         <div className="h-6 w-px bg-shodo-ink/30 mx-4 hidden sm:block" />
 
-        {/* Settings / Toggles */}
+        {/* Furigana toggle */}
         <button
           onClick={toggleFurigana}
           className={`text-sm font-medium transition-colors duration-200 flex items-center gap-2 ${
@@ -177,6 +157,23 @@ export default function Header() {
             />
           </div>
         </button>
+
+        {/* User / Sign out */}
+        <div className="flex items-center gap-3 ml-4">
+          <span
+            className="text-xs text-shodo-ink/40 hidden sm:block truncate max-w-[140px]"
+            title={user.email ?? undefined}
+          >
+            {user.email}
+          </span>
+          <button
+            onClick={signOut}
+            className="text-xs text-shodo-ink/40 hover:text-shodo-ink/70 transition-colors duration-200 whitespace-nowrap"
+            title="Sign out"
+          >
+            Sign out
+          </button>
+        </div>
       </nav>
     </header>
   );

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -11,20 +11,27 @@ export async function apiFetch(
 ): Promise<Response> {
   const headers = new Headers(init?.headers);
 
-  // Ensure Firebase has checked IndexedDB/LocalStorage for a session
-  await auth.authStateReady();
-
-  // If we have a user, attempt to get their active token
-  if (auth.currentUser) {
-    try {
-      const token = await auth.currentUser.getIdToken();
-      headers.set("Authorization", `Bearer ${token}`);
-      console.log(`[apiFetch] Injected token for ${input}`);
-    } catch (error) {
-      console.error(`[apiFetch] Failed to get Firebase token for ${input}:`, error);
-    }
+  // Dev bypass: send no token so the backend guard uses X-Dev-User-Id or
+  // falls back to user_default.
+  if (process.env.NEXT_PUBLIC_DEV_SKIP_AUTH === "true") {
+    const devUid = process.env.NEXT_PUBLIC_DEV_USER_ID;
+    if (devUid) headers.set("X-Dev-User-Id", devUid);
   } else {
-    console.warn(`[apiFetch] No currentUser available for ${input}`);
+    // Ensure Firebase has checked IndexedDB/LocalStorage for a session
+    await auth.authStateReady();
+
+    // If we have a user, attempt to get their active token
+    if (auth.currentUser) {
+      try {
+        const token = await auth.currentUser.getIdToken();
+        headers.set("Authorization", `Bearer ${token}`);
+        console.log(`[apiFetch] Injected token for ${input}`);
+      } catch (error) {
+        console.error(`[apiFetch] Failed to get Firebase token for ${input}:`, error);
+      }
+    } else {
+      console.warn(`[apiFetch] No currentUser available for ${input}`);
+    }
   }
 
   return fetch(input, {

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,55 +1,102 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { onAuthStateChanged, signInAnonymously, User } from "firebase/auth";
+import {
+  onAuthStateChanged,
+  signOut as firebaseSignOut,
+  User,
+} from "firebase/auth";
+import { usePathname, useRouter } from "next/navigation";
 import { auth } from "@/lib/firebase-client";
+import { apiFetch } from "@/lib/api-client";
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  signOut: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
+  signOut: async () => {},
 });
 
 export const useAuth = () => useContext(AuthContext);
 
+const DEV_SKIP_AUTH = process.env.NEXT_PUBLIC_DEV_SKIP_AUTH === "true";
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const router = useRouter();
+  const pathname = usePathname();
 
+  // Subscribe to Firebase auth state once on mount.
   useEffect(() => {
+    // Dev bypass: skip Firebase entirely. The backend guard falls back to
+    // user_default when no Authorization header is present.
+    if (DEV_SKIP_AUTH) {
+      const devUid = process.env.NEXT_PUBLIC_DEV_USER_ID ?? "user_default";
+      console.warn(`[AuthProvider] DEV_SKIP_AUTH is enabled — bypassing Firebase auth. uid: ${devUid}`);
+      setUser({ uid: devUid, email: `${devUid} (dev)` } as User);
+      setLoading(false);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-      if (!currentUser) {
-        // If no user is logged in, automatically sign in anonymously
-        // to get a valid token for requests.
+      if (currentUser) {
+        setUser(currentUser);
+        // Idempotent — creates the UserRoot doc on first login, no-ops thereafter.
         try {
-          console.log("[AuthProvider] No user detected, attempting anonymous sign-in...");
-          await signInAnonymously(auth);
-          console.log("[AuthProvider] Anonymous sign-in success!");
-        } catch (error) {
-          console.error("[AuthProvider] Failed to sign in anonymously:", error);
-          alert(`Firebase Auth Error: Failed to sign in anonymously. Please ensure Anonymous Sign-In is enabled in your Firebase Console. Details: ${error}`);
-          setLoading(false);
+          await apiFetch("/api/users/me");
+        } catch (e) {
+          console.error("[AuthProvider] Failed to initialize user doc:", e);
         }
       } else {
-        setUser(currentUser);
-        setLoading(false);
+        setUser(null);
       }
+      setLoading(false);
     });
 
     return () => unsubscribe();
   }, []);
 
+  // Redirect logic — runs whenever auth state or location changes.
+  useEffect(() => {
+    if (loading || DEV_SKIP_AUTH) return;
+
+    const isPublic = pathname === "/login" || pathname === "/auth/callback";
+    if (!user && !isPublic) {
+      router.push("/login");
+    } else if (user && isPublic) {
+      router.push("/");
+    }
+  }, [user, loading, pathname, router]);
+
+  const signOut = async () => {
+    await firebaseSignOut(auth);
+    // The onAuthStateChanged listener will fire, set user to null,
+    // and the redirect effect above will push to /login.
+  };
+
+  // What to render:
+  // • Loading  → spinner
+  // • No user, not on /login → null (redirect is in-flight, avoid flash)
+  // • No user, on /login  → login page
+  // • User authenticated   → full app
+  const isPublic = pathname === "/login" || pathname === "/auth/callback";
+  const shouldRender = !loading && (!!user || isPublic);
+
   return (
-    <AuthContext.Provider value={{ user, loading }}>
-      {!loading ? children : (
+    <AuthContext.Provider value={{ user, loading, signOut }}>
+      {loading ? (
         <div className="flex h-screen w-full items-center justify-center bg-shodo-paper text-shodo-ink">
-          <p className="animate-pulse">Loading secure session...</p>
+          <p className="animate-pulse">Loading...</p>
         </div>
-      )}
+      ) : shouldRender ? (
+        children
+      ) : null}
     </AuthContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary                                                                                                             
                                                                                                                       
  - Replaces anonymous Firebase sign-in with **passwordless email-link authentication** (`sendSignInLinkToEmail` /       
  `signInWithEmailLink`)                                                                                                 
  - Adds full multi-tenant user isolation — every user gets their own `users/{uid}` Firestore document, initialised on   
  first sign-in via the existing idempotent `GET /users/me` endpoint                                                     
  - New users land on empty Learn, Review, and Manage pages; Scenarios Core Library is available immediately             
  - Dev mode preserved: existing `NEXT_PUBLIC_DEV_SKIP_AUTH` + `NEXT_PUBLIC_DEV_USER_ID` env vars bypass Firebase        
  entirely and target a specific UID                                                                                     
                                                                                                                         
  ## Changes                                                                                                             
                                                                                                                       
  **Frontend**
  - `src/app/login/page.tsx` — email-only sign-in form; shows confirmation screen after link is sent
  - `src/app/auth/callback/page.tsx` — handles Firebase email-link return; cross-device flow prompts for email           
  confirmation if localStorage is empty                                                                                  
  - `src/providers/AuthProvider.tsx` — replaces anonymous auth with route-guarding; `/login` and `/auth/callback` are    
  public; calls `/api/users/me` on auth to initialise user doc; exposes `signOut()` via context                          
  - `src/components/Header.tsx` — hidden when unauthenticated; shows truncated user email and sign-out button          
  - `src/lib/api-client.ts` — dev bypass skips token injection and forwards `X-Dev-User-Id` header when                  
  `NEXT_PUBLIC_DEV_USER_ID` is set                                                                                       
                                                                                                                         
  **Backend**                                                                                                            
  - `src/auth/firebase-auth.guard.ts` — dev-mode fallback now reads `X-Dev-User-Id` request header before falling back to
   `user_default`                                                                                                        
  
  **Docs**                                                                                                               
  - `ARCHITECTURE.md` — new *User Management, Authentication & Multi-Tenancy* section documenting the full auth flow,  
  Firestore scoping pattern, type map, and implementation guide for completing multi-user support; migration history     
  updated                                                                                                              
                                                                                                                         
  ## Firebase Console prerequisites                                                                                      
  
  1. Authentication → Sign-in method → **Email/Password** enabled                                                        
  2. **Email link (passwordless sign-in)** sub-toggle enabled                                                          
  3. Authorized domains — confirm `localhost` is listed                                                                  
  4. **Public-facing name** (shown in auth emails): only exposed in the console once a third-party provider such as      
  Google Sign-In is enabled; set to `AIGENKI` then disable the provider if passwordless-only is preferred                
                                                                                                                         
  ## Test plan                                                                                                           
                                                                                                                       
  - [ ] New user: enter email → receive link → click link → land on empty dashboard                                      
  - [ ] Returning user: same flow, existing data visible
  - [ ] Cross-device: open link on different device → prompted to confirm email → signs in correctly                     
  - [ ] Sign-out button clears session and redirects to `/login`                                                         
  - [ ] Unauthenticated direct URL access redirects to `/login`                                                          
  - [ ] `NEXT_PUBLIC_DEV_SKIP_AUTH=true NEXT_PUBLIC_DEV_USER_ID=<uid> yarn dev` bypasses login and loads data for        
  specified UID                                                                                                          
  - [ ] Backend log confirms correct UID injection in dev mode 