### PR TITLE
fix: manage tab now only displays userKnowledgeUnits

### DIFF
--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -24,6 +24,9 @@ export class KnowledgeUnitsController {
         if (status === 'learning') {
             return this.userKnowledgeUnitsService.findLearningQueueAsKUs(uid);
         }
+        if (status === 'user') {
+            return this.userKnowledgeUnitsService.findAllAsKUs(uid);
+        }
         return this.knowledgeUnitsService.findAll({ status, type, content });
     }
 

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -25,11 +25,7 @@ export class UserKnowledgeUnitsService {
     return { id: doc.id, ...doc.data() } as UserKnowledgeUnit;
   }
 
-  async findLearningQueueAsKUs(uid: string): Promise<KnowledgeUnit[]> {
-    const snapshot = await this.userKusRef(uid)
-      .where('status', '==', 'learning')
-      .get();
-
+  private async _joinKUs(uid: string, snapshot: FirebaseFirestore.QuerySnapshot): Promise<KnowledgeUnit[]> {
     if (snapshot.empty) return [];
 
     const ukus = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as UserKnowledgeUnit));
@@ -56,6 +52,18 @@ export class UserKnowledgeUnitsService {
     }
 
     return result;
+  }
+
+  async findAllAsKUs(uid: string): Promise<KnowledgeUnit[]> {
+    const snapshot = await this.userKusRef(uid).get();
+    return this._joinKUs(uid, snapshot);
+  }
+
+  async findLearningQueueAsKUs(uid: string): Promise<KnowledgeUnit[]> {
+    const snapshot = await this.userKusRef(uid)
+      .where('status', '==', 'learning')
+      .get();
+    return this._joinKUs(uid, snapshot);
   }
 
   async create(uid: string, kuId: string): Promise<UserKnowledgeUnit> {

--- a/frontend/src/app/manage/page.tsx
+++ b/frontend/src/app/manage/page.tsx
@@ -57,7 +57,7 @@ export default function KnowledgeManagementPage() {
       setIsLoading(true);
 
       const [kuResponse, facetResponse] = await Promise.all([
-        apiFetch("/api/knowledge-units/get-all"),
+        apiFetch("/api/knowledge-units/get-all?status=user"),
         apiFetch("/api/reviews/facets"),
       ]);
 


### PR DESCRIPTION
## Summary

  - The Manage page was fetching `/api/knowledge-units/get-all` with no query params, which returns the entire global
   KU corpus rather than the signed-in user's units.
  - Added `UserKnowledgeUnitsService.findAllAsKUs(uid)` — fetches all documents from `users/{uid}/user-kus`
  (regardless of status) and batch-joins them against the global `knowledge-units` collection. The join logic shared
  with `findLearningQueueAsKUs` was extracted into a private `_joinKUs` helper.
  - Added a `status=user` branch in `KnowledgeUnitsController.findAll` that routes to `findAllAsKUs`.
  - Updated `manage/page.tsx` to call `/api/knowledge-units/get-all?status=user`.

  ## Files changed

  | File | Change |
  |---|---|
  | `backend/src/user-knowledge-units/user-knowledge-units.service.ts` | Added `findAllAsKUs`, extracted `_joinKUs`
  helper |
  | `backend/src/knowledge-units/knowledge-units.controller.ts` | Added `status=user` routing branch |
  | `frontend/src/app/manage/page.tsx` | Changed fetch to `?status=user` |

  ## Test plan

  - [ ] Sign in as a real user (not `user_default`)
  - [ ] Navigate to **Manage** — confirm only KUs belonging to that user are listed
  - [ ] Sign in as a second user with different KUs — confirm lists are fully isolated
  - [ ] Confirm the **Learn** tab count and queue are unaffected
  - [ ] Confirm `user_default` / admin corpus management still works via the global endpoint (no `status` param)