### PR TITLE
feat: first phase of concept reviews

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,9 +18,10 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './users/user.module';
 import { UserKnowledgeUnitsModule } from './user-knowledge-units/user-knowledge-units.module';
 import { ConceptsModule } from './concepts/concepts.module';
+import { UserConceptsModule } from './user-concepts/user-concepts.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule],
+  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, UserConceptsModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/concepts/concepts.controller.ts
+++ b/backend/src/concepts/concepts.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Logger, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
 import { ConceptsService } from './concepts.service';
+import { UserConceptsService } from '../user-concepts/user-concepts.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
 
@@ -8,7 +9,10 @@ import { UserId } from '../auth/user-id.decorator';
 export class ConceptsController {
   private readonly logger = new Logger(ConceptsController.name);
 
-  constructor(private readonly conceptsService: ConceptsService) {}
+  constructor(
+    private readonly conceptsService: ConceptsService,
+    private readonly userConceptsService: UserConceptsService,
+  ) {}
 
   /**
    * POST /api/concepts/generate
@@ -25,6 +29,7 @@ export class ConceptsController {
   ) {
     this.logger.log(`POST /concepts/generate — uid=${uid} topic="${topic}" notes=${notes ? `"${notes.slice(0, 80)}…"` : 'none'}`);
     const result = await this.conceptsService.generate(uid, topic, notes);
+    await this.userConceptsService.enroll(uid, result.id);
     this.logger.log(`POST /concepts/generate — done, id=${result.id}`);
     return result;
   }

--- a/backend/src/concepts/concepts.module.ts
+++ b/backend/src/concepts/concepts.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ConceptsService } from './concepts.service';
 import { ConceptsController } from './concepts.controller';
 import { GeminiModule } from '../gemini/gemini.module';
+import { UserConceptsModule } from '../user-concepts/user-concepts.module';
 
 @Module({
-  imports: [GeminiModule],
+  imports: [GeminiModule, UserConceptsModule],
   providers: [ConceptsService],
   controllers: [ConceptsController],
   exports: [ConceptsService],

--- a/backend/src/concepts/concepts.service.ts
+++ b/backend/src/concepts/concepts.service.ts
@@ -17,7 +17,11 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
    - 'englishIntent': A short English example of what the learner wants to say that triggers this rule.
    - 'rule': The exact structural rule to achieve this in Japanese.
    - 'simpleExample': A sentence fragment showing ONLY the noun and its modifier (e.g., "待っている友達"). DO NOT make it a full sentence by adding です or だ. The 'english' translation MUST be a highly literal, structural translation (e.g., "waiting friend"). Include 'japanese', 'english', and 'highlight' (the verbatim adjectival clause substring from 'japanese' — must appear exactly as written).
-   - 'naturalExample': A complete, natural Japanese sentence that MUST directly incorporate the exact fragment generated in 'simpleExample'. Include 'japanese', 'english', and 'highlight' (the verbatim adjectival clause substring — same rule as above).
+   - 'naturalExample': A complete, natural Japanese sentence that MUST directly incorporate the exact fragment generated in the 'simpleExample'. Provide the 'japanese' text, an 'english' translation, a 'fragments' array, and an 'accepted_alternatives' array.
+       * The 'fragments' array MUST split the 'japanese' sentence into 4 to 7 logical syntactic blocks (e.g., ["あそこで", "本を", "読んでいる", "人は", "私の兄です"]).
+       * ALWAYS group particles with their preceding nouns.
+       * When concatenated in order, the strings in the 'fragments' array MUST perfectly reconstruct the 'japanese' string.
+       * The 'accepted_alternatives' array MUST list every other ordering of those exact same fragments that also produces a grammatically correct Japanese sentence. Do NOT include rephrased translations or sentences using different words. If no other ordering is valid, provide an empty array.
 
 3. 'examples': Provide exactly 3 practical, everyday example sentences covering the concept. No more, no less.
 
@@ -50,7 +54,9 @@ You MUST return a valid JSON object matching this schema exactly:
         "naturalExample": {
           "japanese": "<Natural everyday Japanese sentence>",
           "english": "<English translation>",
-          "highlight": "<Verbatim adjectival clause substring from japanese>"
+          "highlight": "<Verbatim adjectival clause substring from japanese>",
+          "fragments": ["<chunk 1>", "<chunk 2>", "..."],
+          "accepted_alternatives": ["<alternative ordering 1 joined>", "..."]
         }
       }
     ],

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -13,6 +13,7 @@ export const USER_STATS_COLLECTION = 'user-stats';
 export const SCENARIOS_COLLECTION = 'scenarios';
 export const CONCEPTS_COLLECTION = 'concepts';
 export const USER_KUS_SUBCOLLECTION = 'user-kus';
+export const USER_CONCEPTS_SUBCOLLECTION = 'user-concepts';
 export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -7,7 +7,9 @@ import {
   Timestamp,
   FieldValue,
 } from '../firebase/firebase.module';
-import { ReviewFacet, QuestionItem, UserQuestionState } from '@/types';
+import { ReviewFacet, QuestionItem, UserQuestionState, ConceptKnowledgeUnit } from '@/types';
+
+type ConceptMechanic = ConceptKnowledgeUnit['data']['mechanics'][number];
 import { GeminiService } from '../gemini/gemini.service';
 import { ReviewsService } from '../reviews/reviews.service';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
@@ -142,7 +144,14 @@ export class QuestionsService {
     return null;
   }
 
-  private async generateAndSave(uid: string, topic: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
+  private async generateAndSave(uid: string, topic: string, kuId: string, facetId?: string, mechanicData?: ConceptMechanic): Promise<QuestionResponse> {
+    if (mechanicData) {
+      return this.generateConceptQuestion(uid, mechanicData, kuId, facetId);
+    }
+    return this.generateVocabQuestion(uid, topic, kuId, facetId);
+  }
+
+  private async generateVocabQuestion(uid: string, topic: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
     const questionOptions = {
       "conjugation": "if the word is a verb, conjugate the verb to a specific form e.g.: Give the past potential form of the verb in question",
       "particle": "Match up the Vocab in question with a particle to give a particular meaning in a sentence that you specify, you can represent the particle with a blank '[____]'",
@@ -184,12 +193,16 @@ Rules:
     let reading: string | undefined;
     let meaning: string | undefined;
     if (kuId) {
-      const kuData = await this.knowledgeUnitsService.findOne(kuId);
-      if (kuData.type === 'Vocab') {
-        reading = kuData.data.reading;
-        meaning = kuData.data.definition;
-      } else if (kuData.type === 'Kanji') {
-        meaning = kuData.data.meaning;
+      try {
+        const kuData = await this.knowledgeUnitsService.findOne(kuId);
+        if (kuData.type === 'Vocab') {
+          reading = kuData.data.reading;
+          meaning = kuData.data.definition;
+        } else if (kuData.type === 'Kanji') {
+          meaning = kuData.data.meaning;
+        }
+      } catch {
+        // concept IDs won't be in knowledge-units; proceed without enrichment
       }
     }
 
@@ -226,6 +239,76 @@ Rules:
 
     await ref.set(newQuestion);
     this.logger.log(`Saved new question ${ref.id} for KU ${kuId}`);
+
+    if (facetId) {
+      await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);
+    }
+
+    return this.toResponse(newQuestion, true);
+  }
+
+  private async generateConceptQuestion(uid: string, mechanic: ConceptMechanic, kuId: string, facetId?: string): Promise<QuestionResponse> {
+    const questionOptions = {
+      "applied-cloze": "Create a fill-in-the-blank question using a full sentence. The blank '[____]' MUST represent the entire grammatical structure taught in the mechanic. Provide the English translation of the sentence as context.",
+      "fragment-translation": "Ask the user to translate a short English fragment into Japanese using the specific grammatical rule. The fragment should not be a full sentence.",
+    };
+
+    const questionOptionTypes = Object.keys(questionOptions);
+    const selectedType = questionOptionTypes[Math.floor(Math.random() * questionOptionTypes.length)];
+
+    const systemPrompt = `You are an expert Japanese tutor.
+You are testing the user on a specific grammatical mechanic.
+Rule Name: ${mechanic.goalTitle}
+Structural Rule: ${mechanic.rule}
+Example Application: ${mechanic.simpleExample.japanese} (${mechanic.simpleExample.english})
+
+Your task is to generate a novel question to test this exact mechanic using this format:
+${questionOptions[selectedType as keyof typeof questionOptions]}
+
+You MUST return ONLY a valid JSON object with the following schema:
+{
+  "question": "The actual question. If fill-in-the-blank, use '[____]' exactly once.",
+  "context": "The English translation of the target sentence/fragment to guide the user.",
+  "answer": "The Japanese text that answers the question or fills the blank.",
+  "accepted_alternatives": ["Array of other valid Japanese answers"]
+}
+
+Rules:
+1. The answer MUST require the user to apply the provided Structural Rule.
+2. Do not use Romaji at all.
+3. For 'applied-cloze', the blank must encapsulate the conjugated rule (e.g., if the rule is modifying a noun, the blank should ideally be the modifier clause).
+4. Use standard, N4/N5 level vocabulary for the surrounding sentence so the user focuses strictly on the grammar mechanic.
+5. Do not add any text before or after the JSON object.`;
+
+    const questionString = await this.geminiService.generateQuestionAI('', systemPrompt, {});
+
+    if (!questionString) throw new Error('AI response was empty.');
+
+    let parsed: { question: string; answer: string; context?: string; accepted_alternatives?: string[] };
+    try {
+      parsed = JSON.parse(questionString);
+    } catch {
+      throw new Error('Failed to parse AI JSON response for concept question');
+    }
+
+    const ref = this.db.collection(QUESTIONS_COLLECTION).doc();
+    const newQuestion: QuestionItem = {
+      id: ref.id,
+      kuId,
+      data: {
+        question: parsed.question,
+        context: parsed.context,
+        answer: parsed.answer,
+        acceptedAlternatives: parsed.accepted_alternatives,
+        difficulty: 'JLPT-N4',
+      },
+      rank: 50,
+      rejectionCount: 0,
+      createdAt: Timestamp.now(),
+    };
+
+    await ref.set(newQuestion);
+    this.logger.log(`Saved new concept question ${ref.id} for KU ${kuId} (mechanic: ${mechanic.goalTitle})`);
 
     if (facetId) {
       await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -10,6 +10,7 @@ import {
     FIRESTORE_CONNECTION,
     REVIEW_FACETS_COLLECTION,
     KNOWLEDGE_UNITS_COLLECTION,
+    CONCEPTS_COLLECTION,
     USER_STATS_COLLECTION,
 } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
@@ -341,9 +342,22 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 return null; // Return null so we can filter it out in the next step
             }
 
+            // concept facets reference a concept, not a knowledge unit
+            if (facet.facetType === 'sentence-assembly' || facet.facetType === 'AI-Generated-Question') {
+                try {
+                    const conceptDoc = await this.db.collection(CONCEPTS_COLLECTION).doc(facet.kuId).get();
+                    if (!conceptDoc.exists) {
+                        this.logger.warn(`Concept ${facet.kuId} not found for facet ${facet.id}`);
+                        return null;
+                    }
+                    return { facet, ku: { id: conceptDoc.id, ...conceptDoc.data() } as KnowledgeUnit, lesson: null };
+                } catch (e) {
+                    this.logger.warn(`Failed to fetch concept for facet ${facet.id}`, e);
+                    return null;
+                }
+            }
+
             // Fetch related KU
-            // (Assuming findOne handles the 404 gracefully or returns null, 
-            // you might want to try/catch here if data integrity is loose)
             let ku: KnowledgeUnit | null = null;
             try {
                 ku = await this.knowledgeUnitsService.findOne(facet.kuId);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -261,6 +261,8 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
         japanese: string;
         english: string;
         highlight: string;
+        fragments: string[];
+        accepted_alternatives: string[];
       };
     }>;
     examples: Array<{
@@ -314,6 +316,14 @@ export interface UserKnowledgeUnit {
   history?: any[];
 }
 
+export interface UserConcept {
+  id: string;
+  userId: string;
+  conceptId: string;
+  startedAt: Timestamp;
+  lastSeenAt?: Timestamp;
+}
+
 /** Distributes Omit across union members, preserving the discriminated union. */
 type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
 
@@ -329,7 +339,8 @@ export type FacetType =
   | "Reading-to-Content"
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
   | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
-  | "audio";
+  | "audio"
+  | "sentence-assembly";
 
 export interface ReviewFacet {
   id: string;

--- a/backend/src/user-concepts/user-concepts.controller.ts
+++ b/backend/src/user-concepts/user-concepts.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Get, Logger, Param, Post, UseGuards } from '@nestjs/common';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+import { UserId } from '../auth/user-id.decorator';
+import { UserConceptsService } from './user-concepts.service';
+
+@Controller('user-concepts')
+@UseGuards(FirebaseAuthGuard)
+export class UserConceptsController {
+  private readonly logger = new Logger(UserConceptsController.name);
+
+  constructor(private readonly userConceptsService: UserConceptsService) {}
+
+  @Post()
+  async enroll(@UserId() uid: string, @Body('conceptId') conceptId: string) {
+    this.logger.log(`POST /user-concepts — uid=${uid} conceptId=${conceptId}`);
+    return this.userConceptsService.enroll(uid, conceptId);
+  }
+
+  @Get()
+  async findAll(@UserId() uid: string) {
+    this.logger.log(`GET /user-concepts — uid=${uid}`);
+    const results = await this.userConceptsService.findAllWithData(uid);
+    this.logger.log(`GET /user-concepts — returned ${results.length} entries`);
+    return results;
+  }
+
+  @Get(':conceptId/facets')
+  async getFacets(@UserId() uid: string, @Param('conceptId') conceptId: string) {
+    this.logger.log(`GET /user-concepts/${conceptId}/facets — uid=${uid}`);
+    return this.userConceptsService.getFacets(uid, conceptId);
+  }
+
+  @Post(':conceptId/facets')
+  async createFacets(
+    @UserId() uid: string,
+    @Param('conceptId') conceptId: string,
+    @Body('mechanicIndices') mechanicIndices: number[],
+    @Body('includeAiQuestion') includeAiQuestion?: boolean,
+  ) {
+    this.logger.log(`POST /user-concepts/${conceptId}/facets — uid=${uid} indices=${mechanicIndices} aiQuestion=${includeAiQuestion}`);
+    return this.userConceptsService.createFacets(uid, conceptId, mechanicIndices, includeAiQuestion);
+  }
+}

--- a/backend/src/user-concepts/user-concepts.module.ts
+++ b/backend/src/user-concepts/user-concepts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UserConceptsService } from './user-concepts.service';
+import { UserConceptsController } from './user-concepts.controller';
+
+@Module({
+  providers: [UserConceptsService],
+  controllers: [UserConceptsController],
+  exports: [UserConceptsService],
+})
+export class UserConceptsModule {}

--- a/backend/src/user-concepts/user-concepts.service.ts
+++ b/backend/src/user-concepts/user-concepts.service.ts
@@ -1,0 +1,160 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Firestore, Timestamp } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, CONCEPTS_COLLECTION, REVIEW_FACETS_COLLECTION, USER_CONCEPTS_SUBCOLLECTION } from '../firebase/firebase.module';
+import { UserConcept, ConceptKnowledgeUnit, ReviewFacet } from '../types';
+
+export type UserConceptWithData = UserConcept & {
+  concept: ConceptKnowledgeUnit & { id: string };
+};
+
+@Injectable()
+export class UserConceptsService {
+  private readonly logger = new Logger(UserConceptsService.name);
+
+  constructor(@Inject(FIRESTORE_CONNECTION) private readonly db: Firestore) {}
+
+  private userConceptsRef(uid: string) {
+    return this.db.collection('users').doc(uid).collection(USER_CONCEPTS_SUBCOLLECTION);
+  }
+
+  private facetsColRef(uid: string) {
+    return this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+  }
+
+  async enroll(uid: string, conceptId: string): Promise<UserConceptWithData> {
+    const existing = await this.userConceptsRef(uid)
+      .where('conceptId', '==', conceptId)
+      .limit(1)
+      .get();
+
+    const now = Timestamp.now();
+    let docId: string;
+
+    if (!existing.empty) {
+      docId = existing.docs[0].id;
+      await this.userConceptsRef(uid).doc(docId).update({ lastSeenAt: now });
+      this.logger.log(`Updated lastSeenAt for uid=${uid} conceptId=${conceptId}`);
+    } else {
+      const payload: Omit<UserConcept, 'id'> = {
+        userId: uid,
+        conceptId,
+        startedAt: now,
+      };
+      const ref = await this.userConceptsRef(uid).add(payload);
+      docId = ref.id;
+      this.logger.log(`Enrolled uid=${uid} in conceptId=${conceptId} userConceptId=${docId}`);
+    }
+
+    const [ucDoc, conceptDoc] = await Promise.all([
+      this.userConceptsRef(uid).doc(docId).get(),
+      this.db.collection(CONCEPTS_COLLECTION).doc(conceptId).get(),
+    ]);
+
+    const userConcept = { id: ucDoc.id, ...ucDoc.data() } as UserConcept;
+    const concept = { id: conceptDoc.id, ...conceptDoc.data() } as ConceptKnowledgeUnit & { id: string };
+
+    return { ...userConcept, concept };
+  }
+
+  async findAllWithData(uid: string): Promise<UserConceptWithData[]> {
+    const snapshot = await this.userConceptsRef(uid)
+      .orderBy('startedAt', 'desc')
+      .get();
+
+    if (snapshot.empty) return [];
+
+    const userConcepts = snapshot.docs.map(d => ({ id: d.id, ...d.data() } as UserConcept));
+
+    const conceptRefs = userConcepts.map(uc => this.db.collection(CONCEPTS_COLLECTION).doc(uc.conceptId));
+    const conceptDocs = await this.db.getAll(...conceptRefs);
+
+    const results: UserConceptWithData[] = [];
+    for (let i = 0; i < userConcepts.length; i++) {
+      const conceptDoc = conceptDocs[i];
+      if (!conceptDoc.exists) {
+        this.logger.warn(`Concept ${userConcepts[i].conceptId} not found for user-concept ${userConcepts[i].id}`);
+        continue;
+      }
+      results.push({
+        ...userConcepts[i],
+        concept: { id: conceptDoc.id, ...conceptDoc.data() } as ConceptKnowledgeUnit & { id: string },
+      });
+    }
+
+    return results;
+  }
+
+  async getFacets(uid: string, conceptId: string): Promise<ReviewFacet[]> {
+    const snapshot = await this.facetsColRef(uid)
+      .where('kuId', '==', conceptId)
+      .get();
+
+    return snapshot.docs.map(d => ({ id: d.id, ...d.data() } as ReviewFacet));
+  }
+
+  async createFacets(uid: string, conceptId: string, mechanicIndices: number[], includeAiQuestion = false): Promise<{ created: number }> {
+    const conceptDoc = await this.db.collection(CONCEPTS_COLLECTION).doc(conceptId).get();
+    if (!conceptDoc.exists) throw new Error(`Concept ${conceptId} not found`);
+
+    const concept = { id: conceptDoc.id, ...conceptDoc.data() } as ConceptKnowledgeUnit & { id: string };
+    const now = Timestamp.now();
+    const batch = this.db.batch();
+    let created = 0;
+
+    for (const idx of mechanicIndices) {
+      const mechanic = concept.data.mechanics[idx];
+      if (!mechanic) {
+        this.logger.warn(`Mechanic index ${idx} out of range for concept ${conceptId}`);
+        continue;
+      }
+
+      const ref = this.facetsColRef(uid).doc();
+      batch.set(ref, {
+        kuId: conceptId,
+        facetType: 'sentence-assembly',
+        srsStage: 0,
+        nextReviewAt: now,
+        createdAt: now,
+        history: [],
+        data: {
+          mechanicIndex: idx,
+          goalTitle: mechanic.goalTitle,
+          fragments: mechanic.naturalExample.fragments,
+          answer: mechanic.naturalExample.japanese,
+          english: mechanic.naturalExample.english,
+          accepted_alternatives: mechanic.naturalExample.accepted_alternatives ?? [],
+        },
+      });
+      created++;
+    }
+
+    if (includeAiQuestion) {
+      const ref = this.facetsColRef(uid).doc();
+      batch.set(ref, {
+        kuId: conceptId,
+        facetType: 'AI-Generated-Question',
+        srsStage: 0,
+        nextReviewAt: now,
+        createdAt: now,
+        history: [],
+        data: {},
+      });
+      created++;
+    }
+
+    await batch.commit();
+
+    await this.userConceptsRef(uid)
+      .where('conceptId', '==', conceptId)
+      .limit(1)
+      .get()
+      .then(snap => {
+        if (!snap.empty) {
+          snap.docs[0].ref.update({ facetCount: created });
+        }
+      });
+
+    this.logger.log(`Created ${created} facets for uid=${uid} conceptId=${conceptId}`);
+    return { created };
+  }
+}

--- a/frontend/src/app/concepts/[id]/page.tsx
+++ b/frontend/src/app/concepts/[id]/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { Fragment, useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { apiFetch } from "@/lib/api-client";
 import { ConceptKnowledgeUnit } from "@/types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-// Bold + dotted underline — distinct from the red targetGrammar highlight
 function highlightClause(text: string, target: string) {
   if (!target) return <span>{text}</span>;
   const parts = text.split(target);
@@ -51,38 +50,68 @@ function highlightGrammar(text: string, target: string) {
 
 export default function ConceptPage() {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
   const [concept, setConcept] = useState<(ConceptKnowledgeUnit & { id: string }) | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Facet checklist state
+  const [isEnrolled, setIsEnrolled] = useState(false);
+  const [hasFacets, setHasFacets] = useState(false);
+  const [selectedMechanics, setSelectedMechanics] = useState<Record<number, boolean>>({});
+  const [includeAiQuestion, setIncludeAiQuestion] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!id) return;
 
-    console.log("[ConceptPage] Fetching concept id:", id);
-
-    apiFetch(`/api/concepts/${id}`)
-      .then((res) => {
-        console.log("[ConceptPage] Response status:", res.status, res.statusText);
-        if (!res.ok) throw new Error(`HTTP ${res.status} — ${res.statusText}`);
-        return res.json();
+    Promise.all([
+      apiFetch(`/api/concepts/${id}`).then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }),
+      apiFetch(`/api/user-concepts`).then(r => r.json()),
+      apiFetch(`/api/user-concepts/${id}/facets`).then(r => r.json()),
+    ])
+      .then(([conceptData, userConcepts, facets]) => {
+        setConcept(conceptData as ConceptKnowledgeUnit & { id: string });
+        const enrolled = Array.isArray(userConcepts) && userConcepts.some((uc: any) => uc.conceptId === id);
+        setIsEnrolled(enrolled);
+        setHasFacets(Array.isArray(facets) && facets.length > 0);
       })
-      .then((data) => {
-        console.log("[ConceptPage] Raw response data:", data);
-        console.log("[ConceptPage] data.type:", data?.type);
-        console.log("[ConceptPage] data.data:", data?.data);
-        console.log("[ConceptPage] data.data.mechanics:", data?.data?.mechanics);
-        console.log("[ConceptPage] data.data.examples:", data?.data?.examples);
-        setConcept(data as ConceptKnowledgeUnit & { id: string });
-      })
-      .catch((err) => {
-        console.error("[ConceptPage] Fetch error:", err);
-        setError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        setLoading(false);
-        console.log("[ConceptPage] Fetch complete");
-      });
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false));
   }, [id]);
+
+  const toggleMechanic = (index: number) => {
+    setSelectedMechanics(prev => ({ ...prev, [index]: !prev[index] }));
+  };
+
+  const handleStartLearning = async () => {
+    const indices = Object.entries(selectedMechanics)
+      .filter(([, checked]) => checked)
+      .map(([i]) => Number(i));
+
+    if (indices.length === 0 && !includeAiQuestion) {
+      setSubmitError("Select at least one item.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const res = await apiFetch(`/api/user-concepts/${id}/facets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mechanicIndices: indices, includeAiQuestion }),
+      });
+      if (!res.ok) throw new Error("Failed to create learning items");
+      router.push("/review");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "An unknown error occurred.");
+      setIsSubmitting(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -95,14 +124,13 @@ export default function ConceptPage() {
   if (error || !concept) {
     return (
       <main className="container mx-auto max-w-3xl px-6 py-12">
-        <p className="text-shodo-accent">
-          {error ?? "Concept not found."}
-        </p>
+        <p className="text-shodo-accent">{error ?? "Concept not found."}</p>
       </main>
     );
   }
 
   const { data } = concept;
+  const showChecklist = isEnrolled && !hasFacets;
 
   return (
     <main className="container mx-auto max-w-3xl px-6 py-12 space-y-14">
@@ -123,10 +151,7 @@ export default function ConceptPage() {
         </h2>
         <div className="space-y-4">
           {data.mechanics.map((m, i) => (
-            <div
-              key={i}
-              className="border border-shodo-ink/10 rounded-xl p-5 space-y-4"
-            >
+            <div key={i} className="border border-shodo-ink/10 rounded-xl p-5 space-y-4">
               <div className="flex items-start gap-4">
                 <span className="text-xs font-bold text-shodo-accent mt-0.5 shrink-0 w-5 text-right">
                   {i + 1}
@@ -163,23 +188,76 @@ export default function ConceptPage() {
         </h2>
         <div className="space-y-4">
           {data.examples.map((ex, i) => (
-            <div
-              key={i}
-              className="border border-shodo-ink/10 rounded-xl px-6 py-5 space-y-2"
-            >
+            <div key={i} className="border border-shodo-ink/10 rounded-xl px-6 py-5 space-y-2">
               <p className="text-2xl text-shodo-ink leading-snug">
                 {highlightGrammar(ex.japanese, ex.targetGrammar)}
               </p>
-              <p className="text-sm text-shodo-ink/45 leading-snug">
-                {ex.reading}
-              </p>
-              <p className="text-sm text-shodo-ink/65 border-t border-shodo-ink/8 pt-2 mt-2">
-                {ex.english}
-              </p>
+              <p className="text-sm text-shodo-ink/45 leading-snug">{ex.reading}</p>
+              <p className="text-sm text-shodo-ink/65 border-t border-shodo-ink/8 pt-2 mt-2">{ex.english}</p>
             </div>
           ))}
         </div>
       </section>
+
+      {/* Choose What to Learn */}
+      {showChecklist && (
+        <section className="border border-shodo-ink/10 rounded-xl p-6 space-y-6">
+          <h2 className="text-base font-semibold text-shodo-ink">Choose What to Learn</h2>
+
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink/40">
+              Sentence Structure
+            </h3>
+            {data.mechanics.map((m, i) => (
+              <label
+                key={i}
+                className="flex items-start gap-3 p-4 border border-shodo-ink/10 rounded-lg hover:bg-shodo-ink/[0.02] cursor-pointer transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border-shodo-ink/30 text-shodo-accent focus:ring-shodo-accent/50"
+                  checked={!!selectedMechanics[i]}
+                  onChange={() => toggleMechanic(i)}
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-shodo-ink">{m.goalTitle}</p>
+                  <p className="text-sm text-shodo-ink/50 mt-0.5">{m.naturalExample.japanese}</p>
+                </div>
+              </label>
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink/40">
+              AI-Generated Questions
+            </h3>
+            <label className="flex items-start gap-3 p-4 border border-shodo-ink/10 rounded-lg hover:bg-shodo-ink/[0.02] cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                className="mt-0.5 h-4 w-4 rounded border-shodo-ink/30 text-shodo-accent focus:ring-shodo-accent/50"
+                checked={includeAiQuestion}
+                onChange={() => setIncludeAiQuestion(prev => !prev)}
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-shodo-ink">AI-Generated Questions</p>
+                <p className="text-sm text-shodo-ink/50 mt-0.5">Practice applying this concept through AI-generated quiz questions</p>
+              </div>
+            </label>
+          </div>
+
+          {submitError && <p className="text-sm text-shodo-accent">{submitError}</p>}
+
+          <button
+            onClick={handleStartLearning}
+            disabled={isSubmitting}
+            className={`w-full py-2.5 rounded-lg text-sm font-medium text-white transition-colors ${
+              isSubmitting ? "bg-blue-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"
+            }`}
+          >
+            {isSubmitting ? "Saving…" : "Start Learning Selected Items"}
+          </button>
+        </section>
+      )}
 
     </main>
   );

--- a/frontend/src/app/concepts/library/page.tsx
+++ b/frontend/src/app/concepts/library/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { Suspense, useState, useEffect } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiFetch } from "@/lib/api-client";
+import { ConceptKnowledgeUnit } from "@/types";
+
+interface CoreConceptEntry {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const CORE_CONCEPTS: CoreConceptEntry[] = [
+  {
+    id: "BGhZpwDbyM1Px57wiMxP",
+    title: "Relative Clauses",
+    description: "How to modify nouns using verb and adjective clauses in Japanese.",
+  },
+];
+
+interface UserConceptEntry {
+  id: string;
+  conceptId: string;
+  startedAt: { _seconds: number };
+  lastSeenAt?: { _seconds: number };
+  concept: ConceptKnowledgeUnit & { id: string };
+}
+
+function ConceptLibraryContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const initialTab = searchParams.get("tab") === "mine" ? "mine" : "core";
+  const [activeTab, setActiveTab] = useState<"core" | "mine">(initialTab);
+
+  useEffect(() => {
+    const tab = searchParams.get("tab") === "mine" ? "mine" : "core";
+    setActiveTab(tab);
+  }, [searchParams]);
+
+  const handleTabChange = (tab: "core" | "mine") => {
+    setActiveTab(tab);
+    const params = new URLSearchParams(searchParams.toString());
+    if (tab === "mine") {
+      params.set("tab", "mine");
+    } else {
+      params.delete("tab");
+    }
+    router.replace(`/concepts/library?${params.toString()}`);
+  };
+
+  const [myConcepts, setMyConcepts] = useState<UserConceptEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [enrollingId, setEnrollingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch("/api/user-concepts")
+      .then((res) => res.json())
+      .then((data: UserConceptEntry[]) => setMyConcepts(data))
+      .catch((err) => console.error("[ConceptLibrary] Failed to fetch:", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleLearn = async (conceptId: string) => {
+    setEnrollingId(conceptId);
+    try {
+      const res = await apiFetch("/api/user-concepts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conceptId }),
+      });
+      if (!res.ok) throw new Error("Enrollment failed");
+      router.push(`/concepts/${conceptId}`);
+    } catch (err) {
+      console.error("[ConceptLibrary] Enroll error:", err);
+      setEnrollingId(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl px-6 py-12 space-y-8">
+      <header className="flex items-center gap-4">
+        <Link
+          href="/concepts"
+          className="text-shodo-ink/30 hover:text-shodo-ink/60 transition-colors text-sm"
+        >
+          ← Back
+        </Link>
+        <div>
+          <h1 className="text-3xl font-bold text-shodo-ink">Concept Library</h1>
+          <p className="text-shodo-ink/50 mt-0.5">Browse grammar concepts and your saved entries.</p>
+        </div>
+      </header>
+
+      {/* Tabs */}
+      <div className="border-b border-shodo-ink/10">
+        <nav className="-mb-px flex gap-8">
+          <button
+            onClick={() => handleTabChange("core")}
+            className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+              activeTab === "core"
+                ? "border-shodo-accent text-shodo-accent"
+                : "border-transparent text-shodo-ink/40 hover:text-shodo-ink/70 hover:border-shodo-ink/20"
+            }`}
+          >
+            Core Library
+          </button>
+          <button
+            onClick={() => handleTabChange("mine")}
+            className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+              activeTab === "mine"
+                ? "border-shodo-accent text-shodo-accent"
+                : "border-transparent text-shodo-ink/40 hover:text-shodo-ink/70 hover:border-shodo-ink/20"
+            }`}
+          >
+            My Concepts {!loading && `(${myConcepts.length})`}
+          </button>
+        </nav>
+      </div>
+
+      {loading && activeTab === "mine" ? (
+        <p className="text-center py-20 text-shodo-ink/30 animate-pulse">Loading…</p>
+      ) : (
+        <main>
+          {activeTab === "core" && (
+            <div className="space-y-3">
+              {CORE_CONCEPTS.map((concept) => (
+                <div
+                  key={concept.id}
+                  className="border border-shodo-ink/10 rounded-xl px-6 py-5 flex flex-col md:flex-row gap-4 md:items-center justify-between hover:border-shodo-ink/20 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-shodo-ink">{concept.title}</h3>
+                    <p className="text-sm text-shodo-ink/50 mt-0.5">{concept.description}</p>
+                  </div>
+                  <button
+                    onClick={() => handleLearn(concept.id)}
+                    disabled={enrollingId === concept.id}
+                    className="shrink-0 px-4 py-2 bg-shodo-ink text-shodo-paper rounded-lg text-sm font-medium hover:bg-shodo-ink/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {enrollingId === concept.id ? "Starting…" : "Learn"}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {activeTab === "mine" && (
+            <div className="space-y-3">
+              {myConcepts.length === 0 && (
+                <p className="text-center py-10 text-shodo-ink/40">
+                  No concepts yet. Generate one from the{" "}
+                  <Link href="/concepts" className="text-shodo-accent hover:underline">
+                    dashboard
+                  </Link>{" "}
+                  or start a Core concept above.
+                </p>
+              )}
+              {myConcepts.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="border border-shodo-ink/10 rounded-xl px-6 py-5 flex flex-col md:flex-row gap-4 md:items-center justify-between hover:border-shodo-ink/20 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-shodo-ink truncate">{entry.concept.data.title}</h3>
+                    <p className="text-sm text-shodo-ink/50 mt-0.5 line-clamp-2">
+                      {entry.concept.data.overview}
+                    </p>
+                    <div className="flex gap-2 mt-2 flex-wrap">
+                      <span className="text-xs border border-shodo-ink/10 text-shodo-ink/40 px-2 py-0.5 rounded-full">
+                        {entry.concept.data.mechanics.length} mechanics
+                      </span>
+                      <span className="text-xs border border-shodo-ink/10 text-shodo-ink/40 px-2 py-0.5 rounded-full">
+                        {entry.concept.data.examples.length} examples
+                      </span>
+                    </div>
+                  </div>
+                  <Link href={`/concepts/${entry.conceptId}`} className="shrink-0">
+                    <button className="px-4 py-2 border border-shodo-ink/15 text-shodo-ink/60 rounded-lg text-sm font-medium hover:bg-shodo-ink/5 transition-colors">
+                      View
+                    </button>
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </main>
+      )}
+    </div>
+  );
+}
+
+export default function ConceptLibrary() {
+  return (
+    <Suspense fallback={<div className="text-center py-20 text-shodo-ink/30">Loading library…</div>}>
+      <ConceptLibraryContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/concepts/page.tsx
+++ b/frontend/src/app/concepts/page.tsx
@@ -1,7 +1,171 @@
-export default function ConceptsPage() {
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { apiFetch } from "@/lib/api-client";
+import { ConceptKnowledgeUnit } from "@/types";
+
+interface UserConceptEntry {
+  id: string;
+  conceptId: string;
+  startedAt: { _seconds: number };
+  lastSeenAt?: { _seconds: number };
+  concept: ConceptKnowledgeUnit & { id: string };
+}
+
+export default function ConceptsDashboard() {
+  const router = useRouter();
+
+  // Form state
+  const [topic, setTopic] = useState("");
+  const [notes, setNotes] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+
+  // Recent activity state
+  const [recentConcepts, setRecentConcepts] = useState<UserConceptEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    apiFetch("/api/user-concepts")
+      .then((res) => res.json())
+      .then((data: UserConceptEntry[]) => setRecentConcepts(data.slice(0, 8)))
+      .catch((err) => console.error("[Concepts] Failed to fetch user concepts:", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleGenerate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsGenerating(true);
+    setGenerateError(null);
+
+    try {
+      const res = await apiFetch("/api/concepts/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ topic: topic.trim(), notes: notes.trim() || undefined }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || "Generation failed");
+
+      router.push(`/concepts/${data.id}`);
+    } catch (err) {
+      setGenerateError(err instanceof Error ? err.message : "An unknown error occurred");
+      setIsGenerating(false);
+    }
+  };
+
   return (
-    <main className="container mx-auto max-w-4xl px-8 py-12">
-      <h1 className="text-2xl font-bold text-shodo-ink">Concepts</h1>
+    <main className="container mx-auto max-w-4xl px-6 py-12 space-y-10">
+
+      {/* Header */}
+      <header className="flex justify-between items-start">
+        <div>
+          <h1 className="text-3xl font-bold text-shodo-ink">Concepts</h1>
+          <p className="text-shodo-ink/50 mt-1">Grammar &amp; Structure</p>
+        </div>
+        <Link href="/concepts/library">
+          <button className="px-4 py-2 bg-shodo-ink/5 hover:bg-shodo-ink/10 text-shodo-ink/70 rounded-lg font-medium transition-colors text-sm border border-shodo-ink/10">
+            Full Library
+          </button>
+        </Link>
+      </header>
+
+      {/* Generate Form */}
+      <section className="border border-shodo-ink/10 rounded-xl p-6 space-y-5">
+        <h2 className="text-base font-semibold text-shodo-ink">Generate New Concept</h2>
+        <form onSubmit={handleGenerate} className="space-y-4">
+          <div>
+            <label htmlFor="topic" className="block text-sm font-medium text-shodo-ink mb-1.5">
+              Grammar Topic
+            </label>
+            <input
+              type="text"
+              id="topic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="e.g. Relative Clauses, て-form, Causative Passive"
+              className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="notes" className="block text-sm font-medium text-shodo-ink mb-1.5">
+              Detailed Notes{" "}
+              <span className="text-shodo-ink/40 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={4}
+              placeholder="Add any specific instructions, focus areas, or constraints — e.g. 'Focus on the past-tense form only'."
+              className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors resize-y font-sans text-sm leading-relaxed"
+            />
+          </div>
+
+          {generateError && (
+            <p className="text-sm text-shodo-accent">{generateError}</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isGenerating}
+              className={`px-6 py-2.5 rounded-lg text-sm font-medium text-shodo-paper transition-colors ${
+                isGenerating
+                  ? "bg-shodo-ink/40 cursor-not-allowed"
+                  : "bg-shodo-ink hover:bg-shodo-ink/80"
+              }`}
+            >
+              {isGenerating ? "Generating via Gemini…" : "Generate Concept"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {/* Recent Activity */}
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold text-shodo-ink">Recent Activity</h2>
+
+        {loading ? (
+          <p className="text-shodo-ink/40 animate-pulse py-6 text-center">Loading…</p>
+        ) : recentConcepts.length === 0 ? (
+          <div className="text-center py-10 border border-dashed border-shodo-ink/15 rounded-xl">
+            <p className="text-shodo-ink/40">No concepts yet.</p>
+            <p className="text-shodo-ink/30 text-sm mt-1">
+              Generate one above or browse the{" "}
+              <Link href="/concepts/library" className="text-shodo-accent hover:underline">
+                Full Library
+              </Link>
+              .
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {recentConcepts.map((entry) => (
+              <Link key={entry.id} href={`/concepts/${entry.conceptId}`} className="block group">
+                <div className="border border-shodo-ink/10 rounded-xl px-5 py-4 hover:border-shodo-ink/25 hover:bg-shodo-ink/[0.02] transition-all">
+                  <div className="flex justify-between items-start gap-4">
+                    <div className="min-w-0">
+                      <h3 className="font-semibold text-shodo-ink group-hover:text-shodo-accent transition-colors truncate">
+                        {entry.concept.data.title}
+                      </h3>
+                      <p className="text-sm text-shodo-ink/50 mt-0.5 line-clamp-1">
+                        {entry.concept.data.overview}
+                      </p>
+                    </div>
+                    <span className="text-xs text-shodo-ink/30 shrink-0 mt-0.5">Grammar</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
     </main>
   );
 }

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -481,7 +481,7 @@ export default function LearnItemPage() {
             onChange={() => handleCheckboxChange("AI-Generated-Question")}
           />
           <span className="ml-3 text-lg text-gray-900 dark:text-white">
-            AI-Generated Quiz Questions
+            AI-Generated Questions
           </span>
         </label>
       </div>
@@ -491,7 +491,7 @@ export default function LearnItemPage() {
         disabled={isSubmitting || !lesson}
         className="mt-6 w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700 disabled:bg-gray-500 disabled:cursor-wait"
       >
-        {isSubmitting ? "Saving..." : "Start Learning Selected Facets"}
+        {isSubmitting ? "Saving..." : "Start Learning Selected Items"}
       </button>
     </div>
   );

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -11,6 +11,7 @@ import EditKnowledgeUnitModal from "@/components/EditKnowledgeUnitModal";
 import { KnowledgeUnit } from "@/types";
 import { getSrsLevelName, getSrsLevelIndex } from "@/utils/srs";
 import { apiFetch } from "@/lib/api-client";
+import SentenceAssemblyCard from "@/components/review/SentenceAssemblyCard";
 
 type AnswerState = "unanswered" | "evaluating" | "correct" | "incorrect";
 
@@ -207,8 +208,11 @@ export default function ReviewPage() {
       setDynamicQuestionId(null);
       setDynamicQuestionIsNew(false);
 
+      const topic = currentItem.ku.type === 'Concept'
+        ? (currentItem.ku as import('@/types').ConceptKnowledgeUnit).data.title
+        : currentItem.ku.content;
       fetchDynamicQuestion(
-        currentItem.ku.content,
+        topic,
         currentItem.facet.id,
         currentItem.ku.id,
       );
@@ -746,7 +750,19 @@ export default function ReviewPage() {
         </div>
       )}
 
+      {/* --- Sentence Assembly --- */}
+      {currentItem.facet.facetType === "sentence-assembly" && (
+        <SentenceAssemblyCard
+          facet={currentItem.facet}
+          concept={currentItem.ku as any}
+          onResult={handleUpdateSrs}
+          onAdvance={advanceToNext}
+          onSkip={advanceToNext}
+        />
+      )}
+
       {/* --- Review Card --- */}
+      {currentItem.facet.facetType !== "sentence-assembly" && (
       <div className="bg-gray-800 shadow-2xl rounded-lg p-8">
         {/* Question Area */}
         <div className="text-center mb-8 min-h-[160px] flex flex-col justify-center">
@@ -885,8 +901,10 @@ export default function ReviewPage() {
         </form>
       </div>
 
+      )}
+
       {/* --- Answer Feedback Section --- */}
-      {answerState !== "unanswered" && answerState !== "evaluating" && (
+      {currentItem.facet.facetType !== "sentence-assembly" && answerState !== "unanswered" && answerState !== "evaluating" && (
         <div
           className={`mt-8 p-6 rounded-lg ${
             answerState === "correct"

--- a/frontend/src/components/review/SentenceAssemblyCard.tsx
+++ b/frontend/src/components/review/SentenceAssemblyCard.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
+import { ReviewFacet, ConceptKnowledgeUnit } from "@/types";
+
+interface Props {
+  facet: ReviewFacet;
+  concept: ConceptKnowledgeUnit & { id: string };
+  onResult: (result: "pass" | "fail") => Promise<void>;
+  onAdvance: () => void;
+  onSkip: () => void;
+}
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export default function SentenceAssemblyCard({ facet, concept, onResult, onAdvance, onSkip }: Props) {
+  const { goalTitle, fragments, answer, english, accepted_alternatives } = facet.data as {
+    goalTitle: string;
+    fragments: string[];
+    answer: string;
+    english: string;
+    accepted_alternatives: string[];
+  };
+
+  const [available, setAvailable] = useState<string[]>(() => shuffleArray(fragments));
+  const [assembled, setAssembled] = useState<string[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [submittedAnswer, setSubmittedAnswer] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (submitted) {
+      setTimeout(() => nextButtonRef.current?.focus(), 50);
+    }
+  }, [submitted]);
+
+  const addFragment = (idx: number) => {
+    if (submitted) return;
+    const fragment = available[idx];
+    setAvailable(prev => prev.filter((_, i) => i !== idx));
+    setAssembled(prev => [...prev, fragment]);
+  };
+
+  const removeFragment = (idx: number) => {
+    if (submitted) return;
+    const fragment = assembled[idx];
+    setAssembled(prev => prev.filter((_, i) => i !== idx));
+    setAvailable(prev => [...prev, fragment]);
+  };
+
+  const handleSubmit = async () => {
+    if (assembled.length === 0 || submitted) return;
+    setIsSubmitting(true);
+    const assembledStr = assembled.join("");
+    const correct = assembledStr === answer || (accepted_alternatives ?? []).includes(assembledStr);
+    setSubmittedAnswer(assembledStr);
+    setIsCorrect(correct);
+    await onResult(correct ? "pass" : "fail");
+    setSubmitted(true);
+    setIsSubmitting(false);
+  };
+
+  return (
+    <div className="bg-gray-800 shadow-2xl rounded-lg p-8 space-y-6">
+      {/* Header */}
+      <div className="text-center">
+        <p className="text-lg font-semibold text-blue-300 mb-1">Sentence Structure</p>
+        <p className="text-sm text-gray-400">{goalTitle}</p>
+      </div>
+
+      {/* Prompt */}
+      <div className="bg-gray-700 rounded-lg px-5 py-4 text-center">
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">Translate</p>
+        <p className="text-xl text-white font-medium">{english}</p>
+      </div>
+
+      {/* Assembly zone */}
+      <div>
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">Your answer</p>
+        <div className="min-h-[52px] flex flex-wrap gap-2 p-3 bg-gray-900 rounded-lg border-2 border-gray-600">
+          {assembled.length === 0 && (
+            <p className="text-gray-600 text-sm self-center">Click fragments below to assemble…</p>
+          )}
+          {assembled.map((fragment, i) => (
+            <button
+              key={`${fragment}-${i}`}
+              onClick={() => removeFragment(i)}
+              disabled={submitted}
+              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-base rounded-md font-medium transition-colors disabled:cursor-default"
+            >
+              {fragment}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Available fragments */}
+      <div>
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">Fragments</p>
+        <div className="flex flex-wrap gap-2">
+          {available.map((fragment, i) => (
+            <button
+              key={`${fragment}-${i}`}
+              onClick={() => addFragment(i)}
+              disabled={submitted}
+              className="px-3 py-1.5 bg-gray-600 hover:bg-gray-500 text-white text-base rounded-md font-medium transition-colors disabled:opacity-40 disabled:cursor-default"
+            >
+              {fragment}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Submit */}
+      {!submitted && (
+        <div className="flex gap-4">
+          <button
+            onClick={onSkip}
+            className="flex-1 px-6 py-3 bg-gray-500 text-white text-lg font-semibold rounded-md shadow-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-gray-800"
+          >
+            Skip
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={assembled.length === 0 || isSubmitting}
+            className="flex-1 px-6 py-3 bg-blue-600 text-white text-lg font-semibold rounded-md shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 disabled:bg-gray-800 disabled:text-gray-500"
+          >
+            {isSubmitting ? "Checking…" : "Submit"}
+          </button>
+        </div>
+      )}
+
+      {/* Feedback */}
+      {submitted && isCorrect !== null && (
+        <div className={`rounded-lg p-5 space-y-3 ${isCorrect ? "bg-green-800" : "bg-red-800"}`}>
+          <h3 className="text-xl font-semibold text-white">
+            {isCorrect ? "Correct" : "Incorrect"}
+          </h3>
+          {isCorrect ? (
+            <div className="space-y-2">
+              <p className="text-gray-200">
+                Your answer of <span className="text-white font-medium">{submittedAnswer}</span> is a correct translation of <span className="text-white font-medium">{english}</span>.
+              </p>
+              {submittedAnswer !== answer && (
+                <p className="text-green-200 text-sm">
+                  While that's acceptable, it's better to say: <span className="text-white font-medium">{answer}</span>
+                </p>
+              )}
+            </div>
+          ) : (
+            <>
+              <p className="text-gray-200">
+                <span className="font-semibold">Correct answer: </span>
+                <span className="text-white font-medium">{answer}</span>
+              </p>
+              <Link
+                href={`/concepts/${concept.id}`}
+                className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
+              >
+                Review concept: {concept.data.title}
+              </Link>
+            </>
+          )}
+          <button
+            ref={nextButtonRef}
+            onClick={onAdvance}
+            className="w-full px-6 py-3 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -298,6 +298,8 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
         japanese: string;
         english: string;
         highlight: string;
+        fragments: string[];
+        accepted_alternatives: string[];
       };
     }>;
     examples: Array<{
@@ -383,7 +385,8 @@ export type FacetType =
   | "Reading-to-Content"
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
   | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
-  | "audio";
+  | "audio"
+  | "sentence-assembly";
 
 export interface ReviewFacet {
   id: string;


### PR DESCRIPTION
## Sentence-assembly review facets                           
                                                                                                                                                                           
  - Added accepted_alternatives: string[] to ConceptKnowledgeUnit.data.mechanics[].naturalExample in both frontend and backend types.                                      
  - Updated the Gemini concept prompt to instruct the model to enumerate all valid reorderings of the generated fragments (not free rephrasing) as accepted_alternatives.  
  - SentenceAssemblyCard evaluation now checks assembledStr === answer || accepted_alternatives.includes(assembledStr).                                                    
  - Correct feedback wording: "Your answer of X is a correct translation of Y." with a secondary note if the user gave an accepted alternative rather than the canonical   
  answer.                                                                                                                                                                  
  - Added onSkip prop to SentenceAssemblyCard; Skip button appears to the left of Submit, styled identically to all other review card Skip buttons.                        
                                                                                                                                                                           
 ##  "AI-Generated Questions" in Choose What to Learn                                                                                                                         
                                                                                                                                                                           
  - Added a second subsection to the concepts/[id]/page.tsx checklist: AI-Generated Questions with a single checkbox.                                                      
  - POST /api/user-concepts/:conceptId/facets now accepts includeAiQuestion?: boolean; when true, a bare AI-Generated-Question facet is batch-created alongside any
  sentence-assembly facets.                                                                                                                                                
  - getFacets broadened to return all facet types for a concept (previously only sentence-assembly) — fixes hasFacets check so the checklist correctly hides once any
  facets exist.                                                                                                                                                            
  - ReviewsService.getDueReviews extended to route AI-Generated-Question facets (in addition to sentence-assembly) to the concepts Firestore collection instead of
  knowledge-units — fixes the "Orphaned facet: KU not found" warning.                                                                                                      
  - QuestionsService.generateVocabQuestion wraps knowledgeUnitsService.findOne in try/catch so concept IDs don't crash question generation.
  - review/page.tsx now uses ku.data.title (e.g. "Relative Clauses") as the AI question topic for Concept-type KUs instead of the slug in ku.content.                      
                                                                                                                                                                           
 ## Minor                                                                                                                                                                    
                                                                                                                                                                           
  - learn/[kuId]/page.tsx: label updated from "AI-Generated Quiz Questions" → "AI-Generated Questions".                                                                    
  - GitHub issue https://github.com/tekgrrl/aisrs-japanese/issues/130 filed: unify KU collection routing to eliminate per-facet-type conditionals in ReviewsService and
  QuestionsService.      