### PR TITLE
feat: implement full multi-tenancy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,10 +60,11 @@ Basic Vocab data was extracted from Wanikani and then boiled down to non-proprie
 - **Meta requirement**: The manage page should eventually be just and admin function and not a list of the Vocab the User has in their learning or review queues or in their overall user context (if we go down that route). This requires a lot of other work to be done first.
 
 ### Users
-- (Given) Global KU data is stored in the `knowledge-units` collection in Firestore and accessed via the `knowledge-units` service.
-- (ToDo)User KU data **should be** metadata that references global KU data (not replicates). It should be stored in users/{uid}/user-kus
-- (ToDo) We need to fully implement users and provide a way for users to sign up and log in.
-  - When a new user logs in for the first time they'll start with a clean slate. Once we have this condition in place we can start to implement a way to add KUs to a user's learning queue using Scenarios and other tools.
+- (Done) Global KU data is stored in the `knowledge-units` collection in Firestore, accessed via the `knowledge-units` service. The service is now user-agnostic — no `userId` filtering on reads, no `userId` written to new documents.
+- (Done) User KU metadata is stored in `users/{uid}/user-kus` as `UserKnowledgeUnit` documents referencing global KUs via `kuId`. Managed by `UserKnowledgeUnitsService`.
+- (Done) Users can sign up and log in via passwordless email-link auth.
+- (Done) When a user interacts with a scenario and clicks "Start Drilling", `UserKnowledgeUnit` documents are created in their sub-collection — this populates their Learning Queue.
+- (ToDo) Questions need a design overhaul — reuse/rotation logic for AI-Generated-Question facets is broken (always reuses the same question regardless of attempt count).
 
 ## User Management, Authentication & Multi-Tenancy
 
@@ -71,7 +72,7 @@ This section documents the current implementation of auth and user scoping so th
 
 ### Current State Summary
 
-Authentication plumbing exists end-to-end but the system effectively operates as **single-tenant** today because the only real user in development is the hardcoded `user_default`. Firebase anonymous auth is wired up on the frontend and real Firebase ID tokens are passed to the backend, but the backend guard silently falls back to `user_default` on any failure or missing token in dev mode.
+The system is now **multi-tenant**. Real users sign in via passwordless email-link auth and get fully isolated data in Firestore sub-collections. The admin user (`user_default`) retains access to top-level collections for corpus management. The backend guard falls back to `user_default` in dev mode when no token is present.
 
 ---
 
@@ -98,9 +99,9 @@ Authentication plumbing exists end-to-end but the system effectively operates as
 
 `backend/src/auth/user-id.decorator.ts` — `@UserId()` param decorator that reads `request.user?.uid`. Used on every protected controller method.
 
-**Hardcoded default user**
+**Admin/default user**
 
-`backend/src/lib/constants.ts` exports `CURRENT_USER_ID = 'user_default'`. The string `'user_default'` is also used directly in the guard. All Firestore documents written during local development will have `userId: 'user_default'`.
+`backend/src/lib/constants.ts` exports `ADMIN_USER_ID = 'user_default'`. The string `'user_default'` is also hardcoded directly in `firebase-auth.guard.ts` (dev-mode fallback) — a TODO exists in `constants.ts` to consolidate this. The admin user manages the global KU corpus and writes to top-level Firestore collections; all other users write to per-user sub-collections.
 
 ---
 
@@ -139,12 +140,14 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 
 | Collection | Scoped by userId? | Notes |
 |---|---|---|
-| `knowledge-units` | Yes (field) | All vocab KUs live here; `userId` field set on every doc |
-| `review-facets` | Yes (field) | SRS state per KU facet |
+| `knowledge-units` | **No** | Global corpus — no `userId` on new docs; legacy docs may still have `userId: 'user_default'` |
+| `users/{uid}/user-kus` | Yes — sub-collection path | Per-user KU metadata; `kuId` references global KU |
+| `users/{uid}/review-facets` | Yes — sub-collection path | Per-user SRS facets (non-admin users) |
+| `review-facets` | Yes (field) | Admin (`user_default`) SRS facets only; `userId` field still required |
 | `lessons` | Yes (field) | AI-generated lesson documents |
-| `questions` | Yes (field) | Question documents |
+| `questions` | Yes (field) | Question documents (global pool, referenced by facet `currentQuestionId`) |
 | `scenarios` | Yes (field) | Roleplay scenario state |
-| `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION).doc(uid)` |
+| `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
 | `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
 | `api-logs` | **No** | Centralised logging; no user field |
 
@@ -189,11 +192,12 @@ The following work is required to complete proper multi-user support. Each item 
 - When a new UID is seen for the first time, create a `users/{uid}` document (default `UserRoot`) and seed any required initial state.
 - This can live in the `UsersService` (`backend/src/users/user.service.ts`) called from an `onAuthStateChanged` or a dedicated `/users/init` endpoint.
 
-**3. Migrate KU user-data to `users/{uid}/user-kus`**
-- Currently all KU data (including user-specific fields like `status`, `personalNotes`, `facet_count`) is stored in the flat `knowledge-units` collection with a `userId` field.
-- Target: split into a **global** `knowledge-units` collection (content, reading, meaning, jlptLevel, wanikaniLevel — no `userId`) and a **per-user** sub-collection `users/{uid}/user-kus` (status, personalNotes, facet_count, kuId pointer).
-- The `UserKnowledgeUnit` type already captures this intended shape.
-- Update `KnowledgeUnitsService` to join the two on reads and write to the correct collection on creates/updates.
+**3. ~~Migrate KU user-data to `users/{uid}/user-kus`~~ — Done**
+- `knowledge-units` is now a global corpus with no `userId` on new documents.
+- `users/{uid}/user-kus` sub-collection holds per-user KU metadata via `UserKnowledgeUnitsService`.
+- `users/{uid}/review-facets` sub-collection holds per-user SRS facets for non-admin users.
+- The Learning Queue (`GET /api/knowledge-units/get-all?status=learning`) returns only the user's UKU-joined global KUs.
+- `KnowledgeUnitsController.findOne` authorises access via direct ownership (admin) OR existence of a UKU for that `kuId`.
 
 **4. Harden the dev guard bypass**
 - The current fallback to `user_default` on any token failure in dev mode is useful but should log a warning so it is obvious when a real token is being silently dropped.
@@ -227,6 +231,15 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
   NEXT_PUBLIC_DEV_SKIP_AUTH=true NEXT_PUBLIC_DEV_USER_ID=<uid> yarn dev
   ```
   Omit `NEXT_PUBLIC_DEV_USER_ID` to fall back to `user_default`.
+**Multi-tenant data isolation (2026-04)**
+
+- **`knowledge-units` made global**: Removed `userId` from all `KnowledgeUnitsService` method signatures and Firestore queries. New KU documents are written without a `userId` field. `KnowledgeUnitsService` is now user-agnostic; `findByContent` absorbs the former `findByContentGlobal`.
+- **`UserKnowledgeUnitsService`** added (`backend/src/user-knowledge-units/`): manages `users/{uid}/user-kus` sub-collection. `create(uid, kuId)` is idempotent. `findLearningQueueAsKUs(uid)` batch-joins UKUs with their global KUs for the learning queue endpoint.
+- **Scenario → UKU flow**: `ScenariosService.advanceState` (encounter→drill) now creates `UserKnowledgeUnit` records instead of `KnowledgeUnit` records. Vocab not found in the global corpus is skipped with a warning.
+- **`review-facets` per-user sub-collection**: `ReviewsService` routes all facet reads/writes to `users/{uid}/review-facets` for non-admin users; `user_default` continues to use the top-level `review-facets` collection with `userId` field scoping. Same routing applied in `StatsService`.
+- **`ADMIN_USER_ID` constant**: `CURRENT_USER_ID` renamed to `ADMIN_USER_ID` in `backend/src/lib/constants.ts`. The string `'user_default'` remains hardcoded in `firebase-auth.guard.ts` pending a follow-up cleanup.
+- **Frontend**: `refreshStats` event dispatched after successful encounter→drill advance so the Learn tab badge updates immediately.
+
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.
   2. Authentication → Sign-in method → **Email link (passwordless sign-in)** enabled (sub-toggle under Email/Password).

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,9 +16,10 @@ import { ScenariosModule } from './scenarios/scenarios.module';
 import { AudioModule } from './audio/audio.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './users/user.module';
+import { UserKnowledgeUnitsModule } from './user-knowledge-units/user-knowledge-units.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule],
+  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -11,6 +11,7 @@ export const API_LOGS_COLLECTION = "api-logs";
 export const QUESTIONS_COLLECTION = "questions";
 export const USER_STATS_COLLECTION = 'user-stats';
 export const SCENARIOS_COLLECTION = 'scenarios';
+export const USER_KUS_SUBCOLLECTION = 'user-kus';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;
 

--- a/backend/src/kanji/kanji.service.ts
+++ b/backend/src/kanji/kanji.service.ts
@@ -31,13 +31,13 @@ export class KanjiService {
         this.logger.log(`apiData = ${JSON.stringify(apiData)}`);
 
         // 2. Fetch Contextual Data (Related Vocab from DB)
-        const relatedVocab = await this.knowledgeUnitsService.findByKanjiComponent(uid, kanjiChar);
+        const relatedVocab = await this.knowledgeUnitsService.findByKanjiComponent(kanjiChar);
 
         // 3. Fetch User Data (Personal Mnemonic) if kuId exists
         let personalMnemonic = '';
         if (kuId) {
             try {
-                const ku = await this.knowledgeUnitsService.findOne(uid, kuId);
+                const ku = await this.knowledgeUnitsService.findOne(kuId);
                 personalMnemonic = ku.personalNotes || ''; // Or a specific field if you added one
             } catch (e) {
                 // Ignore if KU doesn't exist yet (unlikely if coming from lesson page)

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Put, Patch, Param, Body, Query, Post, BadRequestException, UseGuards, HttpCode } from '@nestjs/common';
+import { Controller, Get, Put, Patch, Param, Body, Query, Post, BadRequestException, NotFoundException, UseGuards, HttpCode } from '@nestjs/common';
 import { KnowledgeUnitsService } from './knowledge-units.service';
+import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
 import { ParseArrayPipe } from '@nestjs/common/pipes';
@@ -10,6 +11,7 @@ import { ParseArrayPipe } from '@nestjs/common/pipes';
 export class KnowledgeUnitsController {
     constructor(
         private readonly knowledgeUnitsService: KnowledgeUnitsService,
+        private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
     ) { }
 
     @Get('get-all')
@@ -19,43 +21,55 @@ export class KnowledgeUnitsController {
         @Query('type') type?: string,
         @Query('content', new ParseArrayPipe({ items: String, separator: ',', optional: true })) content?: string[]
     ) {
-        return this.knowledgeUnitsService.findAll(uid, { status, type, content });
+        if (status === 'learning') {
+            return this.userKnowledgeUnitsService.findLearningQueueAsKUs(uid);
+        }
+        return this.knowledgeUnitsService.findAll({ status, type, content });
     }
 
     @Put(':id')
-    async update(@UserId() uid: string, @Param('id') id: string, @Body() body: any) {
-        return this.knowledgeUnitsService.update(uid, id, body);
+    async update(@Param('id') id: string, @Body() body: any) {
+        return this.knowledgeUnitsService.update(id, body);
     }
 
     @Get(':id')
     async findOne(@UserId() uid: string, @Param('id') id: string) {
-        return this.knowledgeUnitsService.findOne(uid, id);
+        const ku = await this.knowledgeUnitsService.findOneById(id);
+        if (!ku) throw new NotFoundException(`Knowledge Unit ${id} not found`);
+
+        // Direct owner (user_default managing corpus) or user has a UKU for this KU
+        if (ku.userId === uid) return ku;
+
+        const uku = await this.userKnowledgeUnitsService.findByKuId(uid, id);
+        if (uku) return ku;
+
+        throw new NotFoundException(`Knowledge Unit ${id} not found`);
     }
 
     @Patch('bulk')
     @HttpCode(200)
-    async bulkUpdate(@UserId() uid: string, @Body() body: any) {
+    async bulkUpdate(@Body() body: any) {
         if (!Array.isArray(body)) {
             throw new BadRequestException('Request body must be an array of Knowledge Units');
         }
-        return this.knowledgeUnitsService.bulkUpdate(uid, body);
+        return this.knowledgeUnitsService.bulkUpdate(body);
     }
 
     @Post('bulk')
     @HttpCode(200)
-    async bulkIngest(@UserId() uid: string, @Body() body: any) {
+    async bulkIngest(@Body() body: any) {
         if (!Array.isArray(body)) {
             throw new BadRequestException('Request body must be an array of Knowledge Units');
         }
-        return this.knowledgeUnitsService.bulkIngest(uid, body);
+        return this.knowledgeUnitsService.bulkIngest(body);
     }
 
     @Post()
-    async create(@UserId() uid: string, @Body() body: any) {
+    async create(@Body() body: any) {
         if (!body.content || !body.type) {
             throw new BadRequestException('Content and Type are required');
         }
-        return this.knowledgeUnitsService.create(uid, body);
+        return this.knowledgeUnitsService.create(body);
     }
 
 }

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -17,10 +17,9 @@ export class KnowledgeUnitsService {
         @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
     ) { }
 
-    async findAll(uid: string, { status, type, content }: { status?: string, type?: string, content?: string[] }) {
+    async findAll({ status, type, content }: { status?: string, type?: string, content?: string[] }) {
         try {
-            let query: Query = this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-                .where("userId", "==", uid);
+            let query: Query = this.db.collection(KNOWLEDGE_UNITS_COLLECTION) as unknown as Query;
 
             if (status) {
                 query = query.where("status", "==", status);
@@ -37,10 +36,8 @@ export class KnowledgeUnitsService {
             const snapshot = await query.orderBy("createdAt", "desc").get();
 
             if (snapshot.empty) {
-                this.logger.warn("No knowledge units found for user");
                 return [];
             }
-
 
             const kus: KnowledgeUnit[] = [];
             snapshot.forEach((doc) => {
@@ -49,9 +46,7 @@ export class KnowledgeUnitsService {
                 kus.push({
                     id: doc.id,
                     ...data,
-                    // Convert Firestore Timestamp to string for client-side
                     createdAt: ts.toDate().toISOString(),
-                    userId: data.userId || uid, // Ensure userId is present
                 } as unknown as KnowledgeUnit);
             });
 
@@ -62,44 +57,27 @@ export class KnowledgeUnitsService {
         }
     }
 
-    async findByContent(uid: string, content: string, type: KnowledgeUnitType): Promise<KnowledgeUnit | null> {
-
-        // Use Cases: Component Kanji Lookup
-
-        const contentQuery = this.db
+    async findByContent(content: string, type: KnowledgeUnitType): Promise<KnowledgeUnit | null> {
+        const snapshot = await this.db
             .collection(KNOWLEDGE_UNITS_COLLECTION)
-            .where("type", "==", type)
-            .where("userId", "==", uid)
-            .where("content", "==", content)
-            .limit(1);
-        const contentSnapshot = await contentQuery.get();
+            .where('type', '==', type)
+            .where('content', '==', content)
+            .limit(1)
+            .get();
 
-        if (!contentSnapshot.empty) {
-            const doc = contentSnapshot.docs[0];
-            const data = doc.data();
-            return {
-                id: doc.id,
-                ...data,
-                // Convert Firestore Timestamp to string for client-side
-                createdAt: (data.createdAt as Timestamp).toDate().toISOString(),
-                userId: data.userId || uid, // Ensure userId is present
-            } as unknown as KnowledgeUnit;
-        } else {
-            this.logger.warn("No knowledge units found for user");
-            return null;
-        }
+        if (snapshot.empty) return null;
+
+        const doc = snapshot.docs[0];
+        const data = doc.data();
+        return {
+            id: doc.id,
+            ...data,
+            createdAt: (data.createdAt as Timestamp).toDate().toISOString(),
+        } as unknown as KnowledgeUnit;
     }
 
-    async findByKanjiComponent(uid: string, kanjiChar: string): Promise<KnowledgeUnit[]> {
-        // Note: Firestore doesn't support substring search (LIKE %char%).
-        // If you don't have a 'components' array on Vocab KUs, you have to do a client-side filter
-        // or rely on the fact that you might have stored this relationship.
-
-        // Hack for now: Fetch all Vocab and filter in memory (fine for small datasets < 1000 docs)
-        // Better long term: Add an array field `containedKanji` to Vocab KUs.
-
+    async findByKanjiComponent(kanjiChar: string): Promise<KnowledgeUnit[]> {
         const snapshot = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-            .where('userId', '==', uid)
             .where('type', '==', 'Vocab')
             .get();
 
@@ -116,21 +94,13 @@ export class KnowledgeUnitsService {
         return matches;
     }
 
-    async ensureKanjiStub(uid: string, char: string, metadata: any): Promise<string> {
-        // 1. Try to find existing
-        const existing = await this.findByContent(uid, char, 'Kanji');
+    async ensureKanjiStub(char: string, metadata: any): Promise<string> {
+        const existing = await this.findByContent(char, 'Kanji');
 
         if (existing) {
-            // Optional: Ensure status is 'learning' if it was 'suspended'
-            if (existing.status !== 'learning') {
-                await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-                    .doc(existing.id)
-                    .update({ status: 'learning' });
-            }
             return existing.id;
         }
 
-        // 2. Create New Stub
         const newRef = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc();
         await newRef.set({
             content: char,
@@ -142,49 +112,41 @@ export class KnowledgeUnitsService {
             },
             status: 'learning',
             facet_count: 0,
-            createdAt: Timestamp.now(), // Use ISO strings for consistency
+            createdAt: Timestamp.now(),
             relatedUnits: [],
-            personalNotes: `Auto-generated component`,
-            userId: uid,
+            personalNotes: 'Auto-generated component',
         });
 
         return newRef.id;
     }
 
-    async ensureVocab(uid: string, content: string): Promise<string> {
-        // 1. Try to find existing
-        const existing = await this.findByContent(uid, content, 'Vocab');
+    async ensureVocab(content: string): Promise<string> {
+        const existing = await this.findByContent(content, 'Vocab');
 
         if (existing) {
             return existing.id;
         }
 
-        // 2. Create New
         const newRef = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc();
         await newRef.set({
-            content: content,
+            content,
             type: 'Vocab',
-            data: {
-                reading: '', // Will be filled by Gemini
-                definition: '', // Will be filled by Gemini
-            },
+            data: { reading: '', definition: '' },
             status: 'learning',
             facet_count: 0,
             createdAt: Timestamp.now(),
             relatedUnits: [],
             personalNotes: '',
-            userId: uid,
         });
 
         return newRef.id;
     }
 
-    async update(uid: string, id: string, updates: Partial<any>) { // typed as 'any' or a DTO to allow flexible updates
+    async update(id: string, updates: Partial<any>) {
         const ref = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(id);
 
-        // verify existence and ownership before writing
         const doc = await ref.get();
-        if (!doc.exists || doc.data()?.userId !== uid) {
+        if (!doc.exists) {
             throw new NotFoundException(`Knowledge Unit ${id} not found`);
         }
 
@@ -192,8 +154,7 @@ export class KnowledgeUnitsService {
         return { id, ...updates };
     }
 
-    async create(uid: string, body: any) {
-        // Validate body (basic)
+    async create(body: any) {
         if (!body.type || !body.content) {
             this.logger.warn("POST /knowledge-units - Validation failed", body);
             throw new BadRequestException("Type and Content are required");
@@ -201,13 +162,13 @@ export class KnowledgeUnitsService {
 
         const newKuData = {
             ...body,
-            relatedUnits: body.relatedUnits || [], // Ensure array exists
-            data: body.data || {}, // Ensure object exists
-            createdAt: Timestamp.now(), // Add Firestore timestamp
+            relatedUnits: body.relatedUnits || [],
+            data: body.data || {},
+            createdAt: Timestamp.now(),
             status: "learning",
             facet_count: 0,
-            userId: uid,
         };
+        delete newKuData.userId; // KUs are global; no user ownership
 
         const newDocRef = await this.db
             .collection(KNOWLEDGE_UNITS_COLLECTION)
@@ -215,15 +176,14 @@ export class KnowledgeUnitsService {
 
         this.logger.log(`POST /knowledge-units - Created unit ${newDocRef.id}`);
         return { id: newDocRef.id };
-    } // END create
+    }
 
-    async bulkUpdate(uid: string, items: Partial<KnowledgeUnit>[]): Promise<{ updated: number; skipped: number; ids: string[] }> {
+    async bulkUpdate(items: Partial<KnowledgeUnit>[]): Promise<{ updated: number; skipped: number; ids: string[] }> {
         if (!Array.isArray(items) || items.length === 0) {
             throw new BadRequestException('items must be a non-empty array');
         }
 
-        // Fields that must never be overwritten by an external caller
-        const IMMUTABLE = new Set(['id', 'userId', 'createdAt', 'status', 'facet_count']);
+        const IMMUTABLE = new Set(['id', 'createdAt']);
 
         const toUpdate: { ref: DocumentReference; data: Record<string, any> }[] = [];
         let skipped = 0;
@@ -266,15 +226,14 @@ export class KnowledgeUnitsService {
         return { updated: updatedIds.length, skipped, ids: updatedIds };
     }
 
-    async bulkIngest(uid: string, items: Partial<KnowledgeUnit>[]): Promise<{ created: number; skipped: number; ids: string[] }> {
+    async bulkIngest(items: Partial<KnowledgeUnit>[]): Promise<{ created: number; skipped: number; ids: string[] }> {
         if (!Array.isArray(items) || items.length === 0) {
             throw new BadRequestException('items must be a non-empty array');
         }
 
-        // Fetch existing content+type combos for this user to support dedup
+        // Dedup against the full global corpus by content+type
         const existingSnapshot = await this.db
             .collection(KNOWLEDGE_UNITS_COLLECTION)
-            .where('userId', '==', uid)
             .select('content', 'type')
             .get();
 
@@ -316,7 +275,6 @@ export class KnowledgeUnitsService {
                     status: 'learning',
                     facet_count: 0,
                     createdAt: Timestamp.now(),
-                    userId: uid,
                 },
             });
         }
@@ -339,28 +297,22 @@ export class KnowledgeUnitsService {
         return { created: createdIds.length, skipped, ids: createdIds };
     }
 
-    async findOne(uid: string, id: string): Promise<KnowledgeUnit> {
-        const docRef = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(id);
-        const doc = await docRef.get();
-
-        if (!doc.exists) {
-            throw new NotFoundException(`Knowledge Unit ${id} not found`);
-        }
-
-        const data = doc.data();
-
-        // Enforce Data Isolation
-        if (data?.userId !== uid) {
-            throw new NotFoundException(`Knowledge Unit ${id} not found`);
-        }
-
+    async findOneById(id: string): Promise<KnowledgeUnit | null> {
+        const doc = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(id).get();
+        if (!doc.exists) return null;
+        const data = doc.data()!;
         return {
             id: doc.id,
             ...data,
-            // Safe Timestamp conversion matching findAll logic
             createdAt: typeof data.createdAt?.toDate === 'function'
                 ? data.createdAt.toDate().toISOString()
                 : data.createdAt,
         } as unknown as KnowledgeUnit;
+    }
+
+    async findOne(id: string): Promise<KnowledgeUnit> {
+        const ku = await this.findOneById(id);
+        if (!ku) throw new NotFoundException(`Knowledge Unit ${id} not found`);
+        return ku;
     }
 }

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -34,7 +34,7 @@ export class LessonsController {
             const trimmed = content.trim();
             if (!trimmed) continue;
 
-            const id = await this.knowledgeUnitsService.ensureVocab(uid, trimmed);
+            const id = await this.knowledgeUnitsService.ensureVocab(trimmed);
             batchItems.push({ id, content: trimmed });
           } catch (e) {
             this.logger.error(`Failed to ensure KU for ${content}`, e);

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -178,8 +178,9 @@ ${VOCAB_INSTRUCTIONS}`;
       if (Object.keys(updates).length > 0) {
         try {
           this.logger.log(`Updating KU ${kuId} with lesson data: ${JSON.stringify(updates)}`);
-          await this.knowledgeUnitsService.update(uid, kuId, updates);
+          await this.knowledgeUnitsService.update(kuId, updates);
         } catch (e) {
+          console.log(e);
           this.logger.error(`Failed to backfill KU ${kuId} with lesson data`, e);
           // Don't fail the response, just log error
         }

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -1,2 +1,5 @@
-// TODO: Replace with a dynamic user ID from an authentication system
-export const CURRENT_USER_ID = 'user_default';
+// The admin/default user who manages the global KU corpus and uses top-level Firestore collections.
+// TODO: This value ('user_default') is also hardcoded directly in:
+//   - backend/src/auth/firebase-auth.guard.ts (dev-mode fallback)
+// Those references should eventually be replaced with this constant.
+export const ADMIN_USER_ID = 'user_default';

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -114,7 +114,7 @@ Rules:
     let reading: string | undefined;
     let meaning: string | undefined;
     if (kuId) {
-      const kuData = await this.knowledgeUnitsService.findOne(uid, kuId);
+      const kuData = await this.knowledgeUnitsService.findOne(kuId);
       reading = kuData.data?.reading;
       // Use 'meaning' (Kanji) or 'definition' (Vocab) depending on what's available
       meaning = kuData.data?.meaning || kuData.data?.definition;
@@ -125,7 +125,7 @@ Rules:
     let returnedQuestionId: string | null = null;
 
     if (facetId) {
-      facetData = (await this.reviewsService.getByFacetId(facetId)) as ReviewFacet;
+      facetData = (await this.reviewsService.getByFacetId(uid, facetId)) as ReviewFacet;
 
       if (facetData) {
 
@@ -232,7 +232,7 @@ Rules:
         this.logger.log(`Saved new question: ${newQuestionRef.id}`);
 
         // Update Facet
-        await this.reviewsService.updateFacetQuestion(facetId, newQuestionRef.id);
+        await this.reviewsService.updateFacetQuestion(uid, facetId, newQuestionRef.id);
         returnedQuestionId = newQuestionRef.id;
       } catch (saveError) {
         this.logger.error("Failed to save generated question", saveError);

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -5,16 +5,17 @@ import {
     NotFoundException,
     forwardRef,
 } from '@nestjs/common';
-import { FieldPath, FieldValue, Firestore, Timestamp } from 'firebase-admin/firestore';
+import { CollectionReference, FieldPath, FieldValue, Firestore, Query, Timestamp } from 'firebase-admin/firestore';
 import {
     FIRESTORE_CONNECTION,
     REVIEW_FACETS_COLLECTION,
     KNOWLEDGE_UNITS_COLLECTION,
     USER_STATS_COLLECTION,
 } from '../firebase/firebase.module';
+import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
-// Removed CURRENT_USER_ID import
+// Removed ADMIN_USER_ID import
 import { FacetType, KnowledgeUnit, Lesson, ReviewFacet } from '@/types';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { LessonsService } from '@/lessons/lessons.service';
@@ -47,30 +48,38 @@ export class ReviewsService {
         private readonly statsService: StatsService,
     ) { }
 
-    async getByFacetId(facetId: string) {
-        const doc = await this.db
-            .collection(REVIEW_FACETS_COLLECTION)
-            .doc(facetId)
-            .get();
+    private facetsColRef(uid: string): CollectionReference {
+        if (uid === ADMIN_USER_ID) {
+            return this.db.collection(REVIEW_FACETS_COLLECTION);
+        }
+        return this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+    }
+
+    private facetsBaseQuery(uid: string): Query {
+        const col = this.facetsColRef(uid);
+        return uid === ADMIN_USER_ID ? col.where('userId', '==', uid) : col;
+    }
+
+    async getByFacetId(uid: string, facetId: string) {
+        const doc = await this.facetsColRef(uid).doc(facetId).get();
         if (!doc.exists) return null;
         return doc.data();
     }
 
     async updateFacetSrs(uid: string, facetId: string, result: 'pass' | 'fail') {
         return this.db.runTransaction(async (transaction) => {
-            const query = this.db
-                .collection(REVIEW_FACETS_COLLECTION)
-                .where(FieldPath.documentId(), '==', facetId)
-                .where('userId', '==', uid);
+            const facetRef = this.facetsColRef(uid).doc(facetId);
+            const facetDoc = await transaction.get(facetRef);
 
-            const snapshot = await query.get();
-
-            if (snapshot.empty) {
+            if (!facetDoc.exists) {
                 throw new NotFoundException('Facet not found');
             }
 
-            const facetDoc = snapshot.docs[0];
-            const facetRef = facetDoc.ref;
+            // For user_default using the shared top-level collection, verify ownership
+            if (uid === ADMIN_USER_ID && facetDoc.data()?.userId !== uid) {
+                throw new NotFoundException('Facet not found');
+            }
+
             const facetData = facetDoc.data() as ReviewFacet;
 
             // Determine the new SRS stage and time of next review
@@ -168,9 +177,8 @@ export class ReviewsService {
         }
     }
 
-    async updateFacetQuestion(facetId: string, questionId: string) {
-        const facetRef = this.db.collection(REVIEW_FACETS_COLLECTION).doc(facetId);
-        await facetRef.update({
+    async updateFacetQuestion(uid: string, facetId: string, questionId: string) {
+        await this.facetsColRef(uid).doc(facetId).update({
             currentQuestionId: questionId,
             questionAttempts: 0,
         });
@@ -264,7 +272,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 const parts = key.split('-');
                 if (parts.length === 3) {
                     const kanjiChar = parts[2];
-                    targetKuId = await this.knowledgeUnitsService.ensureKanjiStub(uid, kanjiChar, data);
+                    targetKuId = await this.knowledgeUnitsService.ensureKanjiStub(kanjiChar, data);
                 }
                 // At this point we should have a KU for the Kanji Component, so skip the rest of the loop
                 continue;
@@ -277,7 +285,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
 
             if (key === 'audio' && modifiedData?.contextExample) {
                 try {
-                    const ku = await this.knowledgeUnitsService.findOne(uid, targetKuId);
+                    const ku = await this.knowledgeUnitsService.findOne(targetKuId);
                     if (ku && ku.content) {
                         const clozeSentence = await this.geminiService.generateClozeSentence(ku.content, modifiedData.contextExample.sentence);
                         modifiedData.clozeSentence = clozeSentence;
@@ -288,8 +296,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
             }
 
             // --- Create the Facet (Batch) ---
-            // Now we just create the facet pointing to whichever ID we resolved (Vocab or Kanji)
-            const newFacetRef = this.db.collection(REVIEW_FACETS_COLLECTION).doc();
+            const newFacetRef = this.facetsColRef(uid).doc();
             batch.set(newFacetRef, {
                 kuId: targetKuId,
                 facetType: key,
@@ -297,7 +304,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 nextReviewAt: now,
                 createdAt: now,
                 history: [],
-                userId: uid,
+                ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                 ...(modifiedData ? { data: modifiedData } : {}),
             });
 
@@ -306,7 +313,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
 
         if (count > 0) {
             try {
-                await this.knowledgeUnitsService.update(uid, kuId, {
+                await this.knowledgeUnitsService.update(kuId, {
                     status: 'reviewing',
                     // Atomically increment existing value by count
                     facet_count: FieldValue.increment(count)
@@ -324,8 +331,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
     async getDueReviews(uid: string) {
         const now = Timestamp.now();
 
-        const snapshot = await this.db.collection(REVIEW_FACETS_COLLECTION)
-            .where('userId', '==', uid)
+        const snapshot = await this.facetsBaseQuery(uid)
             .where('nextReviewAt', '<=', now)
             .orderBy('nextReviewAt', 'asc')
             .get();
@@ -350,7 +356,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
             // you might want to try/catch here if data integrity is loose)
             let ku: KnowledgeUnit | null = null;
             try {
-                ku = await this.knowledgeUnitsService.findOne(uid, facet.kuId);
+                ku = await this.knowledgeUnitsService.findOne(facet.kuId);
             } catch (e) {
                 this.logger.warn(`Orphaned facet ${facet.id}: KU ${facet.kuId} not found`);
             }
@@ -374,9 +380,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
     } // END getDueReviews
 
     async getAllFacets(uid: string) {
-        const snapshot = await this.db.collection(REVIEW_FACETS_COLLECTION)
-            .where('userId', '==', uid)
-            .get();
+        const snapshot = await this.facetsBaseQuery(uid).get();
 
         if (snapshot.empty) {
             return [];

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -7,7 +7,8 @@ import {
 } from '@nestjs/common';
 import { Firestore, CollectionReference, Timestamp, FieldValue } from 'firebase-admin/firestore';
 import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt } from '../types/scenario';
-import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service'; // Import Service
+import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
+import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION } from '../firebase/firebase.module';
 import { GeminiService } from '../gemini/gemini.service';
 
@@ -32,7 +33,8 @@ export class ScenariosService {
   constructor(
     @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
     private readonly geminiService: GeminiService,
-    private readonly knowledgeUnitsService: KnowledgeUnitsService, // Inject Service
+    private readonly knowledgeUnitsService: KnowledgeUnitsService,
+    private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
   ) {
     this.collectionRef = this.db.collection(SCENARIOS_COLLECTION);
   }
@@ -112,7 +114,14 @@ export class ScenariosService {
         targetVocab: dto.targetVocab
       };
 
-      await docRef.set(newScenario);
+      // console.log(newScenario);
+      console.dir(dto, { depth: null, colors: true });
+
+      const cleanData = Object.fromEntries(
+        Object.entries(newScenario).filter(([_, value]) => value !== undefined)
+      );
+
+      await docRef.set(cleanData);
       return id;
 
     } catch (error) {
@@ -133,55 +142,33 @@ export class ScenariosService {
     switch (scenario.state) {
       case 'encounter':
         // Transition Encounter -> Drill
-        // 1. Process Extracted KUs (Smart Linking)
+        // Link each extracted KU to its global KU and create a UserKnowledgeUnit.
         if (scenario.extractedKUs && scenario.extractedKUs.length > 0) {
           const updatedKUs: ExtractedKU[] = [];
 
           for (const ku of scenario.extractedKUs) {
-            // Only process if it doesn't already have an ID (idempotency)
             if (ku.kuId) {
               updatedKUs.push(ku);
               continue;
             }
 
             try {
-              // Map 'vocab' (scenario) to 'Vocab' (KU type)
-              // Currently scenarios only produce 'vocab', but handled generically if possible
-              // or just hardcoded for now since Scenario only has 'vocab' and 'kanji' logic is undefined there
-              const kuType = 'Vocab';
+              const globalKu = await this.knowledgeUnitsService.findByContent(ku.content, 'Vocab');
 
-              // Check existing
-              const existing = await this.knowledgeUnitsService.findByContent(uid, ku.content, kuType);
-
-              if (existing) {
-                this.logger.log(`Smart Link: Found existing KU for "${ku.content}" (ID: ${existing.id})`);
-                updatedKUs.push({ ...ku, kuId: existing.id, status: 'learning' }); // Linked!
+              if (globalKu) {
+                this.logger.log(`Linking "${ku.content}" to global KU ${globalKu.id}`);
+                await this.userKnowledgeUnitsService.create(uid, globalKu.id);
+                updatedKUs.push({ ...ku, kuId: globalKu.id, status: 'learning' });
               } else {
-                // Create New
-                this.logger.log(`Smart Link: Creating new KU for "${ku.content}"`);
-
-                const newIdObj = await this.knowledgeUnitsService.create(uid, {
-                  content: ku.content,
-                  type: kuType,
-                  data: {
-                    reading: ku.reading,
-                    definition: ku.meaning,
-                  },
-                  userId: scenario.userId,
-                  // Add metadata from scenario if needed, e.g. source scenario
-                });
-
-                updatedKUs.push({ ...ku, kuId: newIdObj.id, status: 'new' });
+                this.logger.warn(`No global KU found for "${ku.content}" — skipping UKU creation`);
+                updatedKUs.push(ku);
               }
-
             } catch (error) {
               this.logger.error(`Failed to process KU "${ku.content}" during advanceState`, error);
-              // Keep original KU without ID if failed, to avoid data loss, or throw?
-              // For now, keep original, maybe retry later. 
               updatedKUs.push(ku);
             }
           }
-          // Save updated KUs back to scenario
+
           updateData.extractedKUs = updatedKUs;
         }
 

--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -4,10 +4,12 @@ import {
     FIRESTORE_CONNECTION,
     KNOWLEDGE_UNITS_COLLECTION,
     REVIEW_FACETS_COLLECTION,
-    USER_STATS_COLLECTION // Make sure this is exported in firebase.module/constants
+    USER_STATS_COLLECTION,
+    USER_KUS_SUBCOLLECTION,
 } from '../firebase/firebase.module';
+import { ADMIN_USER_ID } from '../lib/constants';
 
-// Removed CURRENT_USER_ID
+// Removed ADMIN_USER_ID
 
 @Injectable()
 export class StatsService {
@@ -23,23 +25,33 @@ export class StatsService {
             .count()
             .get();
 
+        const ukuLearnQuery = this.db.collection('users').doc(uid)
+            .collection(USER_KUS_SUBCOLLECTION)
+            .where("status", "==", "learning")
+            .count()
+            .get();
+
         const reviewQuery = this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
             .where("userId", "==", uid)
             .where("status", "==", "reviewing")
             .count()
             .get();
 
-        const reviewsDueQuery = this.db.collection(REVIEW_FACETS_COLLECTION)
-            .where("userId", "==", uid)
-            .where("nextReviewAt", "<=", Timestamp.now()) // Safe timestamp comparison
+        const facetsCol = uid === ADMIN_USER_ID
+            ? this.db.collection(REVIEW_FACETS_COLLECTION).where('userId', '==', uid)
+            : this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+
+        const reviewsDueQuery = facetsCol
+            .where("nextReviewAt", "<=", Timestamp.now())
             .count()
             .get();
 
         // New: Fetch User Stats Document
         const userStatsQuery = this.db.collection(USER_STATS_COLLECTION).doc(uid).get();
 
-        const [learnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc] = await Promise.all([
+        const [learnSnapshot, ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc] = await Promise.all([
             learnQuery,
+            ukuLearnQuery,
             reviewQuery,
             reviewsDueQuery,
             userStatsQuery
@@ -119,7 +131,7 @@ export class StatsService {
         }
 
         return {
-            learnCount: learnSnapshot.data().count,
+            learnCount: learnSnapshot.data().count + ukuLearnSnapshot.data().count,
             reviewCount: totalActive,
             reviewsDue: reviewsDueCount,
 

--- a/backend/src/user-knowledge-units/user-knowledge-units.module.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { UserKnowledgeUnitsService } from './user-knowledge-units.service';
+
+@Global()
+@Module({
+  providers: [UserKnowledgeUnitsService],
+  exports: [UserKnowledgeUnitsService],
+})
+export class UserKnowledgeUnitsModule {}

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Firestore, Timestamp } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, KNOWLEDGE_UNITS_COLLECTION, USER_KUS_SUBCOLLECTION } from '../firebase/firebase.module';
+import { KnowledgeUnit, UserKnowledgeUnit } from '../types';
+
+@Injectable()
+export class UserKnowledgeUnitsService {
+  private readonly logger = new Logger(UserKnowledgeUnitsService.name);
+
+  constructor(@Inject(FIRESTORE_CONNECTION) private readonly db: Firestore) {}
+
+  private userKusRef(uid: string) {
+    return this.db.collection('users').doc(uid).collection(USER_KUS_SUBCOLLECTION);
+  }
+
+  async findByKuId(uid: string, kuId: string): Promise<UserKnowledgeUnit | null> {
+    const snapshot = await this.userKusRef(uid)
+      .where('kuId', '==', kuId)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) return null;
+
+    const doc = snapshot.docs[0];
+    return { id: doc.id, ...doc.data() } as UserKnowledgeUnit;
+  }
+
+  async findLearningQueueAsKUs(uid: string): Promise<KnowledgeUnit[]> {
+    const snapshot = await this.userKusRef(uid)
+      .where('status', '==', 'learning')
+      .get();
+
+    if (snapshot.empty) return [];
+
+    const ukus = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as UserKnowledgeUnit));
+
+    const kuRefs = ukus.map(uku => this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(uku.kuId));
+    const kuDocs = await this.db.getAll(...kuRefs);
+
+    const result: KnowledgeUnit[] = [];
+    for (let i = 0; i < ukus.length; i++) {
+      const uku = ukus[i];
+      const kuDoc = kuDocs[i];
+      if (!kuDoc.exists) {
+        this.logger.warn(`Global KU ${uku.kuId} not found for UKU ${uku.id}`);
+        continue;
+      }
+      const kuData = kuDoc.data()!;
+      result.push({
+        id: kuDoc.id,
+        ...kuData,
+        personalNotes: uku.personalNotes,
+        userNotes: uku.userNotes,
+        createdAt: (kuData.createdAt as Timestamp).toDate().toISOString(),
+      } as unknown as KnowledgeUnit);
+    }
+
+    return result;
+  }
+
+  async create(uid: string, kuId: string): Promise<UserKnowledgeUnit> {
+    const existing = await this.findByKuId(uid, kuId);
+    if (existing) {
+      this.logger.log(`UKU already exists for uid=${uid} kuId=${kuId}`);
+      return existing;
+    }
+
+    const now = Timestamp.now();
+    const payload: Omit<UserKnowledgeUnit, 'id'> = {
+      userId: uid,
+      kuId,
+      personalNotes: '',
+      createdAt: now,
+      status: 'learning',
+      facet_count: 0,
+    };
+
+    const ref = await this.userKusRef(uid).add(payload);
+    this.logger.log(`Created UKU id=${ref.id} for uid=${uid} kuId=${kuId}`);
+    return { id: ref.id, ...payload };
+  }
+}

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -226,6 +226,7 @@ export default function ScenarioPage({
       // Refresh scenario data to reflect new state
       await fetchScenario();
       if (scenario.state === "encounter") {
+        window.dispatchEvent(new CustomEvent("refreshStats"));
         alert("Vocabulary added to your queue!");
       } else if (scenario.state === "drill") {
         // Moved to simulate


### PR DESCRIPTION
## Summary
                                                                                                                                                                           
  - **Global KU corpus**: `KnowledgeUnitsService` is now user-agnostic — `userId` removed from all method signatures, Firestore queries, and write payloads. New KU
  documents carry no `userId` field.                                                                                                                                       
  - **`UserKnowledgeUnitsService`** (`backend/src/user-knowledge-units/`): new `@Global` service managing `users/{uid}/user-kus` sub-collection. `create(uid, kuId)` is
  idempotent; `findLearningQueueAsKUs(uid)` batch-fetches global KU data for the learning queue.                                                                           
  - **Scenario → UKU flow**: `ScenariosService.advanceState` (encounter→drill) now creates `UserKnowledgeUnit` records instead of `KnowledgeUnit` records. Vocab absent    
  from the global corpus is skipped with a warning log.                                                                                                                
  - **Learning Queue**: `GET /api/knowledge-units/get-all?status=learning` now returns only the requesting user's UKU-joined global KUs. `findOne` authorises access via   
  direct ownership (admin) or existence of a UKU for that `kuId`.                                                                                                       
  - **Per-user `review-facets`**: `ReviewsService` routes facet reads/writes to `users/{uid}/review-facets` sub-collection for all non-admin users; `user_default`         
  continues using the top-level `review-facets` collection with `userId` field scoping. Same routing in `StatsService`.                                           
  - **`ADMIN_USER_ID`**: renamed from `CURRENT_USER_ID` in `backend/src/lib/constants.ts`; a TODO marks the remaining hardcoded `'user_default'` string in                 
  `firebase-auth.guard.ts`.                                                                                                                               
  - **Frontend**: dispatches `refreshStats` window event after "Start Drilling" so the Learn tab badge updates immediately.                                                
                                                                                                                           
  ## Test plan                                                                                                                                                             
                                                            
  - [ ] Sign in as a real (non-admin) user                                                                                                                                 
  - [ ] Start a scenario and click "Start Drilling" — verify `users/{uid}/user-kus` docs appear in Firestore                                                               
  - [ ] Navigate to Learn tab — verify badge count updates and only the user's UKU-linked KUs appear in the queue
  - [ ] Click a learning item — verify lesson loads (generated if first visit)                                                                                             
  - [ ] Select review facets from the lesson page — verify facets appear in `users/{uid}/review-facets`                                                                    
  - [ ] Complete a review — verify SRS stage advances correctly                                                                                                            
  - [ ] Confirm `user_default` manage page and existing KU/facet data are unaffected    