### PR TITLE
feat: revamped the question service for better question management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@ Basic Vocab data was extracted from Wanikani and then boiled down to non-proprie
 - (Done) User KU metadata is stored in `users/{uid}/user-kus` as `UserKnowledgeUnit` documents referencing global KUs via `kuId`. Managed by `UserKnowledgeUnitsService`.
 - (Done) Users can sign up and log in via passwordless email-link auth.
 - (Done) When a user interacts with a scenario and clicks "Start Drilling", `UserKnowledgeUnit` documents are created in their sub-collection — this populates their Learning Queue.
-- (ToDo) Questions need a design overhaul — reuse/rotation logic for AI-Generated-Question facets is broken (always reuses the same question regardless of attempt count).
+- (Done) Questions have been overhauled — see **Question Corpus** section below and Migration History.
 
 ## User Management, Authentication & Multi-Tenancy
 
@@ -145,7 +145,8 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 | `users/{uid}/review-facets` | Yes — sub-collection path | Per-user SRS facets (non-admin users) |
 | `review-facets` | Yes (field) | Admin (`user_default`) SRS facets only; `userId` field still required |
 | `lessons` | Yes (field) | AI-generated lesson documents |
-| `questions` | Yes (field) | Question documents (global pool, referenced by facet `currentQuestionId`) |
+| `questions` | **No** | Global question corpus — no `userId` on new docs. `rank` and `rejectionCount` fields drive selection. |
+| `users/{uid}/question-states` | Yes — sub-collection path | Per-user `UserQuestionState`: `rejected`, `consecutiveFailures`, `kuId` |
 | `scenarios` | Yes (field) | Roleplay scenario state |
 | `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
 | `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
@@ -159,7 +160,8 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 - **`KnowledgeUnit`** (~line 205) — has `userId` field (marked `@deprecated` as part of future migration to a separate `user-kus` sub-collection). `data` bag holds `jlptLevel`, `wanikaniLevel`, `reading`, `meaning`.
 - **`UserKnowledgeUnit`** (~line 235) — intended future shape: user metadata (`status`, `personalNotes`, `facet_count`) pointing at a global KU via `kuId`. **Not yet used in queries.**
 - **`ReviewFacet`** (~line 261) — bridges to `KnowledgeUnit` via `kuId`; carries `srsStage` (0–8) and `nextReviewAt`.
-- **`UserQuestionState`** (~line 290) — bridges to a global `Question` via `questionId`; tracks answer history per user.
+- **`QuestionItem`** — global question document. `rank: number` (0–100, starts 50, suitable threshold 30); `rejectionCount: number` (observability only). Deprecated fields (`userId`, `status`, `lastUsed`, `previousAnswers`) may exist on legacy docs but are ignored.
+- **`UserQuestionState`** — stored at `users/{uid}/question-states/{questionId}`. `rejected: boolean` (user never sees this question again); `consecutiveFailures: number` (persists across sessions, resets on correct answer, triggers rotation at 3); `kuId` (denormalised for querying).
 
 ---
 
@@ -206,6 +208,35 @@ The following work is required to complete proper multi-user support. Each item 
 **5. Scope `api-logs` by user (optional)**
 - Add `userId` field to log documents so per-user activity can be audited.
 
+## Question Corpus
+
+`AI-Generated-Question` facets draw from a **global question corpus** shared across all users for the same KU.
+
+### Selection logic (`QuestionsService.selectQuestion`)
+1. If the facet has a `currentQuestionId`, try to reuse it — passes if `rank >= 30`, not rejected by this user, and `consecutiveFailures < 3`.
+2. Otherwise query all questions for the KU, apply the same suitability filters, pick the first passing candidate.
+3. If no suitable question exists, generate a new one via Gemini and save it to the global corpus.
+
+### Ranking
+| Event | `questions/{id}.rank` | `UserQuestionState` |
+|---|---|---|
+| Correct answer | +5 | `consecutiveFailures = 0` |
+| Wrong answer | no change | `consecutiveFailures++` |
+| Keep feedback | +5 | — |
+| Request New | no change | `rejected = true`; global `rejectionCount++` |
+| Report feedback | -25 | — |
+
+Rank nominally 0–100 but is not hard-clamped; `>= 30` is the only gate used in queries.
+
+### Key endpoints
+- `GET /api/questions/generate?topic=&facetId=&kuId=` — returns `{ question, answer, context, accepted_alternatives, questionId, isNew }`. `isNew: true` means no `UserQuestionState` exists yet for this user; the frontend uses this to decide whether to show the feedback modal.
+- `PATCH /api/questions/:id/feedback` — body `{ feedback: 'keep' | 'request-new' | 'report' }`.
+
+### Migration note for existing question documents
+Legacy docs lack `rank` and `rejectionCount`. They are served correctly on first use (`rank ?? 50` at read time) but fall below the suitability threshold after their first correct answer or feedback write (`FieldValue.increment` initialises missing fields from 0). Run a one-time backfill of `{ rank: 50, rejectionCount: 0 }` across the `questions` collection to restore them.
+
+---
+
 ## Migration History
 
 **Note**: This section is very much outdated but should be used to summarize the history of the project. 
@@ -239,6 +270,20 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - **`review-facets` per-user sub-collection**: `ReviewsService` routes all facet reads/writes to `users/{uid}/review-facets` for non-admin users; `user_default` continues to use the top-level `review-facets` collection with `userId` field scoping. Same routing applied in `StatsService`.
 - **`ADMIN_USER_ID` constant**: `CURRENT_USER_ID` renamed to `ADMIN_USER_ID` in `backend/src/lib/constants.ts`. The string `'user_default'` remains hardcoded in `firebase-auth.guard.ts` pending a follow-up cleanup.
 - **Frontend**: `refreshStats` event dispatched after successful encounter→drill advance so the Learn tab badge updates immediately.
+
+**Question corpus overhaul (2026-04)**
+
+- Replaced the broken per-facet `questionAttempts` reuse logic with a global question corpus and per-user state model.
+- `questions` collection is now user-agnostic (no `userId` on new docs). Added `rank: number` (starts 50) and `rejectionCount: number` fields.
+- New `users/{uid}/question-states/{questionId}` sub-collection stores per-user `UserQuestionState` (`rejected`, `consecutiveFailures`, `kuId`).
+- `QuestionsService` rewritten: `selectQuestion` (reuse → corpus → generate), `recordAnswer` (rank/failure tracking), `recordFeedback` (keep / request-new / report).
+- `PATCH /api/questions/:id` replaced by `PATCH /api/questions/:id/feedback` with `{ feedback }` body.
+- `GET /api/questions/generate` now returns `isNew: boolean` instead of `status`; frontend uses it to gate the feedback modal.
+- `POST /api/reviews/evaluate` now accepts optional `kuId` and calls `recordAnswer` on every evaluation.
+- `ReviewFacet.questionAttempts` deprecated; `updateFacetQuestion` no longer resets it.
+- Frontend `review/page.tsx`: `dynamicQuestionStatus` state replaced by `dynamicQuestionIsNew`; `isNewAiQuestion` simplified; feedback handlers call `recordFeedback`.
+
+---
 
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -12,6 +12,7 @@ export const QUESTIONS_COLLECTION = "questions";
 export const USER_STATS_COLLECTION = 'user-stats';
 export const SCENARIOS_COLLECTION = 'scenarios';
 export const USER_KUS_SUBCOLLECTION = 'user-kus';
+export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;
 

--- a/backend/src/questions/questions.controller.ts
+++ b/backend/src/questions/questions.controller.ts
@@ -6,31 +6,28 @@ import { UserId } from '../auth/user-id.decorator';
 @Controller('questions')
 @UseGuards(FirebaseAuthGuard)
 export class QuestionsController {
-  constructor(private readonly questionsService: QuestionsService) { }
+  constructor(private readonly questionsService: QuestionsService) {}
 
   @Get('generate')
   async generate(
     @UserId() uid: string,
     @Query('topic') topic: string,
-    @Query('facetId') facetId: string, // Optional depending on your logic
-    @Query('kuId') kuId: string,       // Optional depending on your logic
+    @Query('facetId') facetId: string,
+    @Query('kuId') kuId: string,
   ) {
-    if (!topic) {
-      throw new BadRequestException('Topic is required');
-    }
-    return this.questionsService.generateQuestion(uid, topic, kuId, facetId);
+    if (!topic) throw new BadRequestException('Topic is required');
+    return this.questionsService.selectQuestion(uid, kuId, facetId, topic);
   }
 
-  @Patch(':id')
-  async updateStatus(
+  @Patch(':id/feedback')
+  async recordFeedback(
     @UserId() uid: string,
     @Param('id') id: string,
-    @Body() body: { status: 'active' | 'flagged' | 'inactive' }
+    @Body() body: { feedback: 'keep' | 'request-new' | 'report' },
   ) {
-    if (!body.status || !['active', 'flagged', 'inactive'].includes(body.status)) {
-      throw new BadRequestException('Valid status is required');
+    if (!body.feedback || !['keep', 'request-new', 'report'].includes(body.feedback)) {
+      throw new BadRequestException('feedback must be keep, request-new, or report');
     }
-
-    return this.questionsService.updateStatus(uid, id, body.status);
+    return this.questionsService.recordFeedback(uid, id, body.feedback);
   }
 }

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -1,20 +1,31 @@
-import { Injectable, Inject, Logger, forwardRef, NotFoundException } from '@nestjs/common';
+import { Injectable, Inject, Logger, forwardRef, NotFoundException, BadRequestException } from '@nestjs/common';
 import { Firestore } from 'firebase-admin/firestore';
 import {
   FIRESTORE_CONNECTION,
   QUESTIONS_COLLECTION,
-  REVIEW_FACETS_COLLECTION,
+  QUESTION_STATES_SUBCOLLECTION,
   Timestamp,
   FieldValue,
 } from '../firebase/firebase.module';
-import { BadRequestException } from '@nestjs/common';
-import { ReviewFacet, QuestionItem, KnowledgeUnit } from '@/types';
+import { ReviewFacet, QuestionItem, UserQuestionState } from '@/types';
 import { GeminiService } from '../gemini/gemini.service';
 import { ReviewsService } from '../reviews/reviews.service';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
-// Removed CURRENT_USER_ID import
 
+const SUITABLE_RANK_THRESHOLD = 30;
+const RANK_CORRECT_DELTA = 5;
+const RANK_KEEP_DELTA = 5;
+const RANK_REPORT_DELTA = -25;
+const MAX_CONSECUTIVE_FAILURES = 3;
 
+type QuestionResponse = {
+  question: string;
+  context: string | undefined;
+  answer: string;
+  accepted_alternatives: string[] | undefined;
+  questionId: string;
+  isNew: boolean;
+};
 
 @Injectable()
 export class QuestionsService {
@@ -26,53 +37,123 @@ export class QuestionsService {
     @Inject(forwardRef(() => ReviewsService))
     private readonly reviewsService: ReviewsService,
     private readonly knowledgeUnitsService: KnowledgeUnitsService,
+  ) {}
 
-  ) { }
+  private questionStatesRef(uid: string) {
+    return this.db.collection('users').doc(uid).collection(QUESTION_STATES_SUBCOLLECTION);
+  }
+
+  private toResponse(question: QuestionItem, isNew: boolean): QuestionResponse {
+    return {
+      question: question.data.question,
+      context: question.data.context,
+      answer: question.data.answer,
+      accepted_alternatives: question.data.acceptedAlternatives,
+      questionId: question.id,
+      isNew,
+    };
+  }
 
   async testConnection() {
     const snapshot = await this.db.collection(QUESTIONS_COLLECTION).limit(1).get();
     this.logger.log(`Found ${snapshot.size} questions`);
   }
 
+  async selectQuestion(uid: string, kuId: string, facetId: string, topic: string): Promise<QuestionResponse> {
+    if (!topic) throw new BadRequestException('Topic is required');
 
-  async updateQuestionHistory(questionId: string, userAnswer: string, result: string) {
-    if (questionId) {
-      try {
-        const questionRef = this.db
-          .collection(QUESTIONS_COLLECTION)
-          .doc(questionId);
-        await questionRef.update({
-          previousAnswers: FieldValue.arrayUnion({
-            answer: userAnswer,
-            result: "pass",
-            timestamp: Timestamp.now(),
-          }),
-        });
-        this.logger.log(`Updated question ${questionId} with pass history`);
-      } catch (histError) {
-        this.logger.error(
-          "Failed to update question history (local pass)",
-          histError,
-        );
+    const facetData = facetId
+      ? await this.reviewsService.getByFacetId(uid, facetId) as ReviewFacet | null
+      : null;
+
+    // 1. Try to reuse the question already on the facet
+    if (facetData?.currentQuestionId) {
+      const reused = await this.tryReuseQuestion(uid, facetData.currentQuestionId);
+      if (reused) {
+        this.logger.log(`Reusing question ${facetData.currentQuestionId} for facet ${facetId}`);
+        return reused;
       }
     }
+
+    // 2. Find another suitable question from the global corpus
+    const suitable = await this.findSuitableQuestion(uid, kuId, facetData?.currentQuestionId);
+    if (suitable) {
+      this.logger.log(`Found suitable question ${suitable.questionId} for KU ${kuId}`);
+      if (facetId) await this.reviewsService.updateFacetQuestion(uid, facetId, suitable.questionId);
+      return suitable;
+    }
+
+    // 3. Generate a new question via AI
+    this.logger.log(`No suitable questions for KU ${kuId} — generating new one`);
+    return this.generateAndSave(uid, topic, kuId, facetId);
   }
 
-  async generateQuestion(uid: string, topic: string, kuId: string, facetId: string) {
+  private async tryReuseQuestion(uid: string, questionId: string): Promise<QuestionResponse | null> {
+    const [questionDoc, stateDoc] = await Promise.all([
+      this.db.collection(QUESTIONS_COLLECTION).doc(questionId).get(),
+      this.questionStatesRef(uid).doc(questionId).get(),
+    ]);
 
+    if (!questionDoc.exists) return null;
+
+    const question = { id: questionDoc.id, ...questionDoc.data() } as QuestionItem;
+    const state = stateDoc.exists ? stateDoc.data() as UserQuestionState : null;
+
+    const rank = question.rank ?? 50;
+    if (
+      !state?.rejected &&
+      rank >= SUITABLE_RANK_THRESHOLD &&
+      (state?.consecutiveFailures ?? 0) < MAX_CONSECUTIVE_FAILURES
+    ) {
+      return this.toResponse(question, !stateDoc.exists);
+    }
+
+    return null;
+  }
+
+  private async findSuitableQuestion(uid: string, kuId: string, excludeId?: string): Promise<QuestionResponse | null> {
+    const snapshot = await this.db.collection(QUESTIONS_COLLECTION)
+      .where('kuId', '==', kuId)
+      .get();
+
+    if (snapshot.empty) return null;
+
+    const candidates = snapshot.docs
+      .map(d => ({ id: d.id, ...d.data() } as QuestionItem))
+      .filter(q => q.id !== excludeId && (q.rank ?? 50) >= SUITABLE_RANK_THRESHOLD);
+
+    if (candidates.length === 0) return null;
+
+    const stateDocs = await Promise.all(
+      candidates.map(q => this.questionStatesRef(uid).doc(q.id).get())
+    );
+
+    for (let i = 0; i < candidates.length; i++) {
+      const question = candidates[i];
+      const stateDoc = stateDocs[i];
+      const state = stateDoc.exists ? stateDoc.data() as UserQuestionState : null;
+
+      if (state?.rejected) continue;
+      if ((state?.consecutiveFailures ?? 0) >= MAX_CONSECUTIVE_FAILURES) continue;
+
+      return this.toResponse(question, !stateDoc.exists);
+    }
+
+    return null;
+  }
+
+  private async generateAndSave(uid: string, topic: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
     const questionOptions = {
       "conjugation": "if the word is a verb, conjugate the verb to a specific form e.g.: Give the past potential form of the verb in question",
       "particle": "Match up the Vocab in question with a particle to give a particular meaning in a sentence that you specify, you can represent the particle with a blank '[____]'",
       "translation": "Create a sentence in English for the user to translate into Japanese. The English sentence must naturally force the use of the Target Input.",
-      "fill-in-the-blank": "A context-based, fill-in-the-blank style question with a single blank '[____]'"
-    }
-
+      "fill-in-the-blank": "A context-based, fill-in-the-blank style question with a single blank '[____]'",
+    };
     const questionOptionTypes = Object.keys(questionOptions);
     const selectedType = questionOptionTypes[Math.floor(Math.random() * questionOptionTypes.length)];
 
-    // --- System Prompt ---
-    const systemPrompt = `You are an expert Japanese tutor and quiz generator. 
-You will be prompted with a single piece of Japanese Vocab: a word or grammar concept (the 'topic') and an optional reading and meaning. 
+    const systemPrompt = `You are an expert Japanese tutor and quiz generator.
+You will be prompted with a single piece of Japanese Vocab: a word or grammar concept (the 'topic') and an optional reading and meaning.
 Your task is to create a single, context-based question to test the user's understanding of that word or grammar concept.
 If a reading and/or meaning are provided, you MUST generate a question where the topic matches those specific constraints. Do not generate questions for alternative readings or meanings of the same word.
 You MUST generate a question using the following form:
@@ -100,169 +181,99 @@ Rules:
 12. If the question requires conjugation of a verb and the answer is not the base form, provide enough context to disambiguate the answer.
 13. Do not add any text before or after the JSON object.`;
 
-    let parsedJson: {
-      question: string;
-      answer: string;
-      context?: string;
-      accepted_alternatives?: string[];
-    } | undefined; // Capture parsed result
-
-    if (!topic) {
-      throw new BadRequestException('Topic is required');
-    }
-
     let reading: string | undefined;
     let meaning: string | undefined;
     if (kuId) {
       const kuData = await this.knowledgeUnitsService.findOne(kuId);
       reading = kuData.data?.reading;
-      // Use 'meaning' (Kanji) or 'definition' (Vocab) depending on what's available
       meaning = kuData.data?.meaning || kuData.data?.definition;
     }
-
-    // --- Persistence Logic ---
-    let facetData: ReviewFacet | undefined;
-    let returnedQuestionId: string | null = null;
-
-    if (facetId) {
-      facetData = (await this.reviewsService.getByFacetId(uid, facetId)) as ReviewFacet;
-
-      if (facetData) {
-
-        if (
-          facetData.currentQuestionId &&
-          (facetData.questionAttempts || 0) < 3
-        ) {
-          this.logger.log(
-            `Reusing question ${facetData.currentQuestionId} for facet ${facetId} (attempts: ${facetData.questionAttempts})`,
-          );
-
-
-          const questionDoc = await this.db
-            .collection(QUESTIONS_COLLECTION)
-            .doc(facetData.currentQuestionId)
-            .get();
-
-          if (questionDoc.exists) {
-            const questionItem = questionDoc.data() as QuestionItem;
-
-            // Check if the question is active
-            if (questionItem.status === "inactive") {
-              this.logger.log(`Question ${facetData.currentQuestionId} is inactive. Generating new one.`);
-            } else {
-              this.logger.log(`Question ${facetData.currentQuestionId} found and active. Returning it.`);
-              // Return the stored question data directly
-              // We need to map it back to the expected response format
-              return {
-                question: questionItem.data.question,
-                context: questionItem.data.context,
-                answer: questionItem.data.answer,
-                accepted_alternatives: questionItem.data.acceptedAlternatives,
-                questionId: questionItem.id, // Return the ID
-                status: questionItem.status, // Return the status
-              };
-            }
-          } else {
-            this.logger.log(`Question ${facetData.currentQuestionId} not found. Generating new one.`);
-          }
-        } else {
-          this.logger.log(
-            `Not reusing question. currentQuestionId: ${facetData.currentQuestionId}, attempts: ${facetData.questionAttempts}`,
-          );
-        }
-      } else {
-        this.logger.log`Facet ${facetId} not found`
-      }
-    }
-
-    const runningListSummary = "No weak points identified yet."; // TODO: re-implement running list
 
     let userMessage = `Topic: ${topic}`;
     if (reading) userMessage += `\nReading: ${reading}`;
     if (meaning) userMessage += `\nMeaning: ${meaning}`;
-    userMessage += `\n`;
 
-    // TODO: What to do about the empty LogContext argument?
     const questionString = await this.geminiService.generateQuestionAI(userMessage, systemPrompt, {});
 
-    // Here we get back the json text from Gemini. We need to check we got something and then parse it
-    if (!questionString) {
-      this.logger.error("AI response was empty.");
-      throw new Error("AI response was empty.");
-    }
+    if (!questionString) throw new Error('AI response was empty.');
 
-    // 4. Parse and validate (keeping existing robust parsing logic)
+    let parsed: { question: string; answer: string; context?: string; accepted_alternatives?: string[] };
     try {
-      parsedJson = JSON.parse(questionString);
-    } catch (parseError) {
-      this.logger.error("Failed to parse AI JSON response", {
-        questionString,
-        parseError,
-      });
-      throw new Error("Failed to parse AI JSON response");
+      parsed = JSON.parse(questionString);
+    } catch {
+      throw new Error('Failed to parse AI JSON response');
     }
 
-    if (!parsedJson) {
-      throw new Error(
-        "Evaluation result is missing after AI response parsing.",
-      );
-    }
-
-    // --- Save Generated Question ---
-    if (facetId) {
-      try {
-        const newQuestionRef = this.db.collection(QUESTIONS_COLLECTION).doc();
-        const newQuestionItem: QuestionItem = {
-          id: newQuestionRef.id,
-          kuId: kuId || topic, // Use kuId if available, fallback to topic
-          data: {
-            question: parsedJson.question,
-            context: parsedJson.context,
-            answer: parsedJson.answer,
-            acceptedAlternatives: parsedJson.accepted_alternatives,
-            difficulty: "JLPT-N5", // TODO Need to get this value from the generate-question response eventually
-          },
-          createdAt: Timestamp.now(),
-          lastUsed: Timestamp.now(),
-          userId: uid,
-          status: "active", // Default status
-        };
-
-        await newQuestionRef.set(newQuestionItem);
-        this.logger.log(`Saved new question: ${newQuestionRef.id}`);
-
-        // Update Facet
-        await this.reviewsService.updateFacetQuestion(uid, facetId, newQuestionRef.id);
-        returnedQuestionId = newQuestionRef.id;
-      } catch (saveError) {
-        this.logger.error("Failed to save generated question", saveError);
-        // Don't fail the request if saving fails, just log it
-      }
-    }
-
-    return {
-      ...parsedJson,
-      questionId: returnedQuestionId,
-      status: 'active', // New questions are always active
+    const ref = this.db.collection(QUESTIONS_COLLECTION).doc();
+    const newQuestion: QuestionItem = {
+      id: ref.id,
+      kuId,
+      data: {
+        question: parsed.question,
+        context: parsed.context,
+        answer: parsed.answer,
+        acceptedAlternatives: parsed.accepted_alternatives,
+        difficulty: 'JLPT-N5',
+      },
+      rank: 50,
+      rejectionCount: 0,
+      createdAt: Timestamp.now(),
     };
 
-  } // end generateQuestion
+    await ref.set(newQuestion);
+    this.logger.log(`Saved new question ${ref.id} for KU ${kuId}`);
 
-  async updateStatus(uid: string, id: string, status: 'active' | 'flagged' | 'inactive') {
-    const docRef = this.db.collection(QUESTIONS_COLLECTION).doc(id);
-    const doc = await docRef.get();
-
-    if (!doc.exists) {
-      throw new NotFoundException('Question not found');
+    if (facetId) {
+      await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);
     }
 
-    if (doc.data()?.userId !== uid) {
-      throw new NotFoundException('Question not found');
+    return this.toResponse(newQuestion, true);
+  }
+
+  async recordAnswer(uid: string, questionId: string, kuId: string, result: 'pass' | 'fail') {
+    const questionRef = this.db.collection(QUESTIONS_COLLECTION).doc(questionId);
+    const stateRef = this.questionStatesRef(uid).doc(questionId);
+
+    const batch = this.db.batch();
+
+    if (result === 'pass') {
+      batch.update(questionRef, { rank: FieldValue.increment(RANK_CORRECT_DELTA) });
+      batch.set(stateRef, { questionId, kuId, consecutiveFailures: 0 }, { merge: true });
+    } else {
+      batch.set(stateRef, { questionId, kuId, consecutiveFailures: FieldValue.increment(1) }, { merge: true });
     }
 
-    await docRef.update({ status });
+    try {
+      await batch.commit();
+    } catch (err) {
+      this.logger.error(`Failed to record answer for question ${questionId}`, err);
+    }
+  }
 
-    this.logger.log(`Updated question ${id} status to ${status}`);
-    return { id, status };
-  } // end updateStatus
+  async recordFeedback(uid: string, questionId: string, feedback: 'keep' | 'request-new' | 'report') {
+    const questionRef = this.db.collection(QUESTIONS_COLLECTION).doc(questionId);
+    const doc = await questionRef.get();
+
+    if (!doc.exists) throw new NotFoundException('Question not found');
+
+    const stateRef = this.questionStatesRef(uid).doc(questionId);
+    const batch = this.db.batch();
+
+    switch (feedback) {
+      case 'keep':
+        batch.update(questionRef, { rank: FieldValue.increment(RANK_KEEP_DELTA) });
+        break;
+      case 'request-new':
+        batch.update(questionRef, { rejectionCount: FieldValue.increment(1) });
+        batch.set(stateRef, { rejected: true }, { merge: true });
+        break;
+      case 'report':
+        batch.update(questionRef, { rank: FieldValue.increment(RANK_REPORT_DELTA) });
+        break;
+    }
+
+    await batch.commit();
+    this.logger.log(`Recorded feedback '${feedback}' for question ${questionId}`);
+    return { questionId, feedback };
+  }
 }

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -11,7 +11,7 @@ export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) { }
 
   @Post('evaluate')
-  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId?: string }) {
+  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId: string }) {
     const { userAnswer, expectedAnswers, question, topic, questionId, kuId } = body;
 
     this.logger.log(`body ${JSON.stringify(body)}`);
@@ -23,6 +23,10 @@ export class ReviewsController {
       expectedAnswers.length === 0
     ) {
       throw new BadRequestException('Missing userAnswer or expectedAnswer');
+    }
+
+    if (questionId && !kuId) {
+      throw new BadRequestException('kuId is required when questionId is provided');
     }
 
     return this.reviewsService.evaluateAnswer(uid, userAnswer, expectedAnswers, question, topic, questionId, kuId);

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -11,8 +11,8 @@ export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) { }
 
   @Post('evaluate')
-  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string }) {
-    const { userAnswer, expectedAnswers, question, topic, questionId } = body;
+  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId?: string }) {
+    const { userAnswer, expectedAnswers, question, topic, questionId, kuId } = body;
 
     this.logger.log(`body ${JSON.stringify(body)}`);
 
@@ -25,7 +25,7 @@ export class ReviewsController {
       throw new BadRequestException('Missing userAnswer or expectedAnswer');
     }
 
-    return this.reviewsService.evaluateAnswer(uid, userAnswer, expectedAnswers, question, topic, questionId);
+    return this.reviewsService.evaluateAnswer(uid, userAnswer, expectedAnswers, question, topic, questionId, kuId);
   }
 
   @Put('facets/:id')

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -178,10 +178,7 @@ export class ReviewsService {
     }
 
     async updateFacetQuestion(uid: string, facetId: string, questionId: string) {
-        await this.facetsColRef(uid).doc(facetId).update({
-            currentQuestionId: questionId,
-            questionAttempts: 0,
-        });
+        await this.facetsColRef(uid).doc(facetId).update({ currentQuestionId: questionId });
         this.logger.log(`Updated facet ${facetId} with new question ${questionId}`);
     }
 
@@ -192,6 +189,7 @@ export class ReviewsService {
         question: string,
         topic: string,
         questionId: string,
+        kuId?: string,
     ) {
         // 1. Local Check
         const isLocalMatch = expectedAnswers.some(
@@ -200,15 +198,10 @@ export class ReviewsService {
 
         if (isLocalMatch) {
             this.logger.log(`Local match passed for topic: ${topic}`);
-            this.questionsService.updateQuestionHistory(
-                questionId,
-                userAnswer,
-                'pass',
-            );
-            return {
-                result: 'pass',
-                explanation: 'Correct!',
-            };
+            if (questionId) {
+                await this.questionsService.recordAnswer(uid, questionId, kuId || '', 'pass');
+            }
+            return { result: 'pass', explanation: 'Correct!' };
         }
 
         // 2. AI Fallback
@@ -223,7 +216,7 @@ export class ReviewsService {
 Your task is to evaluate if the user's answer is correct.
 1.  Read the "expected answer(s)". This may be a single answer (e.g., "Family") or a comma-separated list of possible correct answers (e.g., "ドク, トク, よむ").
 2.  Compare the user's answer to the list. The user is correct if their answer is *any one* of the items in the list.
-3.  If you feel that the answer is correct but not in the list, return a pass with an explanation.  
+3.  If you feel that the answer is correct but not in the list, return a pass with an explanation.
 4.  Be lenient with hiragana vs katakana (e.g., if expected is "ドク" and user typed "どく", it's a pass).
 5.  Be lenient with extra punctuation or whitespace.
 6.  Provide your evaluation ONLY as a valid JSON object with the following schema:
@@ -235,21 +228,18 @@ Example for a pass: {"result": "pass", "explanation": "Correct! よむ is one of
 Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected readings were ドク, トク, or よむ."}
 `;
 
-        const schema = {
-            type: 'OBJECT',
-            properties: {
-                result: { type: 'STRING', enum: ['pass', 'fail'] },
-                explanation: { type: 'STRING' },
-            },
-            required: ['result', 'explanation'],
-        };
-
-        return this.geminiService.evaluateAnswer(
+        const evalResult = await this.geminiService.evaluateAnswer(
             systemPrompt,
             userAnswer,
             expectedAnswers,
             { userAnswer, expectedAnswers, question, topic },
-        );
+        ) as { result: 'pass' | 'fail'; explanation: string };
+
+        if (questionId) {
+            await this.questionsService.recordAnswer(uid, questionId, kuId || '', evalResult.result);
+        }
+
+        return evalResult;
     } // END evaluateAnswer
 
     async generateReviewFacets(

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -189,7 +189,7 @@ export class ReviewsService {
         question: string,
         topic: string,
         questionId: string,
-        kuId?: string,
+        kuId: string,
     ) {
         // 1. Local Check
         const isLocalMatch = expectedAnswers.some(
@@ -199,7 +199,7 @@ export class ReviewsService {
         if (isLocalMatch) {
             this.logger.log(`Local match passed for topic: ${topic}`);
             if (questionId) {
-                await this.questionsService.recordAnswer(uid, questionId, kuId || '', 'pass');
+                await this.questionsService.recordAnswer(uid, questionId, kuId, 'pass');
             }
             return { result: 'pass', explanation: 'Correct!' };
         }
@@ -236,7 +236,7 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
         ) as { result: 'pass' | 'fail'; explanation: string };
 
         if (questionId) {
-            await this.questionsService.recordAnswer(uid, questionId, kuId || '', evalResult.result);
+            await this.questionsService.recordAnswer(uid, questionId, kuId, evalResult.result);
         }
 
         return evalResult;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -272,6 +272,7 @@ export interface ReviewFacet {
     stage: number;
   }>;
   currentQuestionId?: string;
+  /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
   data?: any;
 }
@@ -302,8 +303,6 @@ export type LessonDifficulty =
 
 export interface QuestionItem {
   id: string;
-  /** @deprecated - migrating to User state models */
-  userId: string;
   kuId: string;
   data: {
     context?: string;
@@ -312,12 +311,16 @@ export interface QuestionItem {
     acceptedAlternatives?: string[];
     difficulty: LessonDifficulty;
   };
-  /** @deprecated - migrating to User state models */
-  status?: "active" | "flagged" | "inactive"; // Default is 'active' if undefined
+  rank: number;        // 0–100, starts at 50; suitable threshold is 30
+  rejectionCount: number; // tracked for observability; not used for ranking
   createdAt: string | Timestamp;
-  /** @deprecated - migrating to User state models */
+  /** @deprecated */
+  userId?: string;
+  /** @deprecated */
+  status?: "active" | "flagged" | "inactive";
+  /** @deprecated */
   lastUsed?: string | Timestamp;
-  /** @deprecated - migrating to User state models */
+  /** @deprecated */
   previousAnswers?: {
     answer: string;
     result: "pass" | "fail";
@@ -326,15 +329,10 @@ export interface QuestionItem {
 }
 
 export interface UserQuestionState {
-  userId: string;
-  questionId: string; // Bridges to GlobalQuestion.id
-  status: "active" | "flagged" | "inactive";
-  lastUsed?: string | Timestamp;
-  previousAnswers?: {
-    answer: string;
-    result: "pass" | "fail";
-    timestamp: Timestamp;
-  }[];
+  questionId: string;
+  kuId: string;
+  rejected: boolean;       // user will never see this question again
+  consecutiveFailures: number; // resets on correct answer; 3+ triggers rotation
 }
 
 // ─── Feed Engine Types ────────────────────────────────────────────────

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -38,9 +38,7 @@ export default function ReviewPage() {
   const [dynamicQuestionId, setDynamicQuestionId] = useState<string | null>(
     null,
   );
-  const [dynamicQuestionStatus, setDynamicQuestionStatus] = useState<
-    "active" | "flagged" | "inactive" | null
-  >(null);
+  const [dynamicQuestionIsNew, setDynamicQuestionIsNew] = useState<boolean>(false);
 
   // --- Feedback Modal State ---
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
@@ -141,14 +139,14 @@ export default function ReviewPage() {
         context,
         accepted_alternatives,
         questionId,
-        status,
+        isNew,
       } = await response.json();
       setDynamicQuestion(question);
       setDynamicAnswer(answer);
       setDynamicContext(context || null);
       setDynamicAltAnswers(accepted_alternatives || null);
       setDynamicQuestionId(questionId || null);
-      setDynamicQuestionStatus(status || "active");
+      setDynamicQuestionIsNew(isNew ?? false);
     } catch (err) {
       if (err instanceof Error) setError(err.message);
       else setError("An unknown error occurred");
@@ -206,9 +204,8 @@ export default function ReviewPage() {
       setDynamicAnswer(null);
       setDynamicAltAnswers([]);
       setDynamicContext(null);
-      setDynamicContext(null);
       setDynamicQuestionId(null);
-      setDynamicQuestionStatus(null);
+      setDynamicQuestionIsNew(false);
 
       fetchDynamicQuestion(
         currentItem.ku.content,
@@ -220,9 +217,8 @@ export default function ReviewPage() {
       setDynamicAnswer(null);
       setDynamicAltAnswers([]);
       setDynamicContext(null);
-      setDynamicContext(null);
       setDynamicQuestionId(null);
-      setDynamicQuestionStatus(null);
+      setDynamicQuestionIsNew(false);
     }
   }, [currentItem, currentIndex]); // Re-run whenever the currentItem OR the index changes
 
@@ -281,46 +277,27 @@ export default function ReviewPage() {
     }
   };
 
-  const updateQuestionStatus = async (
+  const recordFeedback = async (
     questionId: string,
-    status: "active" | "flagged" | "inactive",
+    feedback: "keep" | "request-new" | "report",
   ) => {
     try {
-      // TODO use nestjs backend service instead
-      const res = await apiFetch(`/api/questions/${questionId}`, {
+      const res = await apiFetch(`/api/questions/${questionId}/feedback`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
+        body: JSON.stringify({ feedback }),
       });
       if (!res.ok) {
-        console.error(
-          `[ReviewPage] updateQuestionStatus failed: ${res.status}`,
-        );
+        console.error(`[ReviewPage] recordFeedback failed: ${res.status}`);
       }
     } catch (err) {
-      console.error("Failed to update question status", err);
+      console.error("Failed to record feedback", err);
     }
   };
 
   const isNewAiQuestion = (item: ReviewItem) => {
     if (item.facet.facetType !== "AI-Generated-Question") return false;
-
-    // If we don't have a dynamic question ID yet, we can't determine.
-    // But this is called during answer evaluation, so it should be set.
-    if (!dynamicQuestionId) return false;
-
-    // If the facet has a recorded question ID that matches the current one,
-    // it means we've seen this question before... UNLESS it is flagged.
-    // If it is flagged (Undecided), we treat it as new so the user can rate it again.
-    if (
-      item.facet.currentQuestionId === dynamicQuestionId &&
-      dynamicQuestionStatus !== "flagged"
-    ) {
-      return false;
-    }
-
-    // Otherwise (no recorded ID, or different ID, or flagged), it's a new question (or needs input).
-    return true;
+    return dynamicQuestionIsNew;
   };
 
   const handleEvaluateAnswer = async (e: FormEvent) => {
@@ -387,8 +364,9 @@ export default function ReviewPage() {
           expectedAnswers,
           question,
           topic,
-          questionType, // Add questionType to the payload
-          questionId, // Add questionId to the payload
+          questionType,
+          questionId,
+          kuId: currentItem.ku.id,
         }),
       });
 
@@ -514,65 +492,20 @@ export default function ReviewPage() {
   };
 
   const handleFeedbackKeep = async () => {
-    if (pendingSrsResult) {
-      await handleUpdateSrs(pendingSrsResult);
-    }
-    // Status is already 'active' by default, so no need to patch unless we want to be explicit
-    // But let's be safe and ensure it's active if it was somehow not
-    if (dynamicQuestionId) {
-      await updateQuestionStatus(dynamicQuestionId, "active");
-
-      // Update local facet state so if it reappears, it's not "new"
-      if (currentItem) {
-        currentItem.facet.currentQuestionId = dynamicQuestionId;
-      }
-    } else {
-      console.warn(
-        "[ReviewPage] handleFeedbackKeep: No dynamicQuestionId to update",
-      );
-    }
+    if (pendingSrsResult) await handleUpdateSrs(pendingSrsResult);
+    if (dynamicQuestionId) await recordFeedback(dynamicQuestionId, "keep");
     advanceToNext();
   };
 
   const handleFeedbackRequestNew = async () => {
-    // Mark as inactive
-    if (dynamicQuestionId) {
-      await updateQuestionStatus(dynamicQuestionId, "inactive");
-    }
-    // Do NOT record SRS history (skip handleUpdateSrs)
-    // But we DO need to make sure this item stays in the queue?
-    // The requirement says: "Re-queue the review facet so it appears again later (with a fresh question)."
-    // If we just advance index, it's gone from this session (unless we re-add it?)
-    // But `reviewQueue` is static for the session usually.
-    // If we want it to appear *later*, we can just leave it alone.
-    // But we are advancing index.
-    // If we want it to appear *in this session* again, we should append it to queue?
-    // "Re-queue... so it appears again later". This could mean "next session".
-    // If we don't update SRS, `nextReviewAt` is still in the past. So it will be fetched next time.
-    // So advancing index is fine. It will just be skipped for now.
-
+    if (dynamicQuestionId) await recordFeedback(dynamicQuestionId, "request-new");
+    // Don't update SRS — facet stays due so it reappears with a fresh question next session
     advanceToNext();
   };
 
   const handleFeedbackUndecided = async () => {
-    // Mark as flagged (so it shows up again next time)
-    if (dynamicQuestionId) {
-      await updateQuestionStatus(dynamicQuestionId, "flagged");
-
-      // Update local facet state so if it reappears, it's not "new"...
-      // ACTUALLY, we want the modal to show again.
-      // But we update the facet's question ID to ensure we track usage.
-      if (currentItem) {
-        currentItem.facet.currentQuestionId = dynamicQuestionId;
-      }
-    }
-
-    // Record SRS tracking data based on the ACTUAL result (pass or fail)
-    // Just like "Keep", we respect the user's answer.
-    if (pendingSrsResult) {
-      await handleUpdateSrs(pendingSrsResult);
-    }
-
+    if (dynamicQuestionId) await recordFeedback(dynamicQuestionId, "report");
+    if (pendingSrsResult) await handleUpdateSrs(pendingSrsResult);
     advanceToNext();
   };
 

--- a/frontend/src/components/QuestionFeedbackModal.tsx
+++ b/frontend/src/components/QuestionFeedbackModal.tsx
@@ -43,9 +43,9 @@ export const QuestionFeedbackModal: React.FC<QuestionFeedbackModalProps> = ({
 
           <button
             onClick={onReport}
-            className="w-full py-3 px-4 bg-gray-600 hover:bg-gray-700 text-white font-semibold rounded-md transition-colors shadow-md flex items-center justify-center gap-2"
+            className="w-full py-3 px-4 bg-red-700 hover:bg-red-800 text-white font-semibold rounded-md transition-colors shadow-md flex items-center justify-center gap-2"
           >
-            <span>🤷 Undecided (will rate next time)</span>
+            <span>🚩 Report (bad question)</span>
           </button>
         </div>
       </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -327,6 +327,7 @@ export interface ReviewFacet {
     stage: number;
   }>;
   currentQuestionId?: string;
+  /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
   data?: any;
 }
@@ -360,8 +361,6 @@ export type LessonDifficulty =
 
 export interface QuestionItem {
   id: string;
-  /** @deprecated - migrating to User state models */
-  userId: string;
   kuId: string;
   data: {
     context?: string;
@@ -370,40 +369,26 @@ export interface QuestionItem {
     acceptedAlternatives?: string[];
     difficulty: LessonDifficulty;
   };
-  /** @deprecated - migrating to User state models */
-  status?: "active" | "flagged" | "inactive"; // Default is 'active' if undefined
+  rank: number;
+  rejectionCount: number;
   createdAt: string | Timestamp;
-  /** @deprecated - migrating to User state models */
+  /** @deprecated */
+  userId?: string;
+  /** @deprecated */
+  status?: "active" | "flagged" | "inactive";
+  /** @deprecated */
   lastUsed?: string | Timestamp;
-  /** @deprecated - migrating to User state models */
+  /** @deprecated */
   previousAnswers?: {
     answer: string;
     result: "pass" | "fail";
     timestamp: Timestamp;
   }[];
-}
-
-export interface GlobalQuestion {
-  id: string;
-  kuId: string;
-  data: {
-    context?: string;
-    question: string;
-    answer: string;
-    acceptedAlternatives?: string[];
-    difficulty: LessonDifficulty;
-  };
-  createdAt: string | Timestamp;
 }
 
 export interface UserQuestionState {
-  userId: string;
-  questionId: string; // Bridges to GlobalQuestion.id
-  status: "active" | "flagged" | "inactive";
-  lastUsed?: string | Timestamp;
-  previousAnswers?: {
-    answer: string;
-    result: "pass" | "fail";
-    timestamp: Timestamp;
-  }[];
+  questionId: string;
+  kuId: string;
+  rejected: boolean;
+  consecutiveFailures: number;
 }


### PR DESCRIPTION
 ## Summary                                                
                                                                                                                                                                           
  - Replaces the broken `AI-Generated-Question` reuse logic (which always served the same question) with a proper global question corpus and per-user state model
  - Questions are now shared across users for the same vocab item and accumulate a community-driven quality ranking over time                                              
  - Users who reject a question never see it again; the rejection is also recorded globally for future review                
                                                                                                                                                                           
  ## Data model changes                                                                                                                                                    
                                                                                                                                                                           
  **`questions/{id}` (global)**                                                                                                                                            
  - Added `rank: number` — starts at 50, range 0–100, suitable threshold is 30                                                                                             
  - Added `rejectionCount: number` — observability only, does not affect ranking
  - Removed `userId` from new documents (questions are now corpus-global)                                                                                                  
  - Deprecated `status`, `lastUsed`, `previousAnswers` (still present on old docs, ignored by new code)                                                                    
                                                                                                                                                                           
  **`users/{uid}/question-states/{questionId}` (new subcollection)**                                                                                                       
  - Wires up the existing `UserQuestionState` type                                                                                                                         
  - `rejected: boolean` — user never sees this question again                                                                                                              
  - `consecutiveFailures: number` — persists across sessions; triggers rotation at 3                                                                                       
                                                                                    
  **`ReviewFacet`**                                                                                                                                                        
  - `questionAttempts` deprecated (failure tracking moved to `UserQuestionState.consecutiveFailures`)                                                                      
                                                                                                                                                                           
  ## Ranking rules                                                                                                                                                         
                                                            
  | Event | Global rank | Per-user state |                                                                                                                                 
  |---|---|---|                                                                                                                                                            
  | Correct answer | +5 | `consecutiveFailures = 0` |
  | Wrong answer | no change | `consecutiveFailures++` |                                                                                                                   
  | Keep | +5 | — |                                                                                                                                                        
  | Request New | no change | `rejected = true`, global `rejectionCount++` |
  | Report | -25 | — |                                                                                                                                                     
                                                                                                                                                                           
  ## API changes
                                                                                                                                                                           
  - `GET /api/questions/generate` — response now returns `isNew: boolean` instead of `status`; frontend uses this to decide whether to show the feedback modal
  - `PATCH /api/questions/:id/feedback` — replaces old `PATCH /api/questions/:id`; body is `{ feedback: 'keep' | 'request-new' | 'report' }`                               
  - `POST /api/reviews/evaluate` — body now accepts optional `kuId` to support per-user question state updates                              
                                                                                                                                                                           
  ## Migration note                                                                                                                                                        
                                                                                                                                                                           
  Existing question documents lack `rank` and `rejectionCount`. They are served correctly on first use (rank defaults to 50 at read time) but fall below the suitability   
  threshold after their first correct answer or feedback write, as `FieldValue.increment` initialises from 0. A one-time backfill of `rank: 50, rejectionCount: 0` on all  
  existing `questions` documents will restore them to the corpus.     