### PR TITLE
feat: implement Concepts backend and Frontend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,6 +41,7 @@ Basic Vocab data was extracted from Wanikani and then boiled down to non-proprie
   - **`review-facets`**: Logic handling the Spaced Repetition System (SRS). Converts learning queue items to review queues using `nextReviewAt` timestamp filtering.
   - **`lessons`**: Assembles Prompts, queries Gemini, and translates the structured JSON or text back to the client.
   - **`scenarios`**: Complex logic handling multi-turn roleplay conversations, evaluations, and state machines mapping encountering new phrases to learning loops.
+  - **`concepts`**: Generates and stores `ConceptKnowledgeUnit` documents (grammar concept pages) via `GeminiService.generateConcept`. Uses a dedicated `GEMINI_MODEL` env var so a higher-capability model can be used independently of the flash model used elsewhere.
   - **`stats`**: Central endpoint for aggregating dashboard/queue numbers.
 - **Database Access**: Uses `firebase-admin` natively (not via Web SDK). Note: Next.js API Routes must not use `firebase-admin`; thus, all such operations are fully isolated in this NestJS layer.
 - **Gemini**: Relies heavily on high-context, single prompt instructions using the current model (`gemini-3-flash-preview`) rather than generic `systemInstruction` prompts.
@@ -58,6 +59,46 @@ Basic Vocab data was extracted from Wanikani and then boiled down to non-proprie
 - Add JLPT badges and Wanikani level badges to the listings for each Vocab
 - Add a way to filter by JLPT level and Wanikani level
 - **Meta requirement**: The manage page should eventually be just and admin function and not a list of the Vocab the User has in their learning or review queues or in their overall user context (if we go down that route). This requires a lot of other work to be done first.
+
+### Interactive Parsing & Scoping Units
+
+**Context**: The standard `ConceptKnowledgeUnit` is optimised for atomic rule introduction (e.g., adjectival clauses). It is insufficient for teaching the dynamic skill of untangling complex, ambiguous scoping in longer sentences — e.g., identifying exactly which verb or noun an adverb like あそこで modifies.
+
+**Proposed Architecture**: Introduce a dedicated `ParsingKnowledgeUnit` designed purely for interactive reading comprehension and relationship mapping, used within scenarios.
+
+#### 1. Data Schema
+
+```typescript
+export interface ParsingKnowledgeUnit extends KnowledgeUnitBase {
+  type: "Parsing";
+  data: {
+    context: string;          // Brief situational setup
+    sentence: {
+      japanese: string;       // The complex/ambiguous sentence
+      english: string;        // Full translation
+    };
+    targetPhrase: string;     // The ambiguous modifier (e.g., "あそこで")
+    correctTarget: string;    // What it actually modifies (e.g., "読んでいる")
+    distractorTarget: string; // The plausible but wrong target (e.g., "人")
+    explanation: string;      // Diagnostic feedback explaining the boundary logic
+  };
+}
+```
+
+#### 2. UI/UX Interaction
+
+- **Presentation**: Render the Japanese sentence and visually highlight the `targetPhrase`.
+- **Interaction**: Prompt the user to identify the scoping boundary (e.g., "Tap the exact word or phrase that [targetPhrase] modifies").
+- **Feedback**: Correct selection confirms the mental model. Selecting the `distractorTarget` (or elsewhere) reveals the `explanation` diagnostic to correct the user's understanding of the sentence structure.
+
+#### 3. Generation Pipeline (Gemini)
+
+Create a new pipeline in `ConceptsService` to generate these units. Instruct the LLM to:
+- Generate Japanese sentences with intentional modifier ambiguity.
+- Explicitly isolate the `targetPhrase`, `correctTarget`, and a highly plausible `distractorTarget`.
+- Provide pedagogical explanations focused on why the syntax dictates one relationship over the other.
+
+---
 
 ### Users
 - (Done) Global KU data is stored in the `knowledge-units` collection in Firestore, accessed via the `knowledge-units` service. The service is now user-agnostic — no `userId` filtering on reads, no `userId` written to new documents.
@@ -108,7 +149,7 @@ The system is now **multi-tenant**. Real users sign in via passwordless email-li
 ### Guard Coverage
 
 Every controller applies `@UseGuards(FirebaseAuthGuard)` at the class level:
-- `auth.controller.ts`, `user.controller.ts`, `knowledge-units.controller.ts`, `reviews.controller.ts`, `lessons.controller.ts`, `questions.controller.ts`, `stats.controller.ts`, `scenarios.controller.ts`, `kanji.controller.ts`
+- `auth.controller.ts`, `user.controller.ts`, `knowledge-units.controller.ts`, `reviews.controller.ts`, `lessons.controller.ts`, `questions.controller.ts`, `stats.controller.ts`, `scenarios.controller.ts`, `kanji.controller.ts`, `concepts.controller.ts`
 
 All service methods accept `uid: string` as their first parameter and use it for Firestore scoping (see below).
 
@@ -150,13 +191,14 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 | `scenarios` | Yes (field) | Roleplay scenario state |
 | `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
 | `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
+| `concepts` | **No** | Global grammar concept corpus — no `userId` on docs; `createdBy` field for audit only |
 | `api-logs` | **No** | Centralised logging; no user field |
 
 ---
 
 ### Key Types
 
-- **`UserRoot`** (`backend/src/types/index.ts` ~line 34) — stored at `users/{uid}`. Contains `stats`, `tutorContext`, and `preferences` (e.g. `dailyMaxNew`).
+- **`UserRoot`** (`backend/src/types/index.ts` ~line 34) — stored at `users/{uid}`. Contains `stats`, `tutorContext`, and two `preferences` fields: `tutorContext.preferences` (feed tuning — `dailyMaxNew`, `dailyMaxTotal`) and a top-level `preferences` object (`showFurigana: boolean`). Top-level preferences are written via `PATCH /api/users/me/preferences` and read on the `/profile` page.
 - **`KnowledgeUnit`** (~line 205) — has `userId` field (marked `@deprecated` as part of future migration to a separate `user-kus` sub-collection). `data` bag holds `jlptLevel`, `wanikaniLevel`, `reading`, `meaning`.
 - **`UserKnowledgeUnit`** (~line 235) — intended future shape: user metadata (`status`, `personalNotes`, `facet_count`) pointing at a global KU via `kuId`. **Not yet used in queries.**
 - **`ReviewFacet`** (~line 261) — bridges to `KnowledgeUnit` via `kuId`; carries `srsStage` (0–8) and `nextReviewAt`.
@@ -172,6 +214,8 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 GOOGLE_CLOUD_PROJECT=gen-lang-client-0878434798   # Firebase project
 FIRESTORE_DB=aisrs-japanese-dev                    # Named Firestore database
 NODE_ENV                                           # 'production' enables strict auth
+MODEL_GEMINI_FLASH=gemini-3-flash-preview          # Default model used by all Gemini methods
+GEMINI_MODEL=gemini-3.1-pro-preview                # Higher-capability model used only by generateConcept
 ```
 
 **Frontend (`frontend/.env.local`)**
@@ -295,12 +339,38 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - Replaced the monolithic `KnowledgeUnit` interface in both `backend/src/types/index.ts` and `frontend/src/types/index.ts` with a tagged union of five sub-types, each with a literal `type` discriminant and a narrowed `data` shape:
   - `VocabKnowledgeUnit` — `data: { reading?, definition?, jlptLevel?, wanikaniLevel? }`
   - `KanjiKnowledgeUnit` — `data: { meaning?, jlptLevel?, wanikaniLevel? }`
-  - `GrammarKnowledgeUnit`, `ConceptKnowledgeUnit`, `ExampleSentenceKnowledgeUnit` — `data: { [key: string]: any }`
+  - `ConceptKnowledgeUnit` — fully typed `data: { title, overview, mechanics[], examples[] }` (see Concepts section)
+  - `GrammarKnowledgeUnit`, `ExampleSentenceKnowledgeUnit` — `data: { [key: string]: any }` (still open)
 - Shared fields extracted into `KnowledgeUnitBase` (common to all sub-types, including deprecated user-state fields held in place until the migration is complete).
 - All `data` shapes retain `[key: string]: any` so existing unnarrowed access patterns (`ku.data.reading` etc.) continue to compile without changes to call sites.
 - `KnowledgeUnitClient` fixed to use a `DistributiveOmit` helper so the discriminated union is preserved through the `Omit<KnowledgeUnit, "createdAt">` operation.
 - No runtime changes — Firestore document shapes are unchanged; all backend service construction already used `as unknown as KnowledgeUnit`.
 - Switching on `ku.type` now gives correct TypeScript narrowing into the appropriate sub-type.
+
+---
+
+**UI overhaul — profile, avatar, nav restructure (2026-04)**
+
+- Added `frontend/src/components/UserAvatar.tsx` — initials-based avatar circle with deterministic colour derived from email hash.
+- Added `frontend/src/components/AvatarMenu.tsx` — avatar button on the far right of the header that opens a dropdown containing Profile & Settings, Library, Manage, and Sign Out. Manage and Library links removed from the main nav row.
+- Added `frontend/src/app/profile/page.tsx` — user profile page showing avatar, email, and a Furigana toggle that persists to the backend.
+- Added `frontend/src/lib/furigana.ts` — shared `applyFurigana` / `loadFurigana` utilities (previously duplicated inline in `Header.tsx`).
+- `Header.tsx` restructured: furigana toggle removed from header bar (Alt+F shortcut retained, now also PATCHes the backend); Concepts link added between Scenarios and the avatar.
+- `UserRoot` gained a top-level `preferences?: { showFurigana?: boolean }` field in both type files. `PATCH /api/users/me/preferences` endpoint added to `UserController` / `UserService`.
+
+**Concepts system (2026-04)**
+
+- New `ConceptKnowledgeUnit` type — fully typed `data` shape replacing the previous `[key: string]: any` open bag:
+  - `title`, `overview` (≤ 2 sentences, no English grammar meta-language)
+  - `mechanics[]` — intent-driven entries with `goalTitle`, `englishIntent`, `rule`, `simpleExample` (fragment + literal translation + `highlight`), `naturalExample` (full sentence embedding the fragment + `highlight`)
+  - `examples[]` — exactly 3 practical sentences with `japanese`, `reading`, `english`, `targetGrammar`
+  - `highlight` fields use the same verbatim-substring contract as `targetGrammar` and drive bold + dotted-underline rendering in the mechanics cards.
+- `backend/src/concepts/` module added: `ConceptsService` (generate / findById / findAll), `ConceptsController` (`POST /api/concepts/generate`, `GET /api/concepts`, `GET /api/concepts/:id`), `ConceptsModule` (imports `GeminiModule`).
+- `CONCEPTS_COLLECTION = 'concepts'` added to `firebase.module.ts`.
+- `GeminiService.generateConcept` added — mirrors `generateLesson` pattern (api-log start/complete, defensive JSON extraction) but uses `this.conceptModelName` sourced from `GEMINI_MODEL` env var, falling back to `this.modelName`. Logs startup line `Using Gemini concept model: …`.
+- `frontend/src/app/concepts/[id]/page.tsx` — client component that fetches real concept data from `GET /api/concepts/:id` and renders it with two highlight helpers: `highlightGrammar` (red tint, used in Examples section) and `highlightClause` (bold + dotted underline, used in mechanics Simple/Natural examples).
+- `frontend/src/app/admin/concepts/page.tsx` — hidden admin page at `/admin/concepts` for triggering concept generation; accepts Topic and optional Detailed Notes fields that are appended to the prompt as `**Additional notes from the teacher:**`.
+- `frontend/src/app/concepts/page.tsx` — empty placeholder page for the Concepts nav link.
 
 ---
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,9 +17,10 @@ import { AudioModule } from './audio/audio.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './users/user.module';
 import { UserKnowledgeUnitsModule } from './user-knowledge-units/user-knowledge-units.module';
+import { ConceptsModule } from './concepts/concepts.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule],
+  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/concepts/concepts.controller.ts
+++ b/backend/src/concepts/concepts.controller.ts
@@ -1,0 +1,61 @@
+import { Body, Controller, Get, Logger, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
+import { ConceptsService } from './concepts.service';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+import { UserId } from '../auth/user-id.decorator';
+
+@Controller('concepts')
+@UseGuards(FirebaseAuthGuard)
+export class ConceptsController {
+  private readonly logger = new Logger(ConceptsController.name);
+
+  constructor(private readonly conceptsService: ConceptsService) {}
+
+  /**
+   * POST /api/concepts/generate
+   * Body: { topic: string }
+   *
+   * Generates a new ConceptKnowledgeUnit via Gemini and persists it to the
+   * `concepts` Firestore collection.
+   */
+  @Post('generate')
+  async generate(
+    @UserId() uid: string,
+    @Body('topic') topic: string,
+    @Body('notes') notes?: string,
+  ) {
+    this.logger.log(`POST /concepts/generate — uid=${uid} topic="${topic}" notes=${notes ? `"${notes.slice(0, 80)}…"` : 'none'}`);
+    const result = await this.conceptsService.generate(uid, topic, notes);
+    this.logger.log(`POST /concepts/generate — done, id=${result.id}`);
+    return result;
+  }
+
+  /**
+   * GET /api/concepts
+   *
+   * Returns all concept documents ordered by creation date descending.
+   */
+  @Get()
+  async findAll() {
+    this.logger.log('GET /concepts');
+    const results = await this.conceptsService.findAll();
+    this.logger.log(`GET /concepts — returned ${results.length} documents`);
+    return results;
+  }
+
+  /**
+   * GET /api/concepts/:id
+   *
+   * Returns a single concept by its Firestore document ID.
+   */
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    this.logger.log(`GET /concepts/${id}`);
+    const concept = await this.conceptsService.findById(id);
+    if (!concept) {
+      this.logger.warn(`GET /concepts/${id} — not found`);
+      throw new NotFoundException(`Concept ${id} not found`);
+    }
+    this.logger.log(`GET /concepts/${id} — found, type=${concept.type}, title="${concept.data?.title}"`);
+    return concept;
+  }
+}

--- a/backend/src/concepts/concepts.module.ts
+++ b/backend/src/concepts/concepts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConceptsService } from './concepts.service';
+import { ConceptsController } from './concepts.controller';
+import { GeminiModule } from '../gemini/gemini.module';
+
+@Module({
+  imports: [GeminiModule],
+  providers: [ConceptsService],
+  controllers: [ConceptsController],
+  exports: [ConceptsService],
+})
+export class ConceptsModule {}

--- a/backend/src/concepts/concepts.service.ts
+++ b/backend/src/concepts/concepts.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Firestore } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, CONCEPTS_COLLECTION } from '../firebase/firebase.module';
+import { GeminiService } from '../gemini/gemini.service';
+import { ConceptKnowledgeUnit } from '../types';
+
+const CONCEPT_PROMPT = (topic: string, notes?: string) => `You are a kind and thoughtful Japanese language teacher with decades of experience. Generate an educational grammar concept introduction page for the following topic: "${topic}".
+
+Write for an English-speaking learner at any level. Use Japanese text for all examples — do not include Romaji anywhere.
+
+**Content Guidelines:**
+
+1. 'overview': Define the concept strictly in terms of how Japanese works — do not reference English grammar rules, relative pronouns, or words like "who", "which", or "that". Maximum two sentences.
+
+2. 'mechanics': Break the grammar down by the learner's communicative intent, not just structural formulas. Each mechanic must contain:
+   - 'goalTitle': An action-oriented title describing what the learner wants to express (e.g., "Describe a noun using a habitual or future action").
+   - 'englishIntent': A short English example of what the learner wants to say that triggers this rule.
+   - 'rule': The exact structural rule to achieve this in Japanese.
+   - 'simpleExample': A sentence fragment showing ONLY the noun and its modifier (e.g., "待っている友達"). DO NOT make it a full sentence by adding です or だ. The 'english' translation MUST be a highly literal, structural translation (e.g., "waiting friend"). Include 'japanese', 'english', and 'highlight' (the verbatim adjectival clause substring from 'japanese' — must appear exactly as written).
+   - 'naturalExample': A complete, natural Japanese sentence that MUST directly incorporate the exact fragment generated in 'simpleExample'. Include 'japanese', 'english', and 'highlight' (the verbatim adjectival clause substring — same rule as above).
+
+3. 'examples': Provide exactly 3 practical, everyday example sentences covering the concept. No more, no less.
+
+4. 'targetGrammar': The specific Japanese substring in the example sentence that directly represents the concept. Must appear verbatim inside the 'japanese' string.
+
+**Constraints:**
+- Examples must be no more complex than JLPT N4.
+- Do not explain meta-linguistic terms (e.g. do not define what a "particle" is).
+- Do not use Romaji anywhere.
+
+**Response Schema:**
+You MUST return a valid JSON object matching this schema exactly:
+{
+  "type": "Concept",
+  "content": "<slug — lowercase, hyphens, e.g. relative-clauses>",
+  "relatedUnits": [],
+  "data": {
+    "title": "<Human-readable title>",
+    "overview": "<Two-sentence maximum introduction>",
+    "mechanics": [
+      {
+        "goalTitle": "<Action-oriented title, e.g. Describe a noun using a habitual or future action>",
+        "englishIntent": "<English example of what the learner wants to say, e.g. 'I want to say: the person who eats sushi'>",
+        "rule": "<Structural rule, e.g. [Verb (plain form)] + [Noun]>",
+        "simpleExample": {
+          "japanese": "<Minimal Japanese sentence>",
+          "english": "<English translation>",
+          "highlight": "<Verbatim adjectival clause substring from japanese>"
+        },
+        "naturalExample": {
+          "japanese": "<Natural everyday Japanese sentence>",
+          "english": "<English translation>",
+          "highlight": "<Verbatim adjectival clause substring from japanese>"
+        }
+      }
+    ],
+    "examples": [
+      {
+        "japanese": "<Full Japanese sentence>",
+        "reading": "<Full reading in hiragana/katakana, space-separated by word>",
+        "english": "<Natural English translation>",
+        "targetGrammar": "<Specific substring that represents the concept — must appear verbatim in japanese>"
+      }
+    ]
+  }
+}${notes ? `\n\n**Additional notes from the teacher:**\n${notes}` : ''}`;
+
+@Injectable()
+export class ConceptsService {
+  private readonly logger = new Logger(ConceptsService.name);
+
+  constructor(
+    @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+    private readonly geminiService: GeminiService,
+  ) { }
+
+  async generate(uid: string, topic: string, notes?: string): Promise<ConceptKnowledgeUnit & { id: string }> {
+    this.logger.log(`Generating concept for topic="${topic}" uid=${uid}`);
+
+    const prompt = CONCEPT_PROMPT(topic, notes);
+    this.logger.log(`Prompt length: ${prompt.length} chars`);
+
+    const jsonString = await this.geminiService.generateConcept(prompt, { topic });
+    this.logger.log(`Raw AI response length: ${jsonString.length} chars`);
+    this.logger.log(`Raw AI response preview: ${jsonString.slice(0, 300)}`);
+
+    let concept: ConceptKnowledgeUnit;
+    try {
+      concept = JSON.parse(jsonString) as ConceptKnowledgeUnit;
+      this.logger.log(`Parsed concept — type=${concept.type} content="${concept.content}" title="${concept.data?.title}"`);
+      this.logger.log(`Mechanics count: ${concept.data?.mechanics?.length ?? 'MISSING'}`);
+      this.logger.log(`Examples count: ${concept.data?.examples?.length ?? 'MISSING'}`);
+    } catch (e) {
+      this.logger.error('Failed to parse AI JSON response for concept', { jsonString, e });
+      throw new Error('Failed to parse AI JSON response for concept');
+    }
+
+    // Destructure id out so the Firestore document doesn't store a duplicate id field
+    // and to avoid TS2783 (spread + explicit property collision on KnowledgeUnitBase.id).
+    const { id: _id, ...conceptData } = concept;
+    this.logger.log(`Writing to Firestore collection "${CONCEPTS_COLLECTION}"`);
+    const docRef = await this.db.collection(CONCEPTS_COLLECTION).add({
+      ...conceptData,
+      createdBy: uid,
+      createdAt: new Date(),
+    });
+
+    this.logger.log(`Saved concept ${docRef.id} for topic="${topic}"`);
+    return { id: docRef.id, ...conceptData } as ConceptKnowledgeUnit & { id: string };
+  }
+
+  async findById(id: string): Promise<(ConceptKnowledgeUnit & { id: string }) | null> {
+    this.logger.log(`findById: querying concepts/${id}`);
+    const doc = await this.db.collection(CONCEPTS_COLLECTION).doc(id).get();
+    this.logger.log(`findById: doc.exists=${doc.exists}`);
+    if (!doc.exists) return null;
+    const raw = doc.data();
+    this.logger.log(`findById: raw keys=${Object.keys(raw ?? {}).join(', ')}`);
+    this.logger.log(`findById: raw.type=${raw?.type} raw.data.title=${raw?.data?.title}`);
+    return { id: doc.id, ...(raw as Omit<ConceptKnowledgeUnit, 'id'>) } as ConceptKnowledgeUnit & { id: string };
+  }
+
+  async findAll(): Promise<(ConceptKnowledgeUnit & { id: string })[]> {
+    const snapshot = await this.db
+      .collection(CONCEPTS_COLLECTION)
+      .orderBy('createdAt', 'desc')
+      .get();
+    return snapshot.docs.map(
+      doc => ({ id: doc.id, ...(doc.data() as Omit<ConceptKnowledgeUnit, 'id'>) }) as ConceptKnowledgeUnit & { id: string },
+    );
+  }
+}

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -11,6 +11,7 @@ export const API_LOGS_COLLECTION = "api-logs";
 export const QUESTIONS_COLLECTION = "questions";
 export const USER_STATS_COLLECTION = 'user-stats';
 export const SCENARIOS_COLLECTION = 'scenarios';
+export const CONCEPTS_COLLECTION = 'concepts';
 export const USER_KUS_SUBCOLLECTION = 'user-kus';
 export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
 export const Timestamp = admin.firestore.Timestamp;

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -17,6 +17,7 @@ export class GeminiService implements OnModuleInit {
 
   private client: GoogleGenAI;
   private modelName: string;
+  private conceptModelName: string;
 
   constructor(
     private configService: ConfigService,
@@ -26,7 +27,9 @@ export class GeminiService implements OnModuleInit {
   onModuleInit() {
     const apiKey = this.configService.get<string>('GEMINI_API_KEY');
     this.modelName = this.configService.get<string>('MODEL_GEMINI_FLASH') || 'gemini-3-flash-preview';
+    this.conceptModelName = this.configService.get<string>('GEMINI_MODEL') || this.modelName;
     this.logger.log(`Using Gemini model: ${this.modelName}`);
+    this.logger.log(`Using Gemini concept model: ${this.conceptModelName}`);
 
     if (!apiKey) {
       throw new Error('GEMINI_API_KEY is not defined in environment variables');
@@ -1035,6 +1038,74 @@ Output: { "clozeSentence": "その犬はとても[_____]。" }`;
         }
         await this.apilogService.completeLog(logRef, updateData).catch(e => this.logger.error(e));
       }
+    }
+  }
+
+  async generateConcept(
+    userMessage: string,
+    logContext?: Record<string, any>,
+  ): Promise<string> {
+    const initialLogData: ApiLog = {
+      timestamp: Timestamp.now(),
+      route: "/concepts/generate",
+      status: "pending",
+      modelUsed: this.conceptModelName,
+      requestData: {
+        userMessage,
+        topic: logContext?.topic,
+      },
+    };
+
+    const logRef = await this.apilogService.startLog(initialLogData);
+    const startTime = performance.now();
+    let errorOccurred = false;
+    let capturedError: any;
+    let conceptString: string | undefined;
+
+    this.logger.log(`Generating concept for topic: "${logContext?.topic ?? 'unknown'}"`);
+
+    try {
+      const apiResponse = await this.client.models.generateContent({
+        model: this.conceptModelName,
+        contents: [{ parts: [{ text: userMessage }] }],
+        config: {
+          responseMimeType: "application/json",
+          temperature: 0.5,
+        },
+      });
+
+      if (!apiResponse?.text) throw new Error("AI response was empty.");
+
+      conceptString = apiResponse.text;
+
+      const jsonStart = conceptString.indexOf("{");
+      const jsonEnd = conceptString.lastIndexOf("}");
+      if (jsonStart === -1 || jsonEnd === -1) {
+        throw new Error("AI response did not contain a valid JSON object.");
+      }
+      conceptString = conceptString.substring(jsonStart, jsonEnd + 1);
+
+      this.logger.log(`Successfully generated concept for "${logContext?.topic ?? 'unknown'}"`);
+      return conceptString;
+
+    } catch (error) {
+      errorOccurred = true;
+      capturedError = error;
+      this.logger.error("Gemini generateConcept error:", error);
+      throw new InternalServerErrorException("Failed to generate concept from AI.");
+
+    } finally {
+      const endTime = performance.now();
+      const updateData: Partial<ApiLog> = {
+        durationMs: (endTime - startTime) / 1000,
+        status: errorOccurred ? "error" : "success",
+      };
+      if (errorOccurred) {
+        updateData.errorData = { message: String(capturedError) };
+      } else {
+        updateData.responseData = { rawText: conceptString?.slice(0, 200) };
+      }
+      await this.apilogService.completeLog(logRef, updateData).catch(e => this.logger.error(e));
     }
   }
 }

--- a/backend/src/kanji/kanji.service.ts
+++ b/backend/src/kanji/kanji.service.ts
@@ -81,7 +81,7 @@ export class KanjiService {
             relatedVocab: relatedVocab.map(ku => ({
                 id: ku.id,
                 content: ku.content,
-                reading: ku.data?.reading || '',
+                reading: ku.type === 'Vocab' ? (ku.data.reading ?? '') : '',
             }))
         };
     }

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -185,8 +185,12 @@ Rules:
     let meaning: string | undefined;
     if (kuId) {
       const kuData = await this.knowledgeUnitsService.findOne(kuId);
-      reading = kuData.data?.reading;
-      meaning = kuData.data?.meaning || kuData.data?.definition;
+      if (kuData.type === 'Vocab') {
+        reading = kuData.data.reading;
+        meaning = kuData.data.definition;
+      } else if (kuData.type === 'Kanji') {
+        meaning = kuData.data.meaning;
+      }
     }
 
     let userMessage = `Topic: ${topic}`;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -245,7 +245,31 @@ export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
 
 export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
   type: "Concept";
-  data: { [key: string]: any };
+  data: {
+    title: string;
+    overview: string;
+    mechanics: Array<{
+      goalTitle: string;
+      englishIntent: string;
+      rule: string;
+      simpleExample: {
+        japanese: string;
+        english: string;
+        highlight: string;
+      };
+      naturalExample: {
+        japanese: string;
+        english: string;
+        highlight: string;
+      };
+    }>;
+    examples: Array<{
+      japanese: string;
+      reading: string;
+      english: string;
+      targetGrammar: string;
+    }>;
+  };
 }
 
 export interface ExampleSentenceKnowledgeUnit extends KnowledgeUnitBase {

--- a/frontend/src/app/admin/concepts/page.tsx
+++ b/frontend/src/app/admin/concepts/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { apiFetch } from "@/lib/api-client";
+
+export default function ConceptAdminPage() {
+  const [topic, setTopic] = useState("Relative Clauses");
+  const [notes, setNotes] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [result, setResult] = useState<{
+    success?: boolean;
+    message?: string;
+    id?: string;
+  } | null>(null);
+
+  const handleGenerate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsGenerating(true);
+    setResult(null);
+
+    const body = { topic, notes: notes.trim() || undefined };
+    console.log("[ConceptAdmin] Submitting generate request:", body);
+
+    try {
+      const response = await apiFetch("/api/concepts/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      console.log("[ConceptAdmin] Response status:", response.status, response.statusText);
+
+      const data = await response.json();
+      console.log("[ConceptAdmin] Response body:", data);
+
+      if (!response.ok) {
+        throw new Error(data.message || "Failed to generate concept");
+      }
+
+      console.log("[ConceptAdmin] Success — Firestore document ID:", data.id);
+      setResult({
+        success: true,
+        message: "Concept generated successfully!",
+        id: data.id,
+      });
+    } catch (error: unknown) {
+      console.error("[ConceptAdmin] Error:", error);
+      setResult({
+        success: false,
+        message: error instanceof Error ? error.message : "An unknown error occurred",
+      });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <main className="container mx-auto max-w-2xl px-8 py-12">
+      <p className="text-xs font-semibold uppercase tracking-widest text-shodo-accent mb-2">
+        Admin
+      </p>
+      <h1 className="text-2xl font-bold text-shodo-ink mb-8 pb-4 border-b border-shodo-ink/10">
+        Concept Generation
+      </h1>
+
+      <form onSubmit={handleGenerate} className="space-y-6">
+        <div>
+          <label
+            htmlFor="topic"
+            className="block text-sm font-medium text-shodo-ink mb-1.5"
+          >
+            Grammar Topic
+          </label>
+          <input
+            type="text"
+            id="topic"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="e.g. Relative Clauses, て-form, Causative Passive"
+            className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors"
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="notes"
+            className="block text-sm font-medium text-shodo-ink mb-1.5"
+          >
+            Detailed Notes{" "}
+            <span className="text-shodo-ink/40 font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={6}
+            placeholder="Add any specific instructions, focus areas, or constraints you want the AI to follow — e.g. 'Focus on the past-tense form only' or 'Include a mechanic for negative relative clauses'."
+            className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors resize-y font-sans text-sm leading-relaxed"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isGenerating}
+          className={`w-full py-2.5 px-4 rounded-lg text-sm font-medium text-shodo-paper transition-colors ${
+            isGenerating
+              ? "bg-shodo-ink/40 cursor-not-allowed"
+              : "bg-shodo-ink hover:bg-shodo-ink/80"
+          }`}
+        >
+          {isGenerating ? "Generating via Gemini…" : "Generate & Store Concept"}
+        </button>
+      </form>
+
+      {result && (
+        <div
+          className={`mt-8 p-4 rounded-lg border ${
+            result.success
+              ? "bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-900"
+              : "bg-red-50 border-red-200 dark:bg-red-950/20 dark:border-red-900"
+          }`}
+        >
+          <p
+            className={`text-sm ${
+              result.success ? "text-green-800 dark:text-green-300" : "text-red-800 dark:text-red-300"
+            }`}
+          >
+            {result.message}
+          </p>
+          {result.id && (
+            <p className="text-sm text-green-700 dark:text-green-400 mt-2 font-mono break-all">
+              Document ID: {result.id}
+            </p>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/concepts/[id]/page.tsx
+++ b/frontend/src/app/concepts/[id]/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { apiFetch } from "@/lib/api-client";
+import { ConceptKnowledgeUnit } from "@/types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Bold + dotted underline — distinct from the red targetGrammar highlight
+function highlightClause(text: string, target: string) {
+  if (!target) return <span>{text}</span>;
+  const parts = text.split(target);
+  if (parts.length === 1) return <span>{text}</span>;
+  return (
+    <>
+      {parts.map((part, i) => (
+        <Fragment key={i}>
+          {part}
+          {i < parts.length - 1 && (
+            <span className="font-bold underline decoration-dotted decoration-shodo-ink/60 underline-offset-2">
+              {target}
+            </span>
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+function highlightGrammar(text: string, target: string) {
+  const parts = text.split(target);
+  if (parts.length === 1) return <span>{text}</span>;
+  return (
+    <>
+      {parts.map((part, i) => (
+        <Fragment key={i}>
+          {part}
+          {i < parts.length - 1 && (
+            <mark className="bg-shodo-accent/15 text-shodo-accent rounded px-0.5 not-italic">
+              {target}
+            </mark>
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function ConceptPage() {
+  const { id } = useParams<{ id: string }>();
+  const [concept, setConcept] = useState<(ConceptKnowledgeUnit & { id: string }) | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+
+    console.log("[ConceptPage] Fetching concept id:", id);
+
+    apiFetch(`/api/concepts/${id}`)
+      .then((res) => {
+        console.log("[ConceptPage] Response status:", res.status, res.statusText);
+        if (!res.ok) throw new Error(`HTTP ${res.status} — ${res.statusText}`);
+        return res.json();
+      })
+      .then((data) => {
+        console.log("[ConceptPage] Raw response data:", data);
+        console.log("[ConceptPage] data.type:", data?.type);
+        console.log("[ConceptPage] data.data:", data?.data);
+        console.log("[ConceptPage] data.data.mechanics:", data?.data?.mechanics);
+        console.log("[ConceptPage] data.data.examples:", data?.data?.examples);
+        setConcept(data as ConceptKnowledgeUnit & { id: string });
+      })
+      .catch((err) => {
+        console.error("[ConceptPage] Fetch error:", err);
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        setLoading(false);
+        console.log("[ConceptPage] Fetch complete");
+      });
+  }, [id]);
+
+  if (loading) {
+    return (
+      <main className="container mx-auto max-w-3xl px-6 py-12">
+        <p className="text-shodo-ink/50 animate-pulse">Loading concept…</p>
+      </main>
+    );
+  }
+
+  if (error || !concept) {
+    return (
+      <main className="container mx-auto max-w-3xl px-6 py-12">
+        <p className="text-shodo-accent">
+          {error ?? "Concept not found."}
+        </p>
+      </main>
+    );
+  }
+
+  const { data } = concept;
+
+  return (
+    <main className="container mx-auto max-w-3xl px-6 py-12 space-y-14">
+
+      {/* Header */}
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-shodo-accent mb-2">
+          Grammar Concept
+        </p>
+        <h1 className="text-4xl font-bold text-shodo-ink mb-5">{data.title}</h1>
+        <p className="text-base text-shodo-ink/70 leading-relaxed">{data.overview}</p>
+      </section>
+
+      {/* Mechanics */}
+      <section>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink/40 mb-5">
+          Rules of Use
+        </h2>
+        <div className="space-y-4">
+          {data.mechanics.map((m, i) => (
+            <div
+              key={i}
+              className="border border-shodo-ink/10 rounded-xl p-5 space-y-4"
+            >
+              <div className="flex items-start gap-4">
+                <span className="text-xs font-bold text-shodo-accent mt-0.5 shrink-0 w-5 text-right">
+                  {i + 1}
+                </span>
+                <div className="space-y-3 flex-1">
+                  <p className="font-semibold text-shodo-ink">{m.goalTitle}</p>
+                  <p className="text-sm text-shodo-ink/50 italic">{m.englishIntent}</p>
+                  <code className="block bg-shodo-ink/5 text-shodo-ink/80 font-mono text-sm rounded-lg px-4 py-2">
+                    {m.rule}
+                  </code>
+                  <div className="grid grid-cols-2 gap-3 pt-1">
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase tracking-wider text-shodo-ink/30">Simple</p>
+                      <p className="text-base text-shodo-ink">{highlightClause(m.simpleExample.japanese, m.simpleExample.highlight)}</p>
+                      <p className="text-xs text-shodo-ink/50">{m.simpleExample.english}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase tracking-wider text-shodo-ink/30">Natural</p>
+                      <p className="text-base text-shodo-ink">{highlightClause(m.naturalExample.japanese, m.naturalExample.highlight)}</p>
+                      <p className="text-xs text-shodo-ink/50">{m.naturalExample.english}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Examples */}
+      <section>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink/40 mb-5">
+          Examples
+        </h2>
+        <div className="space-y-4">
+          {data.examples.map((ex, i) => (
+            <div
+              key={i}
+              className="border border-shodo-ink/10 rounded-xl px-6 py-5 space-y-2"
+            >
+              <p className="text-2xl text-shodo-ink leading-snug">
+                {highlightGrammar(ex.japanese, ex.targetGrammar)}
+              </p>
+              <p className="text-sm text-shodo-ink/45 leading-snug">
+                {ex.reading}
+              </p>
+              <p className="text-sm text-shodo-ink/65 border-t border-shodo-ink/8 pt-2 mt-2">
+                {ex.english}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+    </main>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -282,7 +282,31 @@ export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
 
 export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
   type: "Concept";
-  data: { [key: string]: any };
+  data: {
+    title: string;
+    overview: string;
+    mechanics: Array<{
+      goalTitle: string;
+      englishIntent: string;
+      rule: string;
+      simpleExample: {
+        japanese: string;
+        english: string;
+        highlight: string;
+      };
+      naturalExample: {
+        japanese: string;
+        english: string;
+        highlight: string;
+      };
+    }>;
+    examples: Array<{
+      japanese: string;
+      reading: string;
+      english: string;
+      targetGrammar: string;
+    }>;
+  };
 }
 
 export interface ExampleSentenceKnowledgeUnit extends KnowledgeUnitBase {


### PR DESCRIPTION
## Summary
                                                                                                                                                                           
  - **Profile page & avatar system**: Adds `UserAvatar` (initials + deterministic colour from email hash) and `AvatarMenu` (dropdown with Profile & Settings, Library,
  Manage, Sign Out). Header restructured — Manage and Library removed from the nav row, Concepts link added, furigana toggle removed from the bar (Alt+F shortcut kept, now
   also persists to backend). New `/profile` page with furigana toggle backed by `PATCH /api/users/me/preferences` and `UserRoot.preferences.showFurigana` in Firestore.   
                                                                                                                                                                           
  - **Concepts system**: New `ConceptKnowledgeUnit` type with a fully typed `data` shape (replaces `[key: string]: any`). Mechanics entries are intent-driven (`goalTitle`,
   `englishIntent`, `rule`, `simpleExample`, `naturalExample`) with a `highlight` field on each example that drives bold + dotted-underline rendering. Examples section    
  fixed to exactly 3 sentences with `targetGrammar` highlighting in red. Backend module (`ConceptsService` / `ConceptsController`) exposes `POST /api/concepts/generate`,
  `GET /api/concepts`, and `GET /api/concepts/:id`, all behind `FirebaseAuthGuard`. Firestore collection: `concepts`.                                                      
                                                                                                                     
  - **Dedicated concept model**: `GeminiService.generateConcept` uses `this.conceptModelName` sourced from `GEMINI_MODEL` env var (defaults to flash model if unset),
  independent of the flash model used by all other methods.                                                                                                                
                                                           
  - **Admin tooling**: Hidden page at `/admin/concepts` — accepts Topic + optional Detailed Notes, calls `POST /api/concepts/generate`, displays the resulting Firestore   
  document ID.                                                                                                                                                             
              
  - **Type housekeeping**: `ConceptKnowledgeUnit` removed from the `[key: string]: any` group in both type files. `UserRoot` gains top-level `preferences` field.          
  `questions.service.ts` and `kanji.service.ts` call sites updated to narrow on `ku.type` instead of unguarded `data` access.                                              
                                                                                                                             
  ## Test plan                                                                                                                                                             
                                                                                                                                                                           
  - [ ] Start backend — confirm log lines `Using Gemini model: …` and `Using Gemini concept model: …` both appear
  - [ ] Navigate to `/admin/concepts`, submit a topic, confirm a Firestore document ID is returned                                                                         
  - [ ] Navigate to `/concepts/<id>` — confirm real data renders with mechanics highlight (bold dotted underline) and examples highlight (red tint)
  - [ ] Toggle furigana on `/profile` — confirm toggle state persists across page reload (check `users/{uid}.preferences.showFurigana` in Firestore)                       
  - [ ] Alt+F shortcut — confirm furigana toggles and `api-logs` shows `modelUsed` for any concept generation                                                              
  - [ ] Click avatar in header — confirm dropdown shows Profile & Settings, Library, Manage, Sign Out; confirm Manage and Library no longer appear in the main nav         
  - [ ] `yarn tsc --noEmit` passes in both `/backend` and `/frontend`             