### PR TITLE
refactored the ku type to allow for other union ku types (grammar, etc)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,7 +271,6 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - **`ADMIN_USER_ID` constant**: `CURRENT_USER_ID` renamed to `ADMIN_USER_ID` in `backend/src/lib/constants.ts`. The string `'user_default'` remains hardcoded in `firebase-auth.guard.ts` pending a follow-up cleanup.
 - **Frontend**: `refreshStats` event dispatched after successful encounter→drill advance so the Learn tab badge updates immediately.
 
-<<<<<<< Updated upstream
 **Question corpus overhaul (2026-04)**
 
 - Replaced the broken per-facet `questionAttempts` reuse logic with a global question corpus and per-user state model.
@@ -284,14 +283,25 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - `ReviewFacet.questionAttempts` deprecated; `updateFacetQuestion` no longer resets it.
 - Frontend `review/page.tsx`: `dynamicQuestionStatus` state replaced by `dynamicQuestionIsNew`; `isNewAiQuestion` simplified; feedback handlers call `recordFeedback`.
 
----
-=======
 **Manage page scoped to user KUs (2026-04)**
 
 - **`UserKnowledgeUnitsService.findAllAsKUs(uid)`** added: returns all KUs for a user regardless of status (learning or reviewing), by fetching the full `users/{uid}/user-kus` sub-collection and batch-joining against global `knowledge-units`. The shared join logic was extracted into a private `_joinKUs` helper, which `findLearningQueueAsKUs` also now uses.
 - **`KnowledgeUnitsController` (`GET /api/knowledge-units/get-all`)**: added `status=user` branch that routes to `findAllAsKUs(uid)`.
 - **`frontend/src/app/manage/page.tsx`**: changed the KU fetch from `/api/knowledge-units/get-all` to `/api/knowledge-units/get-all?status=user` so the Manage tab displays only the authenticated user's KUs instead of the entire global corpus.
->>>>>>> Stashed changes
+
+**`KnowledgeUnit` refactored to discriminated union (2026-04)**
+
+- Replaced the monolithic `KnowledgeUnit` interface in both `backend/src/types/index.ts` and `frontend/src/types/index.ts` with a tagged union of five sub-types, each with a literal `type` discriminant and a narrowed `data` shape:
+  - `VocabKnowledgeUnit` — `data: { reading?, definition?, jlptLevel?, wanikaniLevel? }`
+  - `KanjiKnowledgeUnit` — `data: { meaning?, jlptLevel?, wanikaniLevel? }`
+  - `GrammarKnowledgeUnit`, `ConceptKnowledgeUnit`, `ExampleSentenceKnowledgeUnit` — `data: { [key: string]: any }`
+- Shared fields extracted into `KnowledgeUnitBase` (common to all sub-types, including deprecated user-state fields held in place until the migration is complete).
+- All `data` shapes retain `[key: string]: any` so existing unnarrowed access patterns (`ku.data.reading` etc.) continue to compile without changes to call sites.
+- `KnowledgeUnitClient` fixed to use a `DistributiveOmit` helper so the discriminated union is preserved through the `Omit<KnowledgeUnit, "createdAt">` operation.
+- No runtime changes — Firestore document shapes are unchanged; all backend service construction already used `as unknown as KnowledgeUnit`.
+- Switching on `ku.type` now gives correct TypeScript narrowing into the appropriate sub-type.
+
+---
 
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -186,6 +186,77 @@ export type KnowledgeUnitType =
   | "Concept"
   | "ExampleSentence";
 
+// ─── KnowledgeUnit discriminated union ───────────────────────────────────────
+
+/**
+ * Fields shared by every KU sub-type.
+ * Deprecated fields remain here until the User state migration is complete.
+ */
+export interface KnowledgeUnitBase {
+  id: string;
+  content: string; // The main "thing" (e.g., "食べる", "家族")
+  relatedUnits: string[]; // Array of other KnowledgeUnit IDs
+  /** @deprecated migrating to User state models */
+  userId: string;
+  /** @deprecated migrating to User state models */
+  personalNotes: string;
+  /** @deprecated migrating to User state models */
+  userNotes?: string;
+  /** @deprecated migrating to User state models */
+  createdAt: Timestamp;
+  /** @deprecated migrating to User state models */
+  status: "learning" | "reviewing";
+  /** @deprecated migrating to User state models */
+  facet_count: number;
+  /** @deprecated migrating to User state models */
+  history?: any[];
+}
+
+export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Vocab";
+  data: {
+    reading?: string;
+    definition?: string;
+    jlptLevel?: string | null;
+    wanikaniLevel?: number | null;
+    [key: string]: any;
+  };
+}
+
+export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Kanji";
+  data: {
+    meaning?: string;
+    jlptLevel?: string | null;
+    wanikaniLevel?: number | null;
+    [key: string]: any;
+  };
+}
+
+export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Grammar";
+  data: { [key: string]: any };
+}
+
+export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Concept";
+  data: { [key: string]: any };
+}
+
+export interface ExampleSentenceKnowledgeUnit extends KnowledgeUnitBase {
+  type: "ExampleSentence";
+  data: { [key: string]: any };
+}
+
+export type KnowledgeUnit =
+  | VocabKnowledgeUnit
+  | KanjiKnowledgeUnit
+  | GrammarKnowledgeUnit
+  | ConceptKnowledgeUnit
+  | ExampleSentenceKnowledgeUnit;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 export type PartOfSpeech =
   | "transitive-verb"
   | "intransitive-verb"
@@ -202,36 +273,6 @@ export type PartOfSpeech =
   | "suffix"
   | "conjunction";
 
-export interface KnowledgeUnit {
-  id: string;
-  /** @deprecated - migrating to User state models */
-  userId: string;
-  type: KnowledgeUnitType;
-  content: string; // The main "thing" (e.g., "食べる", "家族", "Giving/Receiving")
-  data: {
-    reading?: string;
-    definition?: string;
-    meaning?: string; // For Kanji
-    jlptLevel?: string | null;
-    wanikaniLevel?: number | null;
-    // We can add more specific fields here later
-    [key: string]: any;
-  };
-  /** @deprecated - migrating to User state models */
-  personalNotes: string;
-  /** @deprecated - migrating to User state models */
-  userNotes?: string; // Context for Gemini lesson generation
-  relatedUnits: string[]; // Array of other KnowledgeUnit IDs
-  /** @deprecated - migrating to User state models */
-  createdAt: Timestamp; // Added for sorting
-  /** @deprecated - migrating to User state models */
-  status: "learning" | "reviewing";
-  /** @deprecated - migrating to User state models */
-  facet_count: number;
-  /** @deprecated - migrating to User state models */
-  history?: any[]; // Or define a proper history type
-}
-
 export interface UserKnowledgeUnit {
   id: string;
   userId: string;
@@ -244,7 +285,10 @@ export interface UserKnowledgeUnit {
   history?: any[];
 }
 
-export type KnowledgeUnitClient = Omit<KnowledgeUnit, "createdAt"> & {
+/** Distributes Omit across union members, preserving the discriminated union. */
+type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
+export type KnowledgeUnitClient = DistributiveOmit<KnowledgeUnit, "createdAt"> & {
   createdAt: string;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -224,6 +224,77 @@ export type KnowledgeUnitType =
   | "Concept"
   | "ExampleSentence";
 
+// ─── KnowledgeUnit discriminated union ───────────────────────────────────────
+
+/**
+ * Fields shared by every KU sub-type.
+ * Deprecated fields remain here until the User state migration is complete.
+ */
+export interface KnowledgeUnitBase {
+  id: string;
+  content: string; // The main "thing" (e.g., "食べる", "家族")
+  relatedUnits: string[]; // Array of other KnowledgeUnit IDs
+  /** @deprecated migrating to User state models */
+  userId: string;
+  /** @deprecated migrating to User state models */
+  personalNotes: string;
+  /** @deprecated migrating to User state models */
+  userNotes?: string;
+  /** @deprecated migrating to User state models */
+  createdAt: Timestamp;
+  /** @deprecated migrating to User state models */
+  status: "learning" | "reviewing";
+  /** @deprecated migrating to User state models */
+  facet_count: number;
+  /** @deprecated migrating to User state models */
+  history?: any[];
+}
+
+export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Vocab";
+  data: {
+    reading?: string;
+    definition?: string;
+    jlptLevel?: string | null;
+    wanikaniLevel?: number | null;
+    [key: string]: any;
+  };
+}
+
+export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Kanji";
+  data: {
+    meaning?: string;
+    jlptLevel?: string | null;
+    wanikaniLevel?: number | null;
+    [key: string]: any;
+  };
+}
+
+export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Grammar";
+  data: { [key: string]: any };
+}
+
+export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Concept";
+  data: { [key: string]: any };
+}
+
+export interface ExampleSentenceKnowledgeUnit extends KnowledgeUnitBase {
+  type: "ExampleSentence";
+  data: { [key: string]: any };
+}
+
+export type KnowledgeUnit =
+  | VocabKnowledgeUnit
+  | KanjiKnowledgeUnit
+  | GrammarKnowledgeUnit
+  | ConceptKnowledgeUnit
+  | ExampleSentenceKnowledgeUnit;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 export type PartOfSpeech =
   | "transitive-verb"
   | "intransitive-verb"
@@ -241,36 +312,6 @@ export type PartOfSpeech =
   | "conjunction"
   | "grammar"
   | "expresssion";
-
-export interface KnowledgeUnit {
-  id: string;
-  /** @deprecated - migrating to User state models */
-  userId: string;
-  type: KnowledgeUnitType;
-  content: string; // The main "thing" (e.g., "食べる", "家族", "Giving/Receiving")
-  data: {
-    reading?: string;
-    definition?: string;
-    meaning?: string; // For Kanji
-    jlptLevel?: string | null;
-    wanikaniLevel?: number | null;
-    // We can add more specific fields here later
-    [key: string]: any;
-  };
-  /** @deprecated - migrating to User state models */
-  personalNotes: string;
-  /** @deprecated - migrating to User state models */
-  userNotes?: string;
-  relatedUnits: string[]; // Array of other KnowledgeUnit IDs
-  /** @deprecated - migrating to User state models */
-  createdAt: Timestamp; // Added for sorting
-  /** @deprecated - migrating to User state models */
-  status: "learning" | "reviewing";
-  /** @deprecated - migrating to User state models */
-  facet_count: number;
-  /** @deprecated - migrating to User state models */
-  history?: any[]; // Or define a proper history type
-}
 
 export interface GlobalKnowledgeUnit {
   id: string;
@@ -299,7 +340,10 @@ export interface UserKnowledgeUnit {
   history?: any[];
 }
 
-export type KnowledgeUnitClient = Omit<KnowledgeUnit, "createdAt"> & {
+/** Distributes Omit across union members, preserving the discriminated union. */
+type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
+export type KnowledgeUnitClient = DistributiveOmit<KnowledgeUnit, "createdAt"> & {
   createdAt: string;
 };
 


### PR DESCRIPTION
## Summary

  Refactors the monolithic `KnowledgeUnit` interface in both `backend/src/types/index.ts` and
  `frontend/src/types/index.ts` into a proper discriminated/tagged union, in preparation for adding a new KU type. No
   runtime behaviour changes.

  - Extracted shared fields into `KnowledgeUnitBase`
  - Added five typed sub-interfaces, each with a literal `type` discriminant and a narrowed `data` shape:
    - `VocabKnowledgeUnit` — `data: { reading?, definition?, jlptLevel?, wanikaniLevel? }`
    - `KanjiKnowledgeUnit` — `data: { meaning?, jlptLevel?, wanikaniLevel? }`
    - `GrammarKnowledgeUnit`, `ConceptKnowledgeUnit`, `ExampleSentenceKnowledgeUnit` — open `data` bag
  - `KnowledgeUnit` is now the union of those five sub-types
  - Added `DistributiveOmit` helper and updated `KnowledgeUnitClient` so the union is preserved through the
  `Omit<KnowledgeUnit, "createdAt">` operation
  - Also resolved a git merge conflict left in `ARCHITECTURE.md`

  ## Backward compatibility

  All `data` shapes retain `[key: string]: any`, so existing unnarrowed access patterns (`ku.data.reading`,
  `ku.data.definition`, etc.) compile without changes to any call site. Backend service construction universally uses
   `as unknown as KnowledgeUnit` and is unaffected. Firestore document shapes are unchanged.

  ## What you gain

  - `switch (ku.type)` / `if (ku.type === "Vocab")` blocks now correctly narrow into the appropriate sub-type
  - Adding a new KU type requires only: a new sub-interface + appending it to the union

  ## Files changed

  | File | Change |
  |---|---|
  | `backend/src/types/index.ts` | Replaced `KnowledgeUnit` interface with `KnowledgeUnitBase` + five sub-types +
  union; added `DistributiveOmit` |
  | `frontend/src/types/index.ts` | Same |
  | `ARCHITECTURE.md` | Added migration history entry; resolved merge conflict |

  ## Test plan

  - [ ] `yarn tsc --noEmit` passes in both `/backend` and `/frontend` with no new errors
  - [ ] Learn, Review, and Manage tabs all load and function normally
  - [ ] `ku.type` narrowing works correctly in existing `if (ku.type === "Vocab")` branches (review page, lessons
  service)