### PR TITLE
feat: finalized concept review facets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -328,6 +328,16 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - Frontend `review/page.tsx`: `dynamicQuestionStatus` state replaced by `dynamicQuestionIsNew`; `isNewAiQuestion` simplified; feedback handlers call `recordFeedback`.
 
 ---
+
+**`sentence-cloze` facet type (2026-04)**
+
+- Added `"sentence-cloze"` to `FacetType` in both `backend/src/types/index.ts` and `frontend/src/types/index.ts`.
+- New `frontend/src/components/review/SentenceClozeCard.tsx` — typed fill-in-the-blank card. Renders the sentence with `[____]` replaced by a styled inline blank; wanakana IME input; strict match evaluation against `back.answer` and `back.accepted_alternatives`; reveals `back.fullSentence` on submit.
+- Facet `data` shape: `front: { sentenceWithBlank: string, hint: string }`, `back: { answer: string, fullSentence: string, accepted_alternatives?: string[] }`, `goalTitle?: string`.
+- `review/page.tsx` updated: renders `SentenceClozeCard` for `sentence-cloze` facets; excluded from the standard review-card form and answer-feedback section.
+- Generation (how/when `sentence-cloze` facets are created) is deferred — not yet wired into `UserConceptsService.createFacets`.
+
+---
 **Manage page scoped to user KUs (2026-04)**
 
 - **`UserKnowledgeUnitsService.findAllAsKUs(uid)`** added: returns all KUs for a user regardless of status (learning or reviewing), by fetching the full `users/{uid}/user-kus` sub-collection and batch-joining against global `knowledge-units`. The shared join logic was extracted into a private `_joinKUs` helper, which `findLearningQueueAsKUs` also now uses.

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -249,8 +249,8 @@ Rules:
 
   private async generateConceptQuestion(uid: string, mechanic: ConceptMechanic, kuId: string, facetId?: string): Promise<QuestionResponse> {
     const questionOptions = {
-      "applied-cloze": "Create a fill-in-the-blank question using a full sentence. The blank '[____]' MUST represent the entire grammatical structure taught in the mechanic. Provide the English translation of the sentence as context.",
-      "fragment-translation": "Ask the user to translate a short English fragment into Japanese using the specific grammatical rule. The fragment should not be a full sentence.",
+      "error-correction": "Present a complete Japanese sentence that attempts to use the grammatical rule but contains a specific syntax, particle, or conjugation error related to that rule. Ask the user to correct the error and provide the fully corrected Japanese sentence. Provide the intended English meaning as context.",
+      "novel-translation": "Create a completely new English sentence that naturally forces the use of the grammatical rule. Ask the user to translate it into Japanese. Ensure the vocabulary used is very simple (JLPT N5 level) so the user is only challenged by the grammar structure, not the vocabulary.",
     };
 
     const questionOptionTypes = Object.keys(questionOptions);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -340,7 +340,8 @@ export type FacetType =
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
   | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
   | "audio"
-  | "sentence-assembly";
+  | "sentence-assembly"
+  | "sentence-cloze";
 
 export interface ReviewFacet {
   id: string;

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -12,6 +12,7 @@ import { KnowledgeUnit } from "@/types";
 import { getSrsLevelName, getSrsLevelIndex } from "@/utils/srs";
 import { apiFetch } from "@/lib/api-client";
 import SentenceAssemblyCard from "@/components/review/SentenceAssemblyCard";
+import SentenceClozeCard from "@/components/review/SentenceClozeCard";
 
 type AnswerState = "unanswered" | "evaluating" | "correct" | "incorrect";
 
@@ -761,8 +762,18 @@ export default function ReviewPage() {
         />
       )}
 
+      {/* --- Sentence Cloze --- */}
+      {currentItem.facet.facetType === "sentence-cloze" && (
+        <SentenceClozeCard
+          facet={currentItem.facet}
+          onResult={handleUpdateSrs}
+          onAdvance={advanceToNext}
+          onSkip={advanceToNext}
+        />
+      )}
+
       {/* --- Review Card --- */}
-      {currentItem.facet.facetType !== "sentence-assembly" && (
+      {currentItem.facet.facetType !== "sentence-assembly" && currentItem.facet.facetType !== "sentence-cloze" && (
       <div className="bg-gray-800 shadow-2xl rounded-lg p-8">
         {/* Question Area */}
         <div className="text-center mb-8 min-h-[160px] flex flex-col justify-center">
@@ -904,7 +915,7 @@ export default function ReviewPage() {
       )}
 
       {/* --- Answer Feedback Section --- */}
-      {currentItem.facet.facetType !== "sentence-assembly" && answerState !== "unanswered" && answerState !== "evaluating" && (
+      {currentItem.facet.facetType !== "sentence-assembly" && currentItem.facet.facetType !== "sentence-cloze" && answerState !== "unanswered" && answerState !== "evaluating" && (
         <div
           className={`mt-8 p-6 rounded-lg ${
             answerState === "correct"

--- a/frontend/src/components/review/SentenceClozeCard.tsx
+++ b/frontend/src/components/review/SentenceClozeCard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState, useRef, useEffect, FormEvent } from "react";
+import * as wanakana from "wanakana";
+import { ReviewFacet } from "@/types";
+
+interface ClozeData {
+  front: {
+    sentenceWithBlank: string;
+    hint: string;
+  };
+  back: {
+    answer: string;
+    fullSentence: string;
+    accepted_alternatives?: string[];
+  };
+  goalTitle?: string;
+}
+
+interface Props {
+  facet: ReviewFacet;
+  onResult: (result: "pass" | "fail") => Promise<void>;
+  onAdvance: () => void;
+  onSkip: () => void;
+}
+
+export default function SentenceClozeCard({ facet, onResult, onAdvance, onSkip }: Props) {
+  const { front, back, goalTitle } = facet.data as ClozeData;
+
+  const [userAnswer, setUserAnswer] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (submitted) {
+      setTimeout(() => nextButtonRef.current?.focus(), 50);
+    }
+  }, [submitted]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (submitted || isSubmitting) return;
+    setIsSubmitting(true);
+
+    const trimmed = userAnswer.trim();
+    const allAnswers = [back.answer, ...(back.accepted_alternatives ?? [])];
+    const correct = allAnswers.some(a => a.trim() === trimmed);
+
+    setIsCorrect(correct);
+    await onResult(correct ? "pass" : "fail");
+    setSubmitted(true);
+    setIsSubmitting(false);
+  };
+
+  const renderSentenceWithBlank = (sentence: string) => {
+    const parts = sentence.split("[____]");
+    if (parts.length === 1) return <span>{sentence}</span>;
+    return (
+      <>
+        {parts[0]}
+        <span className="inline-block border-b-2 border-blue-400 text-blue-400 px-1 mx-0.5 min-w-[4rem] text-center">
+          {submitted ? back.answer : "＿＿＿"}
+        </span>
+        {parts[1]}
+      </>
+    );
+  };
+
+  return (
+    <div className="bg-gray-800 shadow-2xl rounded-lg p-8 space-y-6">
+      <div className="text-center">
+        <p className="text-lg font-semibold text-blue-300 mb-1">Fill in the Blank</p>
+        {goalTitle && <p className="text-sm text-gray-400">{goalTitle}</p>}
+      </div>
+
+      <div className="bg-gray-700 rounded-lg px-5 py-4 text-center space-y-2">
+        <p className="text-2xl text-white font-medium leading-relaxed">
+          {renderSentenceWithBlank(front.sentenceWithBlank)}
+        </p>
+        <p className="text-sm text-gray-400 italic">{front.hint}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          key={facet.id}
+          type="text"
+          value={userAnswer}
+          autoFocus
+          onChange={e => setUserAnswer(wanakana.toKana(e.target.value, { IMEMode: true }))}
+          placeholder="回答を入力して..."
+          disabled={submitted}
+          className="w-full p-4 bg-gray-700 border-2 border-gray-600 text-white text-xl rounded-md focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-800 disabled:text-gray-500"
+        />
+
+        {!submitted && (
+          <div className="flex gap-4">
+            <button
+              type="button"
+              onClick={onSkip}
+              className="flex-1 px-6 py-3 bg-gray-500 text-white text-lg font-semibold rounded-md hover:bg-gray-600"
+            >
+              Skip
+            </button>
+            <button
+              type="submit"
+              disabled={userAnswer.trim() === "" || isSubmitting}
+              className="flex-1 px-6 py-3 bg-blue-600 text-white text-lg font-semibold rounded-md hover:bg-blue-700 disabled:bg-gray-800 disabled:text-gray-500"
+            >
+              {isSubmitting ? "Checking…" : "Submit"}
+            </button>
+          </div>
+        )}
+      </form>
+
+      {submitted && isCorrect !== null && (
+        <div className={`rounded-lg p-5 space-y-3 ${isCorrect ? "bg-green-800" : "bg-red-800"}`}>
+          <h3 className="text-xl font-semibold text-white">
+            {isCorrect ? "Correct" : "Incorrect"}
+          </h3>
+          {!isCorrect && (
+            <p className="text-gray-200">
+              <span className="font-semibold">Answer: </span>
+              <span className="text-white font-medium">{back.answer}</span>
+            </p>
+          )}
+          <p className="text-gray-200">
+            <span className="font-semibold">Full sentence: </span>
+            <span className="text-white font-medium">{back.fullSentence}</span>
+          </p>
+          <button
+            ref={nextButtonRef}
+            onClick={onAdvance}
+            className="w-full px-6 py-3 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -386,7 +386,8 @@ export type FacetType =
   | "Kanji-Component-Meaning" // e.g., "食" -> "eat"
   | "Kanji-Component-Reading" // e.g., "食" -> "ショク"
   | "audio"
-  | "sentence-assembly";
+  | "sentence-assembly"
+  | "sentence-cloze";
 
 export interface ReviewFacet {
   id: string;


### PR DESCRIPTION
 ## Summary                                                                                                                                        
                                                                                                                                                    
  - Add `"sentence-cloze"` to `FacetType` in both `backend/src/types/index.ts` and `frontend/src/types/index.ts`                                    
  - New `SentenceClozeCard.tsx` component: renders a Japanese sentence with an inline `[____]` blank, accepts typed Japanese input (wanakana IME),  
  evaluates against `back.answer` + `back.accepted_alternatives`, and reveals the full sentence on submit                                         
  - Wire `sentence-cloze` into `review/page.tsx` alongside the existing `sentence-assembly` branch; excluded from the standard form and             
  answer-feedback sections                                                                                                             
                                                                                                                                                    
  ## Data shape                                             
                                                                                                                                                    
  ```ts                                                     
  facet.data = {                                                                                                                                    
    front: { sentenceWithBlank: string; hint: string };     
    back:  { answer: string; fullSentence: string; accepted_alternatives?: string[] };
    goalTitle?: string;
  }                                                                                                                                                 
   
  Not included                                                                                                                                      
                                                            
  Facet generation (wiring into UserConceptsService.createFacets) is deferred to a follow-up.                                                       
   
  Test plan                                                                                                                                         
                                                            
  - Manually create a sentence-cloze facet document in Firestore and confirm it renders correctly in /review                                        
  - Correct answer (exact match and accepted alternative) advances with green feedback
  - Wrong answer shows red feedback with correct answer and full sentence                                                                           
  - Skip advances without SRS update                                                                                                                
  - Existing sentence-assembly, AI-Generated-Question, and standard facets unaffected             