### PR TITLE
feat: added grammar lessons and the flow from scenarios to reviews

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,7 +185,8 @@ The database uses **flat top-level collections** (not Firestore sub-collections 
 | `users/{uid}/user-kus` | Yes — sub-collection path | Per-user KU metadata; `kuId` references global KU |
 | `users/{uid}/review-facets` | Yes — sub-collection path | Per-user SRS facets (non-admin users) |
 | `review-facets` | Yes (field) | Admin (`user_default`) SRS facets only; `userId` field still required |
-| `lessons` | Yes (field) | AI-generated lesson documents |
+| `lessons` | **No** (Grammar); Yes (field, Vocab/Kanji) | Global `GrammarLesson` docs stored at `lessons/{kuId}` — no `userId`. Vocab/Kanji lessons still scoped by `userId` field. |
+| `users/{uid}/user-grammar-lessons` | Yes — sub-collection path | Per-user per-encounter `UserGrammarLesson` docs. Doc ID: `{kuId}_{sourceType}_{sourceId}` (deterministic, prevents duplicates per source). |
 | `questions` | **No** | Global question corpus — no `userId` on new docs. `rank` and `rejectionCount` fields drive selection. |
 | `users/{uid}/question-states` | Yes — sub-collection path | Per-user `UserQuestionState`: `rejected`, `consecutiveFailures`, `kuId` |
 | `scenarios` | Yes (field) | Roleplay scenario state |
@@ -394,6 +395,20 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - `frontend/src/app/concepts/[id]/page.tsx` — client component that fetches real concept data from `GET /api/concepts/:id` and renders it with two highlight helpers: `highlightGrammar` (red tint, used in Examples section) and `highlightClause` (bold + dotted underline, used in mechanics Simple/Natural examples).
 - `frontend/src/app/admin/concepts/page.tsx` — hidden admin page at `/admin/concepts` for triggering concept generation; accepts Topic and optional Detailed Notes fields that are appended to the prompt as `**Additional notes from the teacher:**`.
 - `frontend/src/app/concepts/page.tsx` — empty placeholder page for the Concepts nav link.
+
+---
+
+**Grammar Lessons — two-tier Global/User model (2026-04-22)**
+
+- Added `GrammarLesson` (global, context-agnostic) and `UserGrammarLesson` (per-user per-encounter) interfaces to both `backend/src/types/index.ts` and `frontend/src/types/index.ts`. `Lesson` union updated to `VocabLesson | KanjiLesson | GrammarLesson`.
+- **Separation of concerns**: The global `GrammarLesson` (stored at `lessons/{kuId}`) holds all teaching content — formation rules, generic examples, JLPT level — and is generated lazily on first learn, then reused for all users. The `UserGrammarLesson` (stored at `users/{uid}/user-grammar-lessons/{kuId}_{sourceType}_{sourceId}`) holds only the user's source context: which scenario or concept introduced the pattern, plus a verbatim `contextExample`. Deterministic doc ID prevents duplicate records per source.
+- **`GrammarNote.pattern`**: new optional field (`～をお願いします` style) for extracting a canonical grammar key separate from the full title. Used as the dedup key in `ensureGrammarKU`.
+- **`KnowledgeUnitsService.ensureGrammarKU(note)`**: get-or-create helper — finds an existing `GrammarKnowledgeUnit` by `note.pattern ?? note.title`, creates one if not found. Prevents duplicate KUs for the same pattern encountered across different scenarios.
+- **`LessonsService` Grammar branch**: `generateLesson` for Grammar type passes the `UserGrammarLesson.contextExample` verbatim to the AI prompt as `examples[0]`, so the familiar sentence anchors the lesson. Stored at `lessons/{kuId}` without a `userId`. `createUserGrammarLesson` and `getUserGrammarLessons` added. `GET /lessons/user-grammar?kuId=` endpoint added.
+- **`ScenariosService.advanceState`** (encounter→drill): replaced direct sentence-assembly facet creation with per-grammar-note pipeline — `ensureGrammarKU` → `UserKnowledgeUnitsService.create` → `LessonsService.createUserGrammarLesson`. `LessonsModule` imported by `ScenariosModule`.
+- **Learn page Grammar branch**: fetches global lesson + user lessons in parallel. Emits one `sentence-assembly` facet per example, plus `AI-Generated-Question` and `Content-to-Definition`. `Content-to-Definition` tagged with `kuType: 'Grammar'` and `definitions: [lesson.meaning]`.
+- **Review page**: `getQuestionType` returns "Grammar Pattern → Meaning" when `data.kuType === 'Grammar'` or no `data.reading` field (legacy facet detection). `getExpectedAnswer` falls back to `facet.data.topic` if `definitions` is empty.
+- **`GrammarLessonView.tsx`** (new): renders pattern header, formation block, amber notes callout, examples with source-context banner, and facet selection checkboxes.
 
 ---
 

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -15,6 +15,7 @@ export const CONCEPTS_COLLECTION = 'concepts';
 export const USER_KUS_SUBCOLLECTION = 'user-kus';
 export const USER_CONCEPTS_SUBCOLLECTION = 'user-concepts';
 export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
+export const USER_GRAMMAR_LESSONS_SUBCOLLECTION = 'user-grammar-lessons';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;
 

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -7,6 +7,7 @@ import { KnowledgeUnit } from '@/types';
 import { KnowledgeUnitType } from '@/types';
 import { NotFoundException } from '@nestjs/common';
 import { Query } from '@google-cloud/firestore';
+import { GrammarNote } from '@/types/scenario';
 
 @Injectable()
 export class KnowledgeUnitsService {
@@ -120,7 +121,7 @@ export class KnowledgeUnitsService {
         return newRef.id;
     }
 
-    async ensureVocab(content: string): Promise<string> {
+    async ensureVocab(content: string, hint?: { reading?: string; definition?: string; jlptLevel?: string }): Promise<string> {
         const existing = await this.findByContent(content, 'Vocab');
 
         if (existing) {
@@ -131,7 +132,11 @@ export class KnowledgeUnitsService {
         await newRef.set({
             content,
             type: 'Vocab',
-            data: { reading: '', definition: '' },
+            data: {
+                reading: hint?.reading ?? '',
+                definition: hint?.definition ?? '',
+                ...(hint?.jlptLevel ? { jlptLevel: hint.jlptLevel } : {}),
+            },
             status: 'learning',
             facet_count: 0,
             createdAt: Timestamp.now(),
@@ -308,6 +313,34 @@ export class KnowledgeUnitsService {
                 ? data.createdAt.toDate().toISOString()
                 : data.createdAt,
         } as unknown as KnowledgeUnit;
+    }
+
+    async ensureGrammarKU(note: GrammarNote): Promise<string> {
+        const content = note.pattern ?? note.title;
+        const existing = await this.findByContent(content, 'Grammar');
+
+        if (existing) {
+            return existing.id;
+        }
+
+        const newRef = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc();
+        await newRef.set({
+            content,
+            type: 'Grammar',
+            data: {
+                title: note.title,
+                explanation: note.explanation,
+                exampleInContext: note.exampleInContext,
+            },
+            status: 'learning',
+            facet_count: 0,
+            createdAt: Timestamp.now(),
+            relatedUnits: [],
+            personalNotes: '',
+        });
+
+        this.logger.log(`Created Grammar KU for pattern "${content}"`);
+        return newRef.id;
     }
 
     async findOne(id: string): Promise<KnowledgeUnit> {

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -90,4 +90,12 @@ export class LessonsController {
 
     return lesson;
   }
+
+  @Get('user-grammar')
+  async getUserGrammarLessons(@UserId() uid: string, @Query('kuId') kuId: string) {
+    if (!kuId) {
+      throw new BadRequestException('kuId is required');
+    }
+    return this.lessonsService.getUserGrammarLessons(uid, kuId);
+  }
 }

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, Inject, Logger, NotFoundException } from '@nestjs/common';
-import { FIRESTORE_CONNECTION, LESSONS_COLLECTION, KNOWLEDGE_UNITS_COLLECTION } from '../firebase/firebase.module';
-import { Firestore, BulkWriter } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, LESSONS_COLLECTION, KNOWLEDGE_UNITS_COLLECTION, USER_GRAMMAR_LESSONS_SUBCOLLECTION } from '../firebase/firebase.module';
+import { Firestore, BulkWriter, Timestamp } from 'firebase-admin/firestore';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
-import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson } from '../types';
+import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson, GrammarKnowledgeUnit, UserGrammarLesson } from '../types';
 import { performance } from 'perf_hooks';
 // Removed CURRENT_USER_ID import
 
@@ -47,9 +47,34 @@ export class LessonsService {
     }
 
     this.logger.log(`No existing lesson for KU ${kuId}. Generating new lesson`);
-    // let jsonSchema: any;
 
     let userMessage: string;
+
+    if (ku.type === "Grammar") {
+      const grammarKu = ku as GrammarKnowledgeUnit;
+      userMessage = `You are an expert Japanese grammar tutor. Generate a lesson for the grammar pattern: ${grammarKu.content}
+
+Pattern title: ${grammarKu.data.title}
+Existing explanation: ${grammarKu.data.explanation}
+Example from context: ${grammarKu.data.exampleInContext?.japanese ?? ''}
+
+${GRAMMAR_INSTRUCTIONS}`;
+
+      const lessonString = await this.geminiService.generateLesson(userMessage, { content: grammarKu.content, kuId }, undefined);
+      if (!lessonString) throw new Error('AI response was empty.');
+
+      let lessonJson: GrammarLesson;
+      try {
+        lessonJson = JSON.parse(lessonString) as GrammarLesson;
+        lessonJson.kuId = kuId;
+      } catch {
+        this.logger.error('Failed to parse Grammar lesson JSON', lessonString);
+        throw new Error('Failed to parse AI JSON response for grammar lesson');
+      }
+
+      await lessonDbRef.set(lessonJson);
+      return lessonJson;
+    }
 
     if (ku.type === "Kanji") {
       const KANJI_USER_PROMPT = `You are an expert Japanese tutor. You will be asked to generate a lesson for the Japanese Kanji: ${ku.content}.
@@ -227,6 +252,12 @@ ${VOCAB_INSTRUCTIONS}`;
   }
 
   async findByKuId(uid: string, kuId: string): Promise<Lesson | null> {
+    // Grammar lessons are global (no userId); read the doc directly
+    const directDoc = await this.db.collection(LESSONS_COLLECTION).doc(kuId).get();
+    if (directDoc.exists && directDoc.data()?.type === 'Grammar') {
+      return { ...directDoc.data() } as GrammarLesson;
+    }
+
     const snapshot = await this.db.collection(LESSONS_COLLECTION)
       .where('kuId', '==', kuId)
       .where('userId', '==', uid)
@@ -240,6 +271,42 @@ ${VOCAB_INSTRUCTIONS}`;
     const doc = snapshot.docs[0];
     return { id: doc.id, ...doc.data() } as unknown as Lesson;
   } // END findByKuId
+
+  async createUserGrammarLesson(
+    uid: string,
+    kuId: string,
+    source: { sourceType: 'scenario' | 'concept'; sourceId: string; sourceTitle: string },
+    contextExample: { japanese: string; english: string; fragments: string[]; accepted_alternatives: string[] },
+  ): Promise<UserGrammarLesson> {
+    const docId = `${kuId}_${source.sourceType}_${source.sourceId}`;
+    const ref = this.db.collection('users').doc(uid).collection(USER_GRAMMAR_LESSONS_SUBCOLLECTION).doc(docId);
+
+    const data: Omit<UserGrammarLesson, 'id'> = {
+      userId: uid,
+      kuId,
+      lessonId: kuId,
+      sourceType: source.sourceType,
+      sourceId: source.sourceId,
+      sourceTitle: source.sourceTitle,
+      contextExample,
+      createdAt: Timestamp.now(),
+    };
+
+    await ref.set(data, { merge: false });
+    this.logger.log(`Created UserGrammarLesson ${docId} for uid=${uid} kuId=${kuId}`);
+    return { id: docId, ...data };
+  }
+
+  async getUserGrammarLessons(uid: string, kuId: string): Promise<UserGrammarLesson[]> {
+    const snapshot = await this.db
+      .collection('users').doc(uid)
+      .collection(USER_GRAMMAR_LESSONS_SUBCOLLECTION)
+      .where('kuId', '==', kuId)
+      .get();
+
+    if (snapshot.empty) return [];
+    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }) as unknown as UserGrammarLesson);
+  }
 
 
   async processBatch(uid: string, vocabValues: { id: string; content: string }[]) {
@@ -379,6 +446,37 @@ You MUST return a valid JSON object matching this schema:
     }
   ]
 }`;
+
+const GRAMMAR_INSTRUCTIONS = `
+The lesson should be in English. Japanese examples must not include Romaji.
+
+Generate a complete grammar lesson matching this JSON schema exactly:
+{
+  "type": "Grammar",
+  "pattern": "The grammar pattern (e.g. ～をお願いします)",
+  "title": "Human-readable name (e.g. Making Requests with ～をお願いします)",
+  "jlptLevel": "One of: N5, N4, N3, N2, N1",
+  "meaning": "One-line summary of what this pattern expresses",
+  "formation": "How to form it (e.g. noun + をお願いします)",
+  "notes": "Nuance, register, common mistakes, contrast with similar patterns",
+  "examples": [
+    {
+      "japanese": "Full example sentence",
+      "english": "English translation",
+      "context": "Short real-world setting label (e.g. convenience store)",
+      "fragments": ["word1", "word2"],
+      "accepted_alternatives": []
+    }
+  ]
+}
+
+Rules:
+- Provide exactly 3 examples
+- ALWAYS use the provided 'Example from context' sentence as examples[0], adapted with fragments and accepted_alternatives filled in
+- examples[1] and examples[2] should be in real-world settings similar to examples[0]'s context
+- fragments must be the Japanese sentence split into meaningful chunks for sentence-assembly drills
+- Keep example sentences at or below JLPT N4 complexity even if the pattern itself is higher level
+`;
 
 const VOCAB_EXAMPLES = `
 **Examples:**

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -52,11 +52,16 @@ export class LessonsService {
 
     if (ku.type === "Grammar") {
       const grammarKu = ku as GrammarKnowledgeUnit;
+      const ctxExample = grammarKu.data.exampleInContext;
       userMessage = `You are an expert Japanese grammar tutor. Generate a lesson for the grammar pattern: ${grammarKu.content}
 
 Pattern title: ${grammarKu.data.title}
 Existing explanation: ${grammarKu.data.explanation}
-Example from context: ${grammarKu.data.exampleInContext?.japanese ?? ''}
+Example from context (USE AS examples[0] VERBATIM):
+  japanese: ${ctxExample?.japanese ?? ''}
+  english: ${ctxExample?.english ?? ''}
+  fragments: ${JSON.stringify(ctxExample?.fragments ?? [])}
+  accepted_alternatives: ${JSON.stringify(ctxExample?.accepted_alternatives ?? [])}
 
 ${GRAMMAR_INSTRUCTIONS}`;
 
@@ -472,9 +477,10 @@ Generate a complete grammar lesson matching this JSON schema exactly:
 
 Rules:
 - Provide exactly 3 examples
-- ALWAYS use the provided 'Example from context' sentence as examples[0], adapted with fragments and accepted_alternatives filled in
-- examples[1] and examples[2] should be in real-world settings similar to examples[0]'s context
-- fragments must be the Japanese sentence split into meaningful chunks for sentence-assembly drills
+- ALWAYS copy the provided 'Example from context' data VERBATIM into examples[0], including its exact fragments and accepted_alternatives
+- examples[1] and examples[2] MUST use completely different Japanese sentences with their own unique fragments
+- fragments must be the Japanese sentence split into meaningful chunks for sentence-assembly drills — each example must have different fragments matching its own sentence
+- NEVER copy fragments from one example to another
 - Keep example sentences at or below JLPT N4 complexity even if the pattern itself is higher level
 `;
 

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -5,7 +5,6 @@ import { GeminiModule } from 'src/gemini/gemini.module';
 import { forwardRef } from '@nestjs/common';
 import { QuestionsModule } from 'src/questions/questions.module';
 import { KnowledgeUnitsModule } from 'src/knowledge-units/knowledge-units.module';
-import { LessonsModule } from '@/lessons/lessons.module';
 import { StatsModule } from '../stats/stats.module';
 
 @Module({
@@ -13,7 +12,6 @@ import { StatsModule } from '../stats/stats.module';
     GeminiModule,
     forwardRef(() => QuestionsModule),
     KnowledgeUnitsModule,
-    LessonsModule,
     StatsModule,
   ],
   controllers: [ReviewsController],

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -4,7 +4,6 @@ import { FIRESTORE_CONNECTION } from '../firebase/firebase.module';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
-import { LessonsService } from '@/lessons/lessons.service';
 import { StatsService } from '../stats/stats.service';
 
 describe('ReviewsService', () => {
@@ -20,7 +19,6 @@ describe('ReviewsService', () => {
   const mockGeminiService = {};
   const mockQuestionsService = {};
   const mockKnowledgeUnitsService = {};
-  const mockLessonsService = {};
   const mockStatsService = {};
 
   beforeEach(async () => {
@@ -31,7 +29,6 @@ describe('ReviewsService', () => {
         { provide: GeminiService, useValue: mockGeminiService },
         { provide: QuestionsService, useValue: mockQuestionsService },
         { provide: KnowledgeUnitsService, useValue: mockKnowledgeUnitsService },
-        { provide: LessonsService, useValue: mockLessonsService },
         { provide: StatsService, useValue: mockStatsService },
       ],
     }).compile();

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -5,21 +5,18 @@ import {
     NotFoundException,
     forwardRef,
 } from '@nestjs/common';
-import { CollectionReference, FieldPath, FieldValue, Firestore, Query, Timestamp } from 'firebase-admin/firestore';
+import { CollectionReference, FieldValue, Firestore, Query, Timestamp } from 'firebase-admin/firestore';
 import {
     FIRESTORE_CONNECTION,
     REVIEW_FACETS_COLLECTION,
     KNOWLEDGE_UNITS_COLLECTION,
-    CONCEPTS_COLLECTION,
     USER_STATS_COLLECTION,
 } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
-// Removed ADMIN_USER_ID import
-import { FacetType, KnowledgeUnit, Lesson, ReviewFacet } from '@/types';
+import { ReviewFacet } from '@/types';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
-import { LessonsService } from '@/lessons/lessons.service';
 import { StatsService } from '../stats/stats.service';
 
 @Injectable()
@@ -42,10 +39,9 @@ export class ReviewsService {
     constructor(
         @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
         private readonly geminiService: GeminiService,
-        @Inject(forwardRef(() => QuestionsService)) // <-- WRAP THIS
+        @Inject(forwardRef(() => QuestionsService))
         private readonly questionsService: QuestionsService,
         private readonly knowledgeUnitsService: KnowledgeUnitsService,
-        private readonly lessonsService: LessonsService,
         private readonly statsService: StatsService,
     ) { }
 
@@ -274,13 +270,10 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
                 modifiedData = { ...data };
             }
 
-            if (key === 'audio' && modifiedData?.contextExample) {
+            if (key === 'audio' && modifiedData?.contextExample && modifiedData?.content) {
                 try {
-                    const ku = await this.knowledgeUnitsService.findOne(targetKuId);
-                    if (ku && ku.content) {
-                        const clozeSentence = await this.geminiService.generateClozeSentence(ku.content, modifiedData.contextExample.sentence);
-                        modifiedData.clozeSentence = clozeSentence;
-                    }
+                    const clozeSentence = await this.geminiService.generateClozeSentence(modifiedData.content, modifiedData.contextExample.sentence);
+                    modifiedData.clozeSentence = clozeSentence;
                 } catch (err) {
                     this.logger.error(`Failed to generate cloze for audio facet ${kuId}`, err);
                 }
@@ -332,55 +325,19 @@ Example for a fail: {"result": "fail", "explanation": "Incorrect. The expected r
             return [];
         }
 
-        // Map in parallel to build the full ReviewItem objects
-        const reviewItems = await Promise.all(snapshot.docs.map(async (doc) => {
-            const facetData = doc.data();
-            const facet = { id: doc.id, ...facetData } as ReviewFacet;
-
-            if (!facet.kuId) {
-                this.logger.warn(`Skipping corrupted facet ${facet.id}: missing kuId`);
-                return null; // Return null so we can filter it out in the next step
-            }
-
-            // concept facets reference a concept, not a knowledge unit
-            if (facet.facetType === 'sentence-assembly' || facet.facetType === 'AI-Generated-Question') {
-                try {
-                    const conceptDoc = await this.db.collection(CONCEPTS_COLLECTION).doc(facet.kuId).get();
-                    if (!conceptDoc.exists) {
-                        this.logger.warn(`Concept ${facet.kuId} not found for facet ${facet.id}`);
-                        return null;
-                    }
-                    return { facet, ku: { id: conceptDoc.id, ...conceptDoc.data() } as KnowledgeUnit, lesson: null };
-                } catch (e) {
-                    this.logger.warn(`Failed to fetch concept for facet ${facet.id}`, e);
+        const reviewItems = snapshot.docs
+            .map(doc => {
+                const facet = { id: doc.id, ...doc.data() } as ReviewFacet;
+                if (!facet.kuId) {
+                    this.logger.warn(`Skipping corrupted facet ${facet.id}: missing kuId`);
                     return null;
                 }
-            }
+                return { facet };
+            })
+            .filter(item => item !== null);
 
-            // Fetch related KU
-            let ku: KnowledgeUnit | null = null;
-            try {
-                ku = await this.knowledgeUnitsService.findOne(facet.kuId);
-            } catch (e) {
-                this.logger.warn(`Orphaned facet ${facet.id}: KU ${facet.kuId} not found`);
-            }
-
-            // Fetch related Lesson
-            let lesson: Lesson | null = null;
-            if (ku) {
-                lesson = await this.lessonsService.findByKuId(uid, ku.id);
-            }
-
-            return {
-                facet,
-                ku,
-                lesson
-            };
-        }));
-
-        // Filter out items where KU was deleted/missing to prevent frontend crashes
-        this.logger.log(`Found ${reviewItems.length} due reviews`);
-        return reviewItems.filter(item => item !== null && item.ku !== null);
+        this.logger.log(`Found ${reviewItems.length} due reviews for user ${uid}`);
+        return reviewItems;
     } // END getDueReviews
 
     async getAllFacets(uid: string) {

--- a/backend/src/scenarios/scenarios.module.ts
+++ b/backend/src/scenarios/scenarios.module.ts
@@ -3,11 +3,13 @@ import { ScenariosController } from './scenarios.controller';
 import { ScenariosService } from './scenarios.service';
 import { GeminiModule } from '../gemini/gemini.module';
 import { KnowledgeUnitsModule } from '../knowledge-units/knowledge-units.module';
+import { LessonsModule } from '../lessons/lessons.module';
 
 @Module({
   imports: [
     GeminiModule,
     KnowledgeUnitsModule,
+    LessonsModule,
   ],
   controllers: [ScenariosController],
   providers: [ScenariosService],

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -9,6 +9,7 @@ import { Firestore, CollectionReference, Timestamp, FieldValue } from 'firebase-
 import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt } from '../types/scenario';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
+import { LessonsService } from '../lessons/lessons.service';
 import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
 import { GeminiService } from '../gemini/gemini.service';
 
@@ -35,6 +36,7 @@ export class ScenariosService {
     private readonly geminiService: GeminiService,
     private readonly knowledgeUnitsService: KnowledgeUnitsService,
     private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
+    private readonly lessonsService: LessonsService,
   ) {
     this.collectionRef = this.db.collection(SCENARIOS_COLLECTION);
   }
@@ -102,6 +104,7 @@ export class ScenariosService {
           meaning: cleanMeaning(ku.meaning),
           type: 'vocab',
           status: 'new',
+          jlptLevel: ku.jlptLevel ?? null,
         })),
         grammarNotes: data.grammarNotes,
         state: 'encounter',
@@ -156,12 +159,18 @@ export class ScenariosService {
               const globalKu = await this.knowledgeUnitsService.findByContent(ku.content, 'Vocab');
 
               if (globalKu) {
-                this.logger.log(`Linking "${ku.content}" to global KU ${globalKu.id}`);
+                this.logger.log(`Linking "${ku.content}" to existing global KU ${globalKu.id}`);
                 await this.userKnowledgeUnitsService.create(uid, globalKu.id);
                 updatedKUs.push({ ...ku, kuId: globalKu.id, status: 'learning' });
               } else {
-                this.logger.warn(`No global KU found for "${ku.content}" — skipping UKU creation`);
-                updatedKUs.push(ku);
+                this.logger.log(`No global KU found for "${ku.content}" — creating new KU with level hint ${ku.jlptLevel ?? 'none'}`);
+                const newKuId = await this.knowledgeUnitsService.ensureVocab(ku.content, {
+                  reading: ku.reading,
+                  definition: ku.meaning,
+                  jlptLevel: ku.jlptLevel,
+                });
+                await this.userKnowledgeUnitsService.create(uid, newKuId);
+                updatedKUs.push({ ...ku, kuId: newKuId, status: 'learning' });
               }
             } catch (error) {
               this.logger.error(`Failed to process KU "${ku.content}" during advanceState`, error);
@@ -172,33 +181,23 @@ export class ScenariosService {
           updateData.extractedKUs = updatedKUs;
         }
 
-        // Create sentence-assembly facets for each grammar note
+        // Emit Grammar KUs + UKUs + UserGrammarLessons for each grammar note
         if (scenario.grammarNotes && scenario.grammarNotes.length > 0) {
-          const facetsRef = this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
-          const facetBatch = this.db.batch();
-          const now = Timestamp.now();
-
           for (const note of scenario.grammarNotes) {
-            const ref = facetsRef.doc();
-            facetBatch.set(ref, {
-              kuId: scenario.id,
-              facetType: 'sentence-assembly',
-              srsStage: 0,
-              nextReviewAt: now,
-              createdAt: now,
-              history: [],
-              data: {
-                goalTitle: note.title,
-                fragments: note.exampleInContext.fragments,
-                answer: note.exampleInContext.japanese,
-                english: note.exampleInContext.english,
-                accepted_alternatives: note.exampleInContext.accepted_alternatives ?? [],
-              },
-            });
+            try {
+              const kuId = await this.knowledgeUnitsService.ensureGrammarKU(note);
+              await this.userKnowledgeUnitsService.create(uid, kuId);
+              await this.lessonsService.createUserGrammarLesson(
+                uid,
+                kuId,
+                { sourceType: 'scenario', sourceId: scenario.id, sourceTitle: scenario.title },
+                note.exampleInContext,
+              );
+            } catch (err) {
+              this.logger.error(`Failed to process grammar note "${note.title}"`, err);
+            }
           }
-
-          await facetBatch.commit();
-          this.logger.log(`Created ${scenario.grammarNotes.length} sentence-assembly facets for uid=${uid} scenarioId=${scenario.id}`);
+          this.logger.log(`Processed ${scenario.grammarNotes.length} grammar notes for uid=${uid} scenarioId=${scenario.id}`);
         }
 
         newState = 'drill';
@@ -410,6 +409,9 @@ Create a "Genki-style" learning scenario for an ADULT traveler/expat (not a stud
      - \`content\`: Japanese text ONLY (e.g., "本屋"). No readings or definitions in this field.
      - \`reading\`: Kana reading ONLY (e.g., "ほんや"). No Romaji.
      - \`meaning\`: English definition ONLY.
+     - \`jlptLevel\`: JLPT level hint for this word (e.g., "N4"). MUST be one of: N5, N4, N3, N2, N1. Use your best judgement for the level of each individual word.
+   - For \`grammarNotes\`:
+     - \`pattern\`: The extractable grammar pattern in isolation (e.g., "～をお願いします", "～ている"). This should be concise and reusable across contexts.
 
 **Output Schema (Return ONLY raw JSON):**
 {
@@ -438,11 +440,13 @@ Create a "Genki-style" learning scenario for an ADULT traveler/expat (not a stud
       "content": "本屋",
       "reading": "ほんや",
       "meaning": "Bookstore",
-      "type": "vocab"
+      "type": "vocab",
+      "jlptLevel": "N4"
     }
   ],
   "grammarNotes": [
     {
+      "pattern": "The extractable grammar pattern, e.g. ～をお願いします",
       "title": "Grammar Point Name",
       "explanation": "Clear explanation",
       "exampleInContext": {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -182,7 +182,42 @@ export interface UserLessonData {
   personalMnemonic?: string;
 }
 
-export type Lesson = VocabLesson | KanjiLesson;
+export interface GrammarLesson {
+  kuId?: string;
+  type: 'Grammar';
+  pattern: string;       // e.g. "～をお願いします"
+  title: string;         // e.g. "Making Requests with ～をお願いします"
+  jlptLevel: string;
+  meaning: string;       // one-line summary
+  formation: string;     // "noun + をお願いします"
+  notes: string;         // nuance, pitfalls
+  examples: {
+    japanese: string;
+    english: string;
+    context?: string;    // e.g. "convenience store" — for future facet targeting
+    fragments: string[];
+    accepted_alternatives: string[];
+  }[];
+}
+
+export interface UserGrammarLesson {
+  id: string;
+  userId: string;
+  kuId: string;
+  lessonId: string;      // = kuId (Grammar lessons stored at lessons/{kuId})
+  sourceType: 'scenario' | 'concept';
+  sourceId: string;
+  sourceTitle: string;
+  contextExample: {
+    japanese: string;
+    english: string;
+    fragments: string[];
+    accepted_alternatives: string[];
+  };
+  createdAt: Timestamp;
+}
+
+export type Lesson = VocabLesson | KanjiLesson | GrammarLesson;
 
 export type KnowledgeUnitType =
   | "Vocab"
@@ -371,14 +406,8 @@ export interface ReviewFacet {
   data?: any;
 }
 
-/**
- * Represents a "joined" review item, combining the
- * facet with its parent KU.
- */
 export interface ReviewItem {
   facet: ReviewFacet;
-  ku: KnowledgeUnit | (KnowledgeUnit & UserKnowledgeUnit);
-  lesson?: Lesson | (VocabLesson & UserLessonData) | (KanjiLesson & UserLessonData);
 }
 
 // This represents the structure of our old db.json

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -26,9 +26,11 @@ export interface ExtractedKU {
     type: 'vocab' | 'kanji';
     kuId?: string;
     status: 'new' | 'learning' | 'mastered';
+    jlptLevel?: string;
 }
 
 export interface GrammarNote {
+    pattern?: string;  // the extractable pattern, e.g. "～をお願いします"
     title: string;
     explanation: string;
     exampleInContext: {

--- a/backend/src/user-concepts/user-concepts.service.ts
+++ b/backend/src/user-concepts/user-concepts.service.ts
@@ -123,6 +123,8 @@ export class UserConceptsService {
           answer: mechanic.naturalExample.japanese,
           english: mechanic.naturalExample.english,
           accepted_alternatives: mechanic.naturalExample.accepted_alternatives ?? [],
+          sourceId: conceptId,
+          sourceTitle: concept.data.title,
         },
       });
       created++;
@@ -137,7 +139,11 @@ export class UserConceptsService {
         nextReviewAt: now,
         createdAt: now,
         history: [],
-        data: {},
+        data: {
+          topic: concept.data.title,
+          sourceId: conceptId,
+          sourceTitle: concept.data.title,
+        },
       });
       created++;
     }

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -276,8 +276,9 @@ export default function LearnItemPage() {
           key: "Content-to-Definition",
           data: {
             content: grammarLesson.pattern,
-            definitions: [grammarLesson.meaning],
+            definitions: [grammarLesson.meaning].filter(Boolean),
             topic: grammarLesson.title,
+            kuType: "Grammar",
           },
         });
       }

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -2,9 +2,10 @@
 
 import React, { useState, useEffect, useRef } from "react"; // <-- Import useRef
 import { useRouter, useParams, useSearchParams } from "next/navigation";
-import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson } from "@/types";
+import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson, UserGrammarLesson } from "@/types";
 import VocabLessonView from "@/components/lessons/VocabLessonView";
 import KanjiLessonView from "@/components/lessons/KanjiLessonView";
+import GrammarLessonView from "@/components/lessons/GrammarLessonView";
 import { apiFetch } from "@/lib/api-client";
 
 export default function LearnItemPage() {
@@ -28,6 +29,7 @@ export default function LearnItemPage() {
   const [kanjiStatuses, setKanjiStatuses] = useState<Record<string, string>>(
     {},
   );
+  const [userGrammarLessons, setUserGrammarLessons] = useState<UserGrammarLesson[]>([]);
 
   const fetchVocabLesson = async (ku: KnowledgeUnit) => {
     setIsLoading(true);
@@ -113,6 +115,26 @@ export default function LearnItemPage() {
     setLesson(data as KanjiLesson);
   };
 
+  const fetchGrammarLesson = async (ku: KnowledgeUnit) => {
+    const [lessonRes, userLessonsRes] = await Promise.all([
+      apiFetch("/api/lessons/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kuId: ku.id }),
+      }),
+      apiFetch(`/api/lessons/user-grammar?kuId=${ku.id}`),
+    ]);
+
+    if (!lessonRes.ok) throw new Error("Failed to generate grammar lesson");
+    const lessonData = (await lessonRes.json()) as GrammarLesson;
+    setLesson(lessonData);
+
+    if (userLessonsRes.ok) {
+      const ugls = (await userLessonsRes.json()) as UserGrammarLesson[];
+      setUserGrammarLessons(ugls);
+    }
+  };
+
   useEffect(() => {
     if (process.env.NODE_ENV === "development" && fetchRef.current) {
       return; // Already fetched, do nothing on the second mount
@@ -136,6 +158,8 @@ export default function LearnItemPage() {
           await fetchVocabLesson(kuData);
         } else if (kuData.type === "Kanji") {
           await fetchKanjiLesson(kuData);
+        } else if (kuData.type === "Grammar") {
+          await fetchGrammarLesson(kuData);
         }
       } catch (err: any) {
         setError(err.message);
@@ -215,16 +239,79 @@ export default function LearnItemPage() {
       });
     }
 
+    // 2a. Grammar facets (handled separately — may emit multiple sentence-assembly facets)
+    if (ku?.type === "Grammar" && lesson?.type === "Grammar") {
+      const grammarLesson = lesson as GrammarLesson;
+      const grammarFacets: { key: string; data: Record<string, any> }[] = [];
+
+      if (selectedFacets["sentence-assembly"]) {
+        grammarLesson.examples.forEach((ex) => {
+          grammarFacets.push({
+            key: "sentence-assembly",
+            data: {
+              goalTitle: grammarLesson.pattern,
+              fragments: ex.fragments,
+              answer: ex.japanese,
+              english: ex.english,
+              accepted_alternatives: ex.accepted_alternatives ?? [],
+              sourceId: ku.id,
+              sourceTitle: grammarLesson.title,
+            },
+          });
+        });
+      }
+      if (selectedFacets["AI-Generated-Question"]) {
+        grammarFacets.push({
+          key: "AI-Generated-Question",
+          data: {
+            content: grammarLesson.pattern,
+            topic: grammarLesson.title,
+            sourceId: ku.id,
+            sourceTitle: grammarLesson.title,
+          },
+        });
+      }
+      if (selectedFacets["Content-to-Definition"]) {
+        grammarFacets.push({
+          key: "Content-to-Definition",
+          data: {
+            content: grammarLesson.pattern,
+            definitions: [grammarLesson.meaning],
+            topic: grammarLesson.title,
+          },
+        });
+      }
+
+      if (grammarFacets.length > 0) {
+        promises.push(
+          apiFetch("/api/reviews/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ kuId: ku.id, facetsToCreate: grammarFacets }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const err = await res.json();
+              throw new Error(err.error || "Failed to create grammar facets");
+            }
+          }),
+        );
+      }
+    }
+
     // 2. Process Standard Review Facets
     if (reviewFacetKeys.length > 0) {
       const facetsToCreatePayload = reviewFacetKeys.map((key) => {
-        if (key.startsWith("Kanji-Component-") && lesson.type === "Vocab") {
+        // Component kanji stub creation (Kanji-Component-食 etc.) — no facet created, just KU stub
+        if (key.startsWith("Kanji-Component-") &&
+            key !== "Kanji-Component-Meaning" &&
+            key !== "Kanji-Component-Reading" &&
+            lesson.type === "Vocab") {
           const kanjiChar = key.split("-")[2];
           const kanjiData = (lesson as VocabLesson).component_kanji?.find(
             (k) => k.kanji === kanjiChar,
           );
           return {
-            key: key,
+            key,
             data: {
               meaning: kanjiData?.meaning,
               onyomi: kanjiData?.onyomi,
@@ -232,17 +319,47 @@ export default function LearnItemPage() {
             },
           };
         }
+        // Standalone kanji facets (from Kanji lesson page)
+        if (key === "Kanji-Component-Meaning" || key === "Kanji-Component-Reading") {
+          const kanjiLesson = lesson as KanjiLesson;
+          return {
+            key,
+            data: {
+              content: ku.content,
+              meaning: kanjiLesson.meaning,
+              onyomi: kanjiLesson.onyomi,
+              kunyomi: kanjiLesson.kunyomi,
+            },
+          };
+        }
+        // Audio facet
         if (key === "audio" && lesson.type === "Vocab") {
           const vocabLesson = lesson as VocabLesson;
           const ex = vocabLesson.context_examples && vocabLesson.context_examples.length > 0
             ? vocabLesson.context_examples[Math.floor(Math.random() * vocabLesson.context_examples.length)]
             : null;
           return {
-            key: key,
-            data: ex ? { contextExample: ex } : undefined,
+            key,
+            data: {
+              content: ku.content,
+              reading: vocabLesson.reading || (ku.type === 'Vocab' ? ku.data.reading : undefined),
+              definitions: vocabLesson.definitions ?? [],
+              ...(ex ? { contextExample: ex } : {}),
+            },
           };
         }
-        return { key: key };
+        // All other facets: Content-to-Definition, Definition-to-Content,
+        // Content-to-Reading, Reading-to-Content, AI-Generated-Question
+        const vocabLesson = lesson.type === "Vocab" ? (lesson as VocabLesson) : null;
+        return {
+          key,
+          data: {
+            content: ku.content,
+            reading: vocabLesson?.reading || (ku.type === 'Vocab' ? ku.data.reading : undefined),
+            definitions: vocabLesson?.definitions ?? [],
+            topic: ku.content,
+          },
+        };
       });
 
       const reviewPromise = apiFetch("/api/reviews/generate", {
@@ -328,7 +445,7 @@ export default function LearnItemPage() {
                 Meaning
               </span>
             </label>
-            {ku?.data.reading !== ku?.content && (
+            {ku?.type === 'Vocab' && ku.data.reading !== ku?.content && (
               <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
                 <input
                   type="checkbox"
@@ -510,7 +627,9 @@ export default function LearnItemPage() {
               ? "..."
               : lesson?.type === "Kanji" && (lesson as KanjiLesson).kanji
                 ? (lesson as KanjiLesson).kanji
-                : ku?.content || "..."}
+                : lesson?.type === "Grammar"
+                  ? (lesson as GrammarLesson).pattern
+                  : ku?.content || "..."}
           </h1>
           {lesson && lesson?.type === "Vocab" && (
             <p className="text-2xl text-gray-500 dark:text-gray-400 capitalize">
@@ -519,6 +638,11 @@ export default function LearnItemPage() {
                 : ku
                   ? ku.type
                   : "..."}{" "}
+            </p>
+          )}
+          {lesson && lesson?.type === "Grammar" && (
+            <p className="text-2xl text-gray-500 dark:text-gray-400">
+              Grammar Pattern
             </p>
           )}
         </header>
@@ -545,10 +669,34 @@ export default function LearnItemPage() {
           <KanjiLessonView lesson={lesson as KanjiLesson} />
         )}
 
-        {!isLoading && !error && lesson && source !== "review" && (
+        {lesson && ku?.type === "Grammar" && (
+          <GrammarLessonView
+            lesson={lesson as GrammarLesson}
+            userLesson={userGrammarLessons[0]}
+            selectedFacets={selectedFacets}
+            onToggleFacet={handleCheckboxChange}
+          />
+        )}
+
+        {!isLoading && !error && lesson && source !== "review" && ku?.type !== "Grammar" && (
           <>
             {renderFacetChecklist()}
           </>
+        )}
+
+        {!isLoading && !error && lesson && source !== "review" && ku?.type === "Grammar" && (
+          <div className="mt-6">
+            {error && (
+              <div className="mb-4 text-red-600 text-sm">{error}</div>
+            )}
+            <button
+              onClick={handleSubmitFacets}
+              disabled={isSubmitting || !lesson}
+              className="w-full py-4 text-lg bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? "Saving..." : "Start Learning Selected Items"}
+            </button>
+          </div>
         )}
       </main>
     </>

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -522,7 +522,9 @@ export default function ReviewPage() {
       case "AI-Generated-Question":
         return `AI Quiz`;
       case "Content-to-Definition":
-        return "Vocab Definition";
+        return (item.facet.data?.kuType === "Grammar" || !item.facet.data?.reading)
+          ? "Grammar Pattern → Meaning"
+          : "Vocab Definition";
       case "Content-to-Reading":
         return "Vocab Reading";
       case "Kanji-Component-Meaning":
@@ -563,11 +565,15 @@ export default function ReviewPage() {
 
     if (facet.facetType === "Content-to-Definition" || facet.facetType === "audio") {
       const defs: string[] = facet.data?.definitions ?? [];
-      return Array.from(new Set(
+      const parsed = Array.from(new Set(
         defs.flatMap((def: string) => def.split(/[,;]/))
             .map((def: string) => def.trim())
             .filter((def: string) => def.length > 0),
       ));
+      if (parsed.length === 0 && facet.data?.topic) {
+        return [facet.data.topic];
+      }
+      return parsed;
     }
 
     if (facet.facetType === "Content-to-Reading") {
@@ -642,6 +648,7 @@ export default function ReviewPage() {
       {/* --- Sentence Assembly --- */}
       {currentItem.facet.facetType === "sentence-assembly" && (
         <SentenceAssemblyCard
+          key={currentItem.facet.id}
           facet={currentItem.facet}
           onResult={handleUpdateSrs}
           onAdvance={advanceToNext}
@@ -652,6 +659,7 @@ export default function ReviewPage() {
       {/* --- Sentence Cloze --- */}
       {currentItem.facet.facetType === "sentence-cloze" && (
         <SentenceClozeCard
+          key={currentItem.facet.id}
           facet={currentItem.facet}
           onResult={handleUpdateSrs}
           onAdvance={advanceToNext}
@@ -742,7 +750,7 @@ export default function ReviewPage() {
           <div className="relative mt-4">
             <button
               type="submit"
-              disabled={answerState !== "unanswered" || isDynamicLoading}
+              disabled={answerState !== "unanswered" || isDynamicLoading || !userAnswer.trim()}
               className="w-full px-6 py-4 bg-blue-600 text-white text-xl font-semibold rounded-md shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 disabled:bg-gray-500 disabled:cursor-wait"
             >
               {answerState === "evaluating" ? "Evaluating..." : "Submit Answer"}

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -3,12 +3,11 @@
 import React, { useState, useEffect, useRef, FormEvent } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ReviewItem, ReviewFacet, VocabLesson, KanjiLesson } from "@/types";
+import { ReviewItem, ReviewFacet, KnowledgeUnit } from "@/types";
 import * as wanakana from "wanakana";
 import { logger } from "@/lib/logger";
 import { QuestionFeedbackModal } from "@/components/QuestionFeedbackModal";
 import EditKnowledgeUnitModal from "@/components/EditKnowledgeUnitModal";
-import { KnowledgeUnit } from "@/types";
 import { getSrsLevelName, getSrsLevelIndex } from "@/utils/srs";
 import { apiFetch } from "@/lib/api-client";
 import SentenceAssemblyCard from "@/components/review/SentenceAssemblyCard";
@@ -185,7 +184,7 @@ export default function ReviewPage() {
     if (currentItem && currentItem.facet.facetType === "audio") {
       // Small timeout to let UI mount
       setTimeout(() => {
-        fetchAndPlayAudio(currentItem.ku.data?.reading || currentItem.ku.content);
+        fetchAndPlayAudio(currentItem.facet.data?.reading || currentItem.facet.data?.content);
       }, 50);
     }
 
@@ -209,13 +208,11 @@ export default function ReviewPage() {
       setDynamicQuestionId(null);
       setDynamicQuestionIsNew(false);
 
-      const topic = currentItem.ku.type === 'Concept'
-        ? (currentItem.ku as import('@/types').ConceptKnowledgeUnit).data.title
-        : currentItem.ku.content;
+      const topic = currentItem.facet.data?.topic || currentItem.facet.data?.content || '';
       fetchDynamicQuestion(
         topic,
         currentItem.facet.id,
-        currentItem.ku.id,
+        currentItem.facet.kuId,
       );
     } else {
       setDynamicQuestion(null);
@@ -343,7 +340,7 @@ export default function ReviewPage() {
 
     const expectedAnswers = getExpectedAnswer(currentItem); // Now using array
     const question = getQuestion(currentItem);
-    const topic = currentItem.ku.content; // The "topic" is the KU content
+    const topic = currentItem.facet.data?.content || '';
     const questionType = getQuestionType(currentItem); // Get the question type
     // Use dynamicQuestionId if available (for AI questions), otherwise fallback to facet's currentQuestionId (though that might be stale)
     const questionId = dynamicQuestionId || currentItem.facet.currentQuestionId;
@@ -371,7 +368,7 @@ export default function ReviewPage() {
           topic,
           questionType,
           questionId,
-          kuId: currentItem.ku.id,
+          kuId: currentItem.facet.kuId,
         }),
       });
 
@@ -446,22 +443,25 @@ export default function ReviewPage() {
   };
 
   // --- Edit Handlers ---
-  const handleEditClick = () => {
-    if (currentItem) {
-      setEditingKu(currentItem.ku);
-      setIsEditModalOpen(true);
+  const handleEditClick = async () => {
+    if (!currentItem) return;
+    try {
+      const response = await apiFetch(`/api/knowledge-units/${currentItem.facet.kuId}`);
+      if (response.ok) {
+        const kuData = await response.json() as KnowledgeUnit;
+        setEditingKu(kuData);
+        setIsEditModalOpen(true);
+      }
+    } catch (err) {
+      console.error("Failed to fetch KU for editing", err);
     }
   };
 
   const handleSaveKu = async (id: string, updates: Partial<KnowledgeUnit>) => {
     try {
-      // 1. Update backend
-      // TODO needs nextjs rewrite
       const response = await apiFetch(`/api/knowledge-units/${id}`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(updates),
       });
 
@@ -469,30 +469,10 @@ export default function ReviewPage() {
         throw new Error("Failed to update unit");
       }
 
-      const updatedKu = await response.json(); // Assuming backend returns the updated KU
-
-      // 2. Update local state (reviewQueue) to reflect changes immediately
-      setReviewQueue((prevQueue) =>
-        prevQueue.map((item) => {
-          if (item.ku.id === id) {
-            // Merge updates into the KU
-            return {
-              ...item,
-              ku: {
-                ...item.ku,
-                ...updates,
-                ...updatedKu,
-              },
-            };
-          }
-          return item;
-        }),
-      );
-
       window.dispatchEvent(new CustomEvent("refreshStats"));
     } catch (err) {
       console.error(err);
-      alert("Failed to save changes"); // Simple alert for now
+      alert("Failed to save changes");
     }
   };
 
@@ -517,22 +497,21 @@ export default function ReviewPage() {
   // --- Helper Functions ---
 
   const getQuestion = (item: ReviewItem): string | null => {
-    const { ku, facet } = item;
+    const { facet } = item;
     switch (facet.facetType) {
       case "audio":
         return facet.data?.clozeSentence || facet.data?.contextExample?.sentence || "Context not found";
       case "AI-Generated-Question":
-        return dynamicQuestion; // Returns null if loading
+        return dynamicQuestion;
       case "Content-to-Definition":
       case "Content-to-Reading":
-        return ku.content;
       case "Kanji-Component-Meaning":
       case "Kanji-Component-Reading":
-        return ku.content;
+        return facet.data?.content || "[No content]";
       case "Definition-to-Content":
-        return ku.data?.definition || "[No Definition]";
+        return facet.data?.definitions?.[0] || "[No Definition]";
       case "Reading-to-Content":
-        return ku.data?.reading || "[No Reading]";
+        return facet.data?.reading || "[No Reading]";
       default:
         return "Unknown Facet";
     }
@@ -572,132 +551,41 @@ export default function ReviewPage() {
   };
 
   const getExpectedAnswer = (item: ReviewItem): string[] => {
-    const { ku, facet } = item;
+    const { facet } = item;
 
-    // 1. Handle AI-Generated questions first
     if (facet.facetType === "AI-Generated-Question") {
-      const allExpectedAnswers = [...dynamicAltAnswers]; // initialize
-
-      if (dynamicAnswer) {
-        allExpectedAnswers.push(dynamicAnswer);
-      }
-      console.log(
-        "Expected answers for AI-Generated Question:",
-        allExpectedAnswers,
-      );
-      return allExpectedAnswers;
+      return [...(dynamicAltAnswers ?? []), ...(dynamicAnswer ? [dynamicAnswer] : [])];
     }
 
-    // 2. Handle "reverse" quizzes
-    if (
-      facet.facetType === "Definition-to-Content" ||
-      facet.facetType === "Reading-to-Content"
-    ) {
-      console.log("Expected answers for reverse quiz:", [ku.content]);
-      return [ku.content];
+    if (facet.facetType === "Definition-to-Content" || facet.facetType === "Reading-to-Content") {
+      return facet.data?.content ? [facet.data.content] : [];
     }
 
-    // 3. Handle "forward" quizzes (Content-to-...)
-    if (ku.type === "Vocab") {
-      // --- VOCAB LOGIC ---
-      const lesson = item.lesson as VocabLesson | undefined;
-      if (facet.facetType === "Content-to-Definition" || facet.facetType === "audio") {
-        // Collect all potential definition strings
-        const rawDefinitions: string[] = [];
-
-        // 1. From Lesson (array)
-        if (lesson?.definitions && Array.isArray(lesson.definitions)) {
-          rawDefinitions.push(...lesson.definitions);
-        }
-
-        // 2. From KU (string)
-        if (ku.data?.definition) {
-          rawDefinitions.push(ku.data.definition);
-        }
-
-        // Process: split by delimiters (comma, semicolon), trim, filter empty
-        const uniqueDefinitions = Array.from(
-          new Set(
-            rawDefinitions
-              .flatMap((def) => def.split(/[,;]/)) // Split by , or ;
-              .map((def) => def.trim())
-              .filter((def) => def.length > 0),
-          ),
-        );
-
-        if (facet.facetType === "audio") {
-          return uniqueDefinitions;
-        }
-
-        console.log(
-          "Expected answers for Content-to-Definition:",
-          uniqueDefinitions,
-        );
-        return uniqueDefinitions;
-      }
-      if (facet.facetType === "Content-to-Reading") {
-        // Use lesson.reading as primary, fallback to ku.data.reading (which might be empty now)
-        // If both are present, we might want to accept both?
-        // But getExpectedAnswer returns string[].
-        // Let's use ku.data.reading if present (legacy source of truth), AND lesson.reading.
-
-        const answers: string[] = [];
-        if (ku.data?.reading) answers.push(ku.data.reading);
-        if (lesson?.reading) answers.push(lesson.reading);
-
-        // Deduplicate
-        const unique = Array.from(new Set(answers));
-
-        if (unique.length > 0) {
-          console.log("Expected answers for Content-to-Reading:", unique);
-          return unique;
-        }
-
-        // Fallback to reading_explanation if absolutely nothing else (unlikely with Gemini)
-        return [lesson?.reading_explanation || ""];
-      }
-    } else if (ku.type === "Kanji") {
-      // --- KANJI LOGIC ---
-      if (facet.facetType === "Content-to-Definition") {
-        // Kanji "definition" is the 'meaning' field from the lesson
-        const kanjiDefinitionString = ku.data?.meaning || "";
-        return kanjiDefinitionString.split(",").map((answer) => answer.trim());
-      }
-      if (facet.facetType === "Content-to-Reading") {
-        // Kanji "reading" is a combination of all onyomi and kunyomi
-        const onyomi = ku.data?.onyomi || [];
-        const kunyomi = ku.data?.kunyomi || [];
-        const allReadings = [...onyomi, ...kunyomi];
-
-        if (allReadings.length > 0) {
-          return allReadings; // facilitate Gemini short circuit
-          //return allReadings.join(', '); // e.g., "ドク, トク, よむ"
-        }
-        // Fallback just in case lesson is old/missing
-        console.log("Expected answers for Content-to-Reading (fallback):", [
-          ku.data?.onyomi || ku.data?.kunyomi || "",
-        ]);
-        return ku.data?.onyomi || ku.data?.kunyomi || [];
-      }
+    if (facet.facetType === "Content-to-Definition" || facet.facetType === "audio") {
+      const defs: string[] = facet.data?.definitions ?? [];
+      return Array.from(new Set(
+        defs.flatMap((def: string) => def.split(/[,;]/))
+            .map((def: string) => def.trim())
+            .filter((def: string) => def.length > 0),
+      ));
     }
 
-    // --- KANJI COMPONENT LOGIC ---
+    if (facet.facetType === "Content-to-Reading") {
+      return facet.data?.reading ? [facet.data.reading] : [];
+    }
+
     if (facet.facetType === "Kanji-Component-Meaning") {
-      const meaningStr = ku.data?.meaning || "";
-
-      return meaningStr
+      return (facet.data?.meaning || "")
         .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s);
-    }
-    if (facet.facetType === "Kanji-Component-Reading") {
-      return ku.data?.onyomi || [];
+        .map((s: string) => s.trim())
+        .filter((s: string) => s);
     }
 
-    // Fallback for any other combo
-    logger.warn(
-      `getExpectedAnswer: No answer path for ${ku.type} / ${facet.facetType}`,
-    );
+    if (facet.facetType === "Kanji-Component-Reading") {
+      return facet.data?.onyomi ?? [];
+    }
+
+    logger.warn(`getExpectedAnswer: No answer path for facetType=${facet.facetType}`);
     return [];
   };
 
@@ -755,7 +643,6 @@ export default function ReviewPage() {
       {currentItem.facet.facetType === "sentence-assembly" && (
         <SentenceAssemblyCard
           facet={currentItem.facet}
-          concept={currentItem.ku.type === 'Concept' ? currentItem.ku as import('@/types').ConceptKnowledgeUnit & { id: string } : undefined}
           onResult={handleUpdateSrs}
           onAdvance={advanceToNext}
           onSkip={advanceToNext}
@@ -806,7 +693,7 @@ export default function ReviewPage() {
                 <div className="mt-6 flex justify-center">
                   <button
                     type="button"
-                    onClick={() => fetchAndPlayAudio(currentItem.ku.data?.reading || currentItem.ku.content)}
+                    onClick={() => fetchAndPlayAudio(currentItem.facet.data?.reading || currentItem.facet.data?.content)}
                     className="flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 rounded-full text-white font-semibold transition-transform transform active:scale-95 shadow-md"
                   >
                     <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
@@ -874,7 +761,7 @@ export default function ReviewPage() {
                 type="button"
                 onClick={() => {
                   if (currentItem) {
-                    router.push(`/learn/${currentItem.ku.id}?source=review`);
+                    router.push(`/learn/${currentItem.facet.kuId}?source=review`);
                   }
                 }}
                 disabled={answerState !== "unanswered" || isDynamicLoading}
@@ -939,9 +826,9 @@ export default function ReviewPage() {
             <div className="mb-4">
               <p className="text-lg text-gray-200">
                 <span className="font-semibold">Word:</span>{" "}
-                <span className="text-2xl font-bold text-white">{currentItem.ku.content}</span>
-                {currentItem.ku.data?.reading && currentItem.ku.data.reading !== currentItem.ku.content && (
-                  <span className="ml-2 text-gray-300">({currentItem.ku.data.reading})</span>
+                <span className="text-2xl font-bold text-white">{currentItem.facet.data?.content}</span>
+                {currentItem.facet.data?.reading && currentItem.facet.data.reading !== currentItem.facet.data.content && (
+                  <span className="ml-2 text-gray-300">({currentItem.facet.data.reading})</span>
                 )}
               </p>
               <p className="text-lg text-gray-200 mt-2">
@@ -961,10 +848,10 @@ export default function ReviewPage() {
           {answerState === "incorrect" && currentItem && (
             <div className="mt-4">
               <Link
-                href={`/learn/${currentItem.ku.id}?source=review`}
+                href={`/learn/${currentItem.facet.kuId}?source=review`}
                 className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
               >
-                Review lesson on {currentItem.ku.content}
+                Review lesson on {currentItem.facet.data?.content}
               </Link>
             </div>
           )}

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -119,6 +119,7 @@ export default function ScenarioPage({
   }, [scenario]);
 
   const [advancing, setAdvancing] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -227,7 +228,8 @@ export default function ScenarioPage({
       await fetchScenario();
       if (scenario.state === "encounter") {
         window.dispatchEvent(new CustomEvent("refreshStats"));
-        alert("Vocabulary added to your queue!");
+        setToast(`${scenario.extractedKUs.length} items added to your learning queue`);
+        setTimeout(() => setToast(null), 4000);
       } else if (scenario.state === "drill") {
         // Moved to simulate
       } else if (scenario.state === "simulate") {
@@ -353,6 +355,12 @@ export default function ScenarioPage({
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8 pb-24">
+      {toast && (
+        <div className="fixed top-4 right-4 z-50 bg-green-600 text-white px-6 py-3 rounded-lg shadow-lg font-semibold animate-in fade-in slide-in-from-top-2">
+          {toast}
+        </div>
+      )}
+
       {fromLibrary && (
         <button
           onClick={handleBackToLibrary}
@@ -786,40 +794,48 @@ export default function ScenarioPage({
       {/* Only show if NOT completed, because Report Card has its own button */}
       {scenario.state !== "completed" && (
         <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 p-4 shadow-lg">
-          <div className="max-w-4xl mx-auto flex justify-between items-center">
-            <div className="text-sm text-slate-500">
-              {scenario.extractedKUs.length} items extracted
-            </div>
-            <button
-              onClick={handleAdvance}
-              disabled={
-                advancing ||
-                (scenario.state === "simulate" && chatHistory.length === 0)
-              }
-              className={`px-8 py-3 rounded-lg font-bold transition-colors shadow-sm ${
-                scenario.state === "encounter"
-                  ? "bg-indigo-600 hover:bg-indigo-700 text-white"
-                  : scenario.state === "drill"
-                    ? "bg-purple-600 hover:bg-purple-700 text-white"
-                    : scenario.state === "simulate"
-                      ? scenario.isObjectiveMet
-                        ? "bg-green-600 hover:bg-green-700 text-white" // Objective Met
-                        : "bg-amber-500 hover:bg-amber-600 text-white" // Warning / Early Exit
-                      : "bg-green-600 hover:bg-green-700 text-white"
-              } ${advancing || (scenario.state === "simulate" && chatHistory.length === 0) ? "opacity-50 cursor-not-allowed" : ""}`}
-            >
-              {advancing
-                ? "Processing..."
-                : scenario.state === "encounter"
-                  ? "Start Drilling →"
-                  : scenario.state === "drill"
-                    ? "Start Roleplay →"
-                    : scenario.state === "simulate"
-                      ? scenario.isObjectiveMet
-                        ? "Complete Mission"
-                        : "End Session Early"
-                      : "Completed"}
-            </button>
+          <div className="max-w-4xl mx-auto">
+            {scenario.state === "encounter" ? (
+              <button
+                onClick={handleAdvance}
+                disabled={advancing}
+                className={`w-full py-4 text-lg rounded-xl font-bold transition-colors shadow-sm bg-indigo-600 hover:bg-indigo-700 text-white ${advancing ? "opacity-50 cursor-not-allowed" : ""}`}
+              >
+                {advancing ? "Processing..." : "Start Learning Vocab and Grammar"}
+              </button>
+            ) : (
+              <div className="flex justify-between items-center">
+                <div className="text-sm text-slate-500">
+                  {scenario.extractedKUs.length} items extracted
+                </div>
+                <button
+                  onClick={handleAdvance}
+                  disabled={
+                    advancing ||
+                    (scenario.state === "simulate" && chatHistory.length === 0)
+                  }
+                  className={`px-8 py-3 rounded-lg font-bold transition-colors shadow-sm ${
+                    scenario.state === "drill"
+                      ? "bg-purple-600 hover:bg-purple-700 text-white"
+                      : scenario.state === "simulate"
+                        ? scenario.isObjectiveMet
+                          ? "bg-green-600 hover:bg-green-700 text-white"
+                          : "bg-amber-500 hover:bg-amber-600 text-white"
+                        : "bg-green-600 hover:bg-green-700 text-white"
+                  } ${advancing || (scenario.state === "simulate" && chatHistory.length === 0) ? "opacity-50 cursor-not-allowed" : ""}`}
+                >
+                  {advancing
+                    ? "Processing..."
+                    : scenario.state === "drill"
+                      ? "Start Roleplay →"
+                      : scenario.state === "simulate"
+                        ? scenario.isObjectiveMet
+                          ? "Complete Mission"
+                          : "End Session Early"
+                        : "Completed"}
+                </button>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/lessons/GrammarLessonView.tsx
+++ b/frontend/src/components/lessons/GrammarLessonView.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { useState } from "react";
+import { GrammarLesson, UserGrammarLesson } from "@/types";
+
+interface GrammarLessonViewProps {
+  lesson: GrammarLesson;
+  userLesson?: UserGrammarLesson;
+  selectedFacets: Record<string, boolean>;
+  onToggleFacet: (key: string) => void;
+}
+
+export default function GrammarLessonView({
+  lesson,
+  userLesson,
+  selectedFacets,
+  onToggleFacet,
+}: GrammarLessonViewProps) {
+  const [revealedExamples, setRevealedExamples] = useState<Record<number, boolean>>({});
+
+  const toggleReveal = (idx: number) => {
+    setRevealedExamples((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  };
+
+  const facetOptions = [
+    { key: "sentence-assembly", label: "Sentence Assembly", description: "Reassemble example sentences" },
+    { key: "AI-Generated-Question", label: "AI Question", description: "Answer a dynamic question about this pattern" },
+    { key: "Content-to-Definition", label: "Pattern → Meaning", description: "See the pattern, recall its meaning" },
+  ];
+
+  return (
+    <div className="space-y-8">
+      {/* Source Context Banner */}
+      {userLesson && (
+        <div className="bg-indigo-50 border-l-4 border-indigo-400 px-4 py-3 rounded-r-lg text-sm text-indigo-800">
+          First encountered in <strong>{userLesson.sourceTitle}</strong>
+        </div>
+      )}
+
+      {/* Pattern Header */}
+      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center shadow-sm">
+        <div className="text-4xl font-bold text-slate-900 mb-2">{lesson.pattern}</div>
+        <div className="text-slate-500 text-sm mb-3">{lesson.title}</div>
+        <span className="inline-block px-3 py-1 bg-indigo-100 text-indigo-800 text-xs font-bold rounded-full">
+          {lesson.jlptLevel}
+        </span>
+      </div>
+
+      {/* Meaning */}
+      <div className="bg-slate-50 border border-slate-200 rounded-xl p-5">
+        <h2 className="text-sm font-bold text-slate-500 uppercase tracking-wide mb-2">Meaning</h2>
+        <p className="text-slate-800 text-lg">{lesson.meaning}</p>
+      </div>
+
+      {/* Formation */}
+      <div className="bg-slate-50 border border-slate-200 rounded-xl p-5">
+        <h2 className="text-sm font-bold text-slate-500 uppercase tracking-wide mb-2">Formation</h2>
+        <p className="font-mono text-slate-900 bg-white border border-slate-100 rounded px-4 py-2 inline-block">
+          {lesson.formation}
+        </p>
+      </div>
+
+      {/* Notes */}
+      {lesson.notes && (
+        <div className="bg-amber-50 border-l-4 border-amber-400 p-4 rounded-r-lg">
+          <h2 className="text-sm font-bold text-amber-700 uppercase tracking-wide mb-2">Notes</h2>
+          <p className="text-amber-900 text-sm leading-relaxed">{lesson.notes}</p>
+        </div>
+      )}
+
+      {/* Examples */}
+      <div>
+        <h2 className="text-xl font-bold text-slate-800 mb-4">Examples</h2>
+        <div className="space-y-4">
+          {lesson.examples.map((ex, idx) => {
+            const isFromSource = idx === 0 && userLesson;
+            return (
+              <div
+                key={idx}
+                className={`border rounded-xl p-5 ${isFromSource ? "bg-indigo-50 border-indigo-200" : "bg-white border-slate-200"}`}
+              >
+                {isFromSource && (
+                  <div className="text-xs font-bold text-indigo-500 uppercase mb-2">
+                    From {userLesson!.sourceTitle}
+                  </div>
+                )}
+                {ex.context && !isFromSource && (
+                  <div className="text-xs font-bold text-slate-400 uppercase mb-2">{ex.context}</div>
+                )}
+                <p className="text-xl font-medium text-slate-900 mb-1">{ex.japanese}</p>
+                <button
+                  onClick={() => toggleReveal(idx)}
+                  className="text-sm text-indigo-600 hover:text-indigo-800 transition-colors"
+                >
+                  {revealedExamples[idx] ? "Hide translation" : "Show translation"}
+                </button>
+                {revealedExamples[idx] && (
+                  <p className="text-slate-500 text-sm mt-1">{ex.english}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Facet Selection */}
+      <div className="border-t border-slate-200 pt-8">
+        <h2 className="text-xl font-bold text-slate-800 mb-2">Review Methods</h2>
+        <p className="text-sm text-slate-500 mb-4">
+          Choose which review types to add to your queue.
+        </p>
+        <div className="space-y-3">
+          {facetOptions.map(({ key, label, description }) => (
+            <label
+              key={key}
+              className="flex items-start gap-3 p-4 bg-white border border-slate-200 rounded-xl cursor-pointer hover:border-indigo-300 transition-colors"
+            >
+              <input
+                type="checkbox"
+                checked={!!selectedFacets[key]}
+                onChange={() => onToggleFacet(key)}
+                className="mt-1 w-4 h-4 accent-indigo-600"
+              />
+              <div>
+                <div className="font-semibold text-slate-800">{label}</div>
+                <div className="text-sm text-slate-500">{description}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/review/SentenceAssemblyCard.tsx
+++ b/frontend/src/components/review/SentenceAssemblyCard.tsx
@@ -31,7 +31,9 @@ export default function SentenceAssemblyCard({ facet, onResult, onAdvance, onSki
     sourceTitle?: string;
   };
 
-  const [available, setAvailable] = useState<string[]>(() => shuffleArray(fragments));
+  const normalize = (s: string) => s.replace(/[。、！？!?\.]+$/u, "").trim();
+  const missingData = !Array.isArray(fragments) || fragments.length === 0 || !answer;
+  const [available, setAvailable] = useState<string[]>(() => shuffleArray(Array.isArray(fragments) ? fragments : []));
   const [assembled, setAssembled] = useState<string[]>([]);
   const [submitted, setSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
@@ -63,13 +65,52 @@ export default function SentenceAssemblyCard({ facet, onResult, onAdvance, onSki
     if (assembled.length === 0 || submitted) return;
     setIsSubmitting(true);
     const assembledStr = assembled.join("");
-    const correct = assembledStr === answer || (accepted_alternatives ?? []).includes(assembledStr);
+    const exactMatch = assembledStr === answer || normalize(assembledStr) === normalize(answer);
+    const altMatch = (accepted_alternatives ?? []).some(a => assembledStr === a || normalize(assembledStr) === normalize(a));
+    const correct = exactMatch || altMatch;
+
+    if (!correct) {
+      console.group("[SentenceAssembly] Incorrect answer diagnosis");
+      console.log("Submitted:  ", JSON.stringify(assembledStr));
+      console.log("Expected:   ", JSON.stringify(answer));
+      console.log("Alternatives:", JSON.stringify(accepted_alternatives ?? []));
+      console.log("Fragments used:", assembled);
+      if (assembledStr.length === answer.length) {
+        const diffs = [...assembledStr].map((ch, i) =>
+          ch !== answer[i]
+            ? `[${i}] submitted U+${ch.codePointAt(0)?.toString(16)} vs expected U+${answer[i].codePointAt(0)?.toString(16)}`
+            : null
+        ).filter(Boolean);
+        console.log("Char diffs (same length):", diffs.length ? diffs : "none — possible whitespace/normalization issue");
+        console.log("Submitted codepoints: ", [...assembledStr].map(c => c.codePointAt(0)?.toString(16)).join(" "));
+        console.log("Expected  codepoints: ", [...answer].map(c => c.codePointAt(0)?.toString(16)).join(" "));
+      } else {
+        console.log(`Length mismatch: submitted=${assembledStr.length}, expected=${answer.length}`);
+      }
+      console.groupEnd();
+    } else {
+      console.log(`[SentenceAssembly] Correct (${exactMatch ? "exact" : "alternative match"}):`, JSON.stringify(assembledStr));
+    }
+
     setSubmittedAnswer(assembledStr);
     setIsCorrect(correct);
     await onResult(correct ? "pass" : "fail");
     setSubmitted(true);
     setIsSubmitting(false);
   };
+
+  if (missingData) {
+    console.warn("[SentenceAssembly] Facet missing required data", { facetId: facet.id, fragments, answer });
+    return (
+      <div className="bg-gray-800 shadow-2xl rounded-lg p-8 space-y-4 text-center">
+        <p className="text-amber-400 font-semibold">This review card has incomplete data and cannot be shown.</p>
+        <p className="text-gray-400 text-sm">Facet ID: {facet.id}</p>
+        <button onClick={onSkip} className="px-6 py-3 bg-gray-600 text-white rounded-md hover:bg-gray-500">
+          Skip
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-gray-800 shadow-2xl rounded-lg p-8 space-y-6">
@@ -134,7 +175,7 @@ export default function SentenceAssemblyCard({ facet, onResult, onAdvance, onSki
           <button
             onClick={handleSubmit}
             disabled={assembled.length === 0 || isSubmitting}
-            className="flex-1 px-6 py-3 bg-blue-600 text-white text-lg font-semibold rounded-md shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 disabled:bg-gray-800 disabled:text-gray-500"
+            className="flex-1 px-6 py-3 bg-blue-600 text-white text-lg font-semibold rounded-md shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 disabled:bg-gray-500 disabled:cursor-wait"
           >
             {isSubmitting ? "Checking…" : "Submit"}
           </button>
@@ -152,7 +193,7 @@ export default function SentenceAssemblyCard({ facet, onResult, onAdvance, onSki
               <p className="text-gray-200">
                 Your answer of <span className="text-white font-medium">{submittedAnswer}</span> is a correct translation of <span className="text-white font-medium">{english}</span>.
               </p>
-              {submittedAnswer !== answer && (
+              {normalize(submittedAnswer) !== normalize(answer) && (
                 <p className="text-green-200 text-sm">
                   While that's acceptable, it's better to say: <span className="text-white font-medium">{answer}</span>
                 </p>

--- a/frontend/src/components/review/SentenceAssemblyCard.tsx
+++ b/frontend/src/components/review/SentenceAssemblyCard.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
-import { ReviewFacet, ConceptKnowledgeUnit } from "@/types";
+import { ReviewFacet } from "@/types";
 
 interface Props {
   facet: ReviewFacet;
-  concept?: ConceptKnowledgeUnit & { id: string };
   onResult: (result: "pass" | "fail") => Promise<void>;
   onAdvance: () => void;
   onSkip: () => void;
@@ -21,13 +20,15 @@ function shuffleArray<T>(arr: T[]): T[] {
   return a;
 }
 
-export default function SentenceAssemblyCard({ facet, concept, onResult, onAdvance, onSkip }: Props) {
-  const { goalTitle, fragments, answer, english, accepted_alternatives } = facet.data as {
+export default function SentenceAssemblyCard({ facet, onResult, onAdvance, onSkip }: Props) {
+  const { goalTitle, fragments, answer, english, accepted_alternatives, sourceId, sourceTitle } = facet.data as {
     goalTitle: string;
     fragments: string[];
     answer: string;
     english: string;
     accepted_alternatives: string[];
+    sourceId?: string;
+    sourceTitle?: string;
   };
 
   const [available, setAvailable] = useState<string[]>(() => shuffleArray(fragments));
@@ -163,12 +164,12 @@ export default function SentenceAssemblyCard({ facet, concept, onResult, onAdvan
                 <span className="font-semibold">Correct answer: </span>
                 <span className="text-white font-medium">{answer}</span>
               </p>
-              {concept && (
+              {sourceId && (
                 <Link
-                  href={`/concepts/${concept.id}`}
+                  href={`/concepts/${sourceId}`}
                   className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
                 >
-                  Review concept: {concept.data.title}
+                  Review concept: {sourceTitle}
                 </Link>
               )}
             </>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -215,9 +215,45 @@ export interface UserLessonData {
   personalMnemonic?: string;
 }
 
+export interface GrammarLesson {
+  kuId?: string;
+  type: "Grammar";
+  pattern: string;
+  title: string;
+  jlptLevel: string;
+  meaning: string;
+  formation: string;
+  notes: string;
+  examples: {
+    japanese: string;
+    english: string;
+    context?: string;
+    fragments: string[];
+    accepted_alternatives: string[];
+  }[];
+}
+
+export interface UserGrammarLesson {
+  id: string;
+  userId: string;
+  kuId: string;
+  lessonId: string;
+  sourceType: "scenario" | "concept";
+  sourceId: string;
+  sourceTitle: string;
+  contextExample: {
+    japanese: string;
+    english: string;
+    fragments: string[];
+    accepted_alternatives: string[];
+  };
+  createdAt: Timestamp;
+}
+
 export type Lesson =
   | VocabLesson
   | KanjiLesson
+  | GrammarLesson
   | GlobalVocabLesson
   | GlobalKanjiLesson;
 
@@ -417,17 +453,8 @@ export interface ReviewFacet {
   data?: any;
 }
 
-/**
- * Represents a "joined" review item, combining the
- * facet with its parent KU.
- */
 export interface ReviewItem {
   facet: ReviewFacet;
-  ku: KnowledgeUnit | (GlobalKnowledgeUnit & UserKnowledgeUnit);
-  lesson?:
-    | Lesson
-    | (GlobalVocabLesson & UserLessonData)
-    | (GlobalKanjiLesson & UserLessonData);
 }
 
 // This represents the structure of our old db.json

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -30,9 +30,11 @@ export interface ExtractedKU {
   type: "vocab" | "kanji";
   kuId?: string;
   status: "new" | "learning" | "mastered";
+  jlptLevel?: string;
 }
 
 export interface GrammarNote {
+  pattern?: string;
   title: string;
   explanation: string;
   exampleInContext: {


### PR DESCRIPTION
  ### Summary                                                                                                                                                                                     
                                                                                                                                                                                              
  Implements the full Grammar learning pipeline, from scenario encounter through to spaced repetition review.                                                                                 
                                                            
  Architecture: Follows a two-tier Global/User model — a context-agnostic GrammarLesson is generated once and shared globally (stored at lessons/{kuId}), while a UserGrammarLesson is created
   per user per encounter, anchoring the lesson to the scenario or concept where the user first saw the pattern. This preserves the learning context (e.g. "you first saw ～をお願いします in
  the Convenience Store Run") without polluting the global KU with user-specific data.                                                                                                        
                                                            
  #### What changed:

  - Scenario advanceState — replaced direct sentence-assembly facet creation for grammar notes with proper Level 1→2 emission: ensureGrammarKU + UKU creation + UserGrammarLesson creation per
   grammar note
  - AI prompt — updated to emit a pattern field on grammar notes (e.g. ～をお願いします) separate from the human-readable title                                                               
  - LessonsService — Grammar branch in generateLesson (global, lazy, no userId); new createUserGrammarLesson and getUserGrammarLessons methods                                                
  - KnowledgeUnitsService — new ensureGrammarKU method (get-or-create by pattern content)                                                                                                     
  - GET /lessons/user-grammar?kuId= — new endpoint returning all UserGrammarLessons for a user/pattern pair                                                                                   
  - GrammarLessonView component — displays pattern, formation, meaning, amber notes callout, examples with source context banner (first example anchored to originating scenario), and inline 
  facet selection                                                                                                                                                                             
  - Learn page — Grammar branch fetches lesson + user lessons in parallel; emits one sentence-assembly facet per example, plus optional AI-Generated-Question and Content-to-Definition facets
                                                                                                                                                                                              
  Review facets emitted: sentence-assembly (one per example), AI-Generated-Question, Content-to-Definition                                                                                    
                                                                                                                                                                                              
  Idempotency: UserGrammarLesson uses deterministic doc ID {kuId}_{sourceType}_{sourceId} — re-pressing "Start Learning" on the same scenario is safe. 