### PR TITLE
feat: add sentence assemblies to scenarios

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -338,6 +338,19 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - Generation (how/when `sentence-cloze` facets are created) is deferred — not yet wired into `UserConceptsService.createFacets`.
 
 ---
+
+**Grammar types + scenario sentence-assembly facets (2026-04-21)**
+
+- **`GrammarKnowledgeUnit.data`** fully typed in both type files: `{ title: string, explanation: string, exampleInContext: { japanese: string, english: string, fragments: string[], accepted_alternatives: string[] } }`.
+- **`GrammarNote`** (both `backend/src/types/scenario.ts` and `frontend/src/types/scenario.ts`) updated to match: `exampleInContext` changed from a flat string to the same structured object.
+- **Gemini scenario prompt** (`buildArchitectPrompt`): `grammarNotes` output schema updated to return the structured `exampleInContext` object. Fragment rules added: minimal grammatical chunks, joined in order must reproduce the `japanese` field exactly, no romaji.
+- **`ScenariosService.advanceState`** encounter→drill: after linking vocab KUs, now batch-creates one `sentence-assembly` facet per grammar note into `users/{uid}/review-facets`. Facet `kuId = scenario.id`; `data` shape matches the existing `SentenceAssemblyCard` contract (`goalTitle`, `fragments`, `answer`, `english`, `accepted_alternatives`).
+- **`SentenceAssemblyCard`**: `concept` prop made optional; "Review concept" link is conditionally rendered. `review/page.tsx` passes `concept` only when `ku.type === 'Concept'`.
+- **`scenarios/[id]/page.tsx`**: grammar notes section updated to render `note.exampleInContext.japanese` and `note.exampleInContext.english`.
+- Deleted orphaned `scenario-templates` Firestore collection (written by `migrate-v2-architecture.ts` but never read by the app).
+- Issue #133 filed: migrate `scenarios` top-level collection to `users/{uid}/scenarios` sub-collection.
+
+---
 **Manage page scoped to user KUs (2026-04)**
 
 - **`UserKnowledgeUnitsService.findAllAsKUs(uid)`** added: returns all KUs for a user regardless of status (learning or reviewing), by fetching the full `users/{uid}/user-kus` sub-collection and batch-joining against global `knowledge-units`. The shared join logic was extracted into a private `_joinKUs` helper, which `findLearningQueueAsKUs` also now uses.

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -9,7 +9,7 @@ import { Firestore, CollectionReference, Timestamp, FieldValue } from 'firebase-
 import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt } from '../types/scenario';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
-import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION } from '../firebase/firebase.module';
+import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
 import { GeminiService } from '../gemini/gemini.service';
 
 // Centralized Role Definitions to ensure Prompt and Heuristic are always in sync
@@ -170,6 +170,35 @@ export class ScenariosService {
           }
 
           updateData.extractedKUs = updatedKUs;
+        }
+
+        // Create sentence-assembly facets for each grammar note
+        if (scenario.grammarNotes && scenario.grammarNotes.length > 0) {
+          const facetsRef = this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+          const facetBatch = this.db.batch();
+          const now = Timestamp.now();
+
+          for (const note of scenario.grammarNotes) {
+            const ref = facetsRef.doc();
+            facetBatch.set(ref, {
+              kuId: scenario.id,
+              facetType: 'sentence-assembly',
+              srsStage: 0,
+              nextReviewAt: now,
+              createdAt: now,
+              history: [],
+              data: {
+                goalTitle: note.title,
+                fragments: note.exampleInContext.fragments,
+                answer: note.exampleInContext.japanese,
+                english: note.exampleInContext.english,
+                accepted_alternatives: note.exampleInContext.accepted_alternatives ?? [],
+              },
+            });
+          }
+
+          await facetBatch.commit();
+          this.logger.log(`Created ${scenario.grammarNotes.length} sentence-assembly facets for uid=${uid} scenarioId=${scenario.id}`);
         }
 
         newState = 'drill';
@@ -413,9 +442,25 @@ Create a "Genki-style" learning scenario for an ADULT traveler/expat (not a stud
     }
   ],
   "grammarNotes": [
-    { "title": "Grammar Point Name", "explanation": "Clear explanation", "exampleInContext": "Example from dialogue" }
+    {
+      "title": "Grammar Point Name",
+      "explanation": "Clear explanation",
+      "exampleInContext": {
+        "japanese": "The example sentence in Japanese only, no furigana or Romaji",
+        "english": "The English translation of the example",
+        "fragments": ["minimal", "meaningful", "chunks", "of", "the", "sentence"],
+        "accepted_alternatives": ["array of valid re-orderings or omittable-particle variants, or empty array"]
+      }
+    }
   ]
 }
+
+**Grammar Note Fragments Rules:**
+- \`fragments\` MUST be an array of minimal grammatical chunks that together reconstruct the full \`japanese\` sentence when joined with no spaces.
+- Each fragment should be the smallest meaningful unit — split at particle boundaries, verb endings, and conjunctions (e.g., ["あれ", "は", "いくら", "です", "か"] for "あれはいくらですか").
+- NEVER include Romaji or furigana in fragments.
+- \`accepted_alternatives\` should list any valid alternative orderings of the same sentence, or be an empty array if none exist.
+- Joining all fragments in order MUST exactly reproduce the \`japanese\` field.
 `;
   }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -240,7 +240,16 @@ export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
 
 export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
   type: "Grammar";
-  data: { [key: string]: any };
+  data: {
+    title: string;
+    explanation: string;
+    exampleInContext: {
+      japanese: string;
+      english: string;
+      fragments: string[];
+      accepted_alternatives: string[];
+    };
+  };
 }
 
 export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -31,7 +31,12 @@ export interface ExtractedKU {
 export interface GrammarNote {
     title: string;
     explanation: string;
-    exampleInContext: string;
+    exampleInContext: {
+        japanese: string;
+        english: string;
+        fragments: string[];
+        accepted_alternatives: string[];
+    };
 }
 
 export interface ScenarioEvaluation {

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -755,7 +755,7 @@ export default function ReviewPage() {
       {currentItem.facet.facetType === "sentence-assembly" && (
         <SentenceAssemblyCard
           facet={currentItem.facet}
-          concept={currentItem.ku as any}
+          concept={currentItem.ku.type === 'Concept' ? currentItem.ku as import('@/types').ConceptKnowledgeUnit & { id: string } : undefined}
           onResult={handleUpdateSrs}
           onAdvance={advanceToNext}
           onSkip={advanceToNext}

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -735,7 +735,8 @@ export default function ScenarioPage({
                       {note.explanation}
                     </p>
                     <div className="bg-white/60 p-2 rounded text-amber-900 text-sm font-mono">
-                      {note.exampleInContext}
+                      <span className="font-medium">{note.exampleInContext.japanese}</span>
+                      <span className="ml-2 text-amber-700 font-sans font-normal">({note.exampleInContext.english})</span>
                     </div>
                   </div>
                 ))}

--- a/frontend/src/components/review/SentenceAssemblyCard.tsx
+++ b/frontend/src/components/review/SentenceAssemblyCard.tsx
@@ -6,7 +6,7 @@ import { ReviewFacet, ConceptKnowledgeUnit } from "@/types";
 
 interface Props {
   facet: ReviewFacet;
-  concept: ConceptKnowledgeUnit & { id: string };
+  concept?: ConceptKnowledgeUnit & { id: string };
   onResult: (result: "pass" | "fail") => Promise<void>;
   onAdvance: () => void;
   onSkip: () => void;
@@ -163,12 +163,14 @@ export default function SentenceAssemblyCard({ facet, concept, onResult, onAdvan
                 <span className="font-semibold">Correct answer: </span>
                 <span className="text-white font-medium">{answer}</span>
               </p>
-              <Link
-                href={`/concepts/${concept.id}`}
-                className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
-              >
-                Review concept: {concept.data.title}
-              </Link>
+              {concept && (
+                <Link
+                  href={`/concepts/${concept.id}`}
+                  className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
+                >
+                  Review concept: {concept.data.title}
+                </Link>
+              )}
             </>
           )}
           <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -277,7 +277,16 @@ export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
 
 export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
   type: "Grammar";
-  data: { [key: string]: any };
+  data: {
+    title: string;
+    explanation: string;
+    exampleInContext: {
+      japanese: string;
+      english: string;
+      fragments: string[];
+      accepted_alternatives: string[];
+    };
+  };
 }
 
 export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -35,7 +35,12 @@ export interface ExtractedKU {
 export interface GrammarNote {
   title: string;
   explanation: string;
-  exampleInContext: string;
+  exampleInContext: {
+    japanese: string;
+    english: string;
+    fragments: string[];
+    accepted_alternatives: string[];
+  };
 }
 
 export interface ScenarioEvaluation {


### PR DESCRIPTION
  ## Summary                                                                                                                                        
                                                            
  - Add `sentence-cloze` review facet type — new `SentenceClozeCard` component renders                                                              
    an inline blank, accepts typed Japanese input (wanakana IME), evaluates by strict
    match, and reveals the full sentence on submit. Generation deferred to a follow-up.                                                             
  - Flesh out `GrammarKnowledgeUnit` and `GrammarNote` types: `exampleInContext`                                                                    
    restructured from a flat string to `{ japanese, english, fragments, accepted_alternatives }`                                                    
  - Wire grammar notes into the review system: `ScenariosService.advanceState`                                                                      
    encounter→drill now batch-creates one `sentence-assembly` facet per grammar note                                                                
    (`kuId = scenario.id`) in `users/{uid}/review-facets`.                                                                                          
  - Update Gemini scenario prompt to return the structured `exampleInContext` object                                                                
    with fragments (minimal grammatical chunks that rejoin to reproduce the sentence exactly).                                                      
  - Make `SentenceAssemblyCard.concept` optional so scenario-sourced facets (which have                                                             
    no backing concept) render correctly; "Review concept" link is now conditional.                                                                 
  - Delete orphaned `scenario-templates` Firestore collection (seeded by an old migration                                                           
    script, never read by the running app).                                                                                                         
  - File issue #133: migrate `scenarios` top-level collection to `users/{uid}/scenarios`.                                                           
                                                                                                                                                    
  ## Files changed                                                                                                                                  
                                                            
  - `backend/src/types/index.ts` — `GrammarKnowledgeUnit.data.exampleInContext` typed                                                               
  - `backend/src/types/scenario.ts` — `GrammarNote.exampleInContext` typed                                                                          
  - `frontend/src/types/index.ts` — same                                  
  - `frontend/src/types/scenario.ts` — same                                                                                                         
  - `backend/src/scenarios/scenarios.service.ts` — prompt schema + `advanceState` facet creation                                                    
  - `frontend/src/components/review/SentenceClozeCard.tsx` — new                                
  - `frontend/src/components/review/SentenceAssemblyCard.tsx` — `concept` optional                                                                  
  - `frontend/src/app/review/page.tsx` — `sentence-cloze` branch; conditional `concept` pass                                                        
  - `frontend/src/app/scenarios/[id]/page.tsx` — render `exampleInContext` object fields                                                            
                                                                                                                                                    
  ## Test plan                                                                                                                                      
                                                                                                                                                    
  - [ ] Generate a new scenario — confirm 