### PR TITLE
feat: Better Learning Queue and Lessons

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,7 +191,7 @@ Per-user data lives in **Firestore sub-collections** under `users/{uid}/<collect
 | `users/{uid}/user-grammar-lessons` | Yes — sub-collection path | Per-user per-encounter `UserGrammarLesson` docs. Doc ID: `{kuId}_{sourceType}_{sourceId}` (deterministic, prevents duplicates per source). |
 | `questions` | **No** | Global question corpus — no `userId` on new docs. `rank` and `rejectionCount` fields drive selection. |
 | `users/{uid}/question-states` | Yes — sub-collection path | Per-user `UserQuestionState`: `rejected`, `consecutiveFailures`, `kuId` |
-| `scenarios` | Yes (field) | Roleplay scenario state |
+| `scenarios` | Yes (field) | Roleplay scenario state. `sourceKuId` field links back to the vocabulary KU that triggered generation from a context example. Requires composite index on `(userId, sourceKuId, createdAt)`. |
 | `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
 | `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
 | `concepts` | **No** | Global grammar concept corpus — no `userId` on docs; `createdBy` field for audit only |
@@ -397,6 +397,34 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - `frontend/src/app/concepts/[id]/page.tsx` — client component that fetches real concept data from `GET /api/concepts/:id` and renders it with two highlight helpers: `highlightGrammar` (red tint, used in Examples section) and `highlightClause` (bold + dotted underline, used in mechanics Simple/Natural examples).
 - `frontend/src/app/admin/concepts/page.tsx` — hidden admin page at `/admin/concepts` for triggering concept generation; accepts Topic and optional Detailed Notes fields that are appended to the prompt as `**Additional notes from the teacher:**`.
 - `frontend/src/app/concepts/page.tsx` — empty placeholder page for the Concepts nav link.
+
+---
+
+**Review facets + lesson page overhaul (2026-04-25)**
+
+`generateReviewFacets` (`ReviewsService`) now:
+- Pre-fetches existing parent facets before the batch write; standard facet types are skipped if already present (dedup).
+- Auto-creates `Kanji-Component-Meaning` + `Kanji-Component-Reading` review facets for each selected kanji component, with per-KU dedup (pre-fetches each kanji's existing facets before creating).
+- Tracks `newFacetCount` per kanji; UKU `facet_count` is only incremented for newly created facets.
+- Kanji UKU updates run in parallel via `Promise.all` (was sequential `for...await`).
+- `batch.commit()` is called _before_ all UKU updates (was after — bug fix).
+- Parent UKU `status` is set to `learning` if `count > 0 || kanjiLinked > 0` (was `count > 0` only — bug fix when only kanji components were selected).
+
+`GET /api/reviews/facets?kuId=` — new query param in `ReviewsController`/`ReviewsService` returns all facets for a given KU. Used by the lesson page to determine which facet types already exist.
+
+Lesson page (`/learn/[kuId]`):
+- Fetches existing facets and any linked scenarios on load (parallel with lesson fetch).
+- Facet checklist conditionally renders: already-configured types shown as disabled checked checkboxes in a subsection; unconfigured types remain selectable. Heading: "Select Additional Items to Review".
+- After submit: re-fetches facets and updates UI in-place — no redirect.
+- Kanji component status detection: switched from `?status=learning` (broken after `status` moved to UKU) to `?status=user` + client-side filter on `ukuStatus` field.
+- Context examples: display "✓ View scenario →" link if a scenario already exists for that sentence (`sourceKuId` lookup), preventing duplicate scenario generation.
+- Scenario generation POST includes `sourceKuId: ku.id`.
+
+`GET /api/scenarios?sourceKuId=` — new query param in `ScenariosController`/`ScenariosService`. Returns slim stubs (`id`, `title`, `sourceContextSentence`, `createdAt`) ordered by `createdAt desc`. Requires Firestore composite index on `(userId, sourceKuId, createdAt)` on `scenarios` collection.
+
+Scenario page (`/scenarios/[id]`): shows "← Back to Lesson" breadcrumb when `scenario.sourceKuId` is set.
+
+Library page (`/learn`): Kanji items now show `data.meaning` in the hint column (previously blank).
 
 ---
 

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -111,11 +111,8 @@ export class KnowledgeUnitsService {
                 onyomi: metadata?.onyomi || [],
                 kunyomi: metadata?.kunyomi || [],
             },
-            status: 'learning',
-            facet_count: 0,
             createdAt: Timestamp.now(),
             relatedUnits: [],
-            personalNotes: 'Auto-generated component',
         });
 
         return newRef.id;

--- a/backend/src/prompts/scenario.prompts.ts
+++ b/backend/src/prompts/scenario.prompts.ts
@@ -48,9 +48,10 @@ Create a "Genki-style" learning scenario for an ADULT traveler/expat (not a stud
 3. **Grammar Notes:** Identify 1-2 key grammar points used in the dialogue and explain them like a textbook (Genki style).
 4. **Visual Context:** Provide a descriptive prompt that could be used to generate an image of the scene.
 5. **Role Constraints:**
-   - **User Roles:** ${ALLOWED_USER_ROLES.join(', ')}
-   - **Partner Roles:** ${ALLOWED_AI_ROLES.join(', ')}
-   - Use these exact terms (or their Japanese equivalents provided in the list) for the 'roles' object and 'participants' array.
+${dto.userRole && dto.aiRole
+  ? `   - **User Role:** ${dto.userRole}\n   - **AI Role:** ${dto.aiRole}\n   - Use these exact terms for the 'roles' object and 'participants' array.`
+  : `   - **User Roles:** ${ALLOWED_USER_ROLES.join(', ')}\n   - **Partner Roles:** ${ALLOWED_AI_ROLES.join(', ')}\n   - Use these exact terms (or their Japanese equivalents provided in the list) for the 'roles' object and 'participants' array.`
+}
 6. **Data Formatting (CRITICAL):**
    - \`title\`, \`description\` and all \`setting\` object fields should be in English
    - **NO ROMAJI**. Never include Romaji in any field.

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -59,7 +59,14 @@ export class ReviewsController {
   }
 
   @Get('facets')
-  async getFacets(@UserId() uid: string, @Query('due') due: string) {
+  async getFacets(
+    @UserId() uid: string,
+    @Query('due') due: string,
+    @Query('kuId') kuId: string,
+  ) {
+    if (kuId) {
+      return this.reviewsService.getFacetsByKuId(uid, kuId);
+    }
     if (due === 'true') {
       return this.reviewsService.getDueReviews(uid);
     }

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -6,6 +6,7 @@ import { forwardRef } from '@nestjs/common';
 import { QuestionsModule } from 'src/questions/questions.module';
 import { KnowledgeUnitsModule } from 'src/knowledge-units/knowledge-units.module';
 import { StatsModule } from '../stats/stats.module';
+import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { StatsModule } from '../stats/stats.module';
     forwardRef(() => QuestionsModule),
     KnowledgeUnitsModule,
     StatsModule,
+    UserKnowledgeUnitsModule,
   ],
   controllers: [ReviewsController],
   providers: [ReviewsService],

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -9,7 +9,6 @@ import { CollectionReference, FieldValue, Firestore, Query, Timestamp } from 'fi
 import {
     FIRESTORE_CONNECTION,
     REVIEW_FACETS_COLLECTION,
-    KNOWLEDGE_UNITS_COLLECTION,
     USER_STATS_COLLECTION,
 } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
@@ -17,6 +16,7 @@ import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
 import { ReviewFacet } from '@/types';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
+import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { StatsService } from '../stats/stats.service';
 import { buildAnswerEvaluatorPrompt } from '../prompts/evaluation.prompts';
 
@@ -43,6 +43,7 @@ export class ReviewsService {
         @Inject(forwardRef(() => QuestionsService))
         private readonly questionsService: QuestionsService,
         private readonly knowledgeUnitsService: KnowledgeUnitsService,
+        private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
         private readonly statsService: StatsService,
     ) { }
 
@@ -65,7 +66,7 @@ export class ReviewsService {
     }
 
     async updateFacetSrs(uid: string, facetId: string, result: 'pass' | 'fail') {
-        return this.db.runTransaction(async (transaction) => {
+        const txResult = await this.db.runTransaction(async (transaction) => {
             const facetRef = this.facetsColRef(uid).doc(facetId);
             const facetDoc = await transaction.get(facetRef);
 
@@ -119,16 +120,6 @@ export class ReviewsService {
                 }),
             });
 
-            // 4. WRITE (Knowledge Unit Propagation)
-            // If the item reached Mastered (Mushin - Stage 8), we update the KU status.
-            if (nextSrsStage === 8 && facetData.kuId) {
-                const kuRef = this.db
-                    .collection(KNOWLEDGE_UNITS_COLLECTION)
-                    .doc(facetData.kuId);
-                // Optimistic update for now
-                transaction.update(kuRef, { status: 'mastered' });
-            }
-
             this.logger.log(
                 `SRS Update [${facetId}]: ${result.toUpperCase()} | Stage ${currentSrsStage} -> ${nextSrsStage}`,
             );
@@ -138,8 +129,22 @@ export class ReviewsService {
                 facetId,
                 newStage: nextSrsStage,
                 nextReview: nextReviewDate,
+                kuId: facetData.kuId,
+                reachedMastered: nextSrsStage === 8,
             };
         });
+
+        // Post-transaction: propagate mastered status to UKU (outside transaction — queries not allowed inside)
+        if (txResult.reachedMastered && txResult.kuId) {
+            try {
+                await this.userKnowledgeUnitsService.update(uid, txResult.kuId, { status: 'mastered' });
+                this.logger.log(`Marked UKU mastered for uid=${uid} kuId=${txResult.kuId}`);
+            } catch (e) {
+                this.logger.error(`Failed to mark UKU mastered for uid=${uid} kuId=${txResult.kuId}`, e);
+            }
+        }
+
+        return { success: txResult.success, facetId: txResult.facetId, newStage: txResult.newStage, nextReview: txResult.nextReview };
     }
 
     /**
@@ -226,31 +231,75 @@ export class ReviewsService {
         kuId: string,
         facetsToCreate: { key: string; data?: any }[],
     ) {
+        // Pre-fetch existing facets for the parent KU to prevent duplicates on re-submission
+        const existingParentFacets = await this.getFacetsByKuId(uid, kuId);
+        const existingParentTypes = new Set(existingParentFacets.map(f => f.facetType));
+
         const batch = this.db.batch();
-        let count = 0;
+        let count = 0;                        // review facets created for the parent KU
+        let kanjiLinked = 0;                  // Kanji component stubs linked
+        const kanjiLinkedKuIds: { kuId: string; newFacetCount: number }[] = [];
         const now = Timestamp.now();
-        let parentFacetCount = 0; // Correctly track parent's direct facets
 
         for (const facet of facetsToCreate) {
             const { key, data } = facet;
-            this.logger.log(`Generating review facet ${key} for KU ${kuId}`);
-            let targetKuId = kuId; // Default to the parent KU (Vocab)
+            this.logger.log(`Processing facet ${key} for KU ${kuId}`);
+            const targetKuId = kuId;
 
             // --- Handle Kanji Components ---
             if (key.startsWith('Kanji-Component-') && key !== 'Kanji-Component-Meaning' && key !== 'Kanji-Component-Reading') {
                 const parts = key.split('-');
                 if (parts.length === 3) {
                     const kanjiChar = parts[2];
-                    targetKuId = await this.knowledgeUnitsService.ensureKanjiStub(kanjiChar, data);
+                    const kanjiKuId = await this.knowledgeUnitsService.ensureKanjiStub(kanjiChar, data);
+                    await this.userKnowledgeUnitsService.create(uid, kanjiKuId);
+
+                    // Dedup: only create facets that don't already exist on the Kanji KU
+                    const existingKanjiFacets = await this.getFacetsByKuId(uid, kanjiKuId);
+                    const existingKanjiTypes = new Set(existingKanjiFacets.map(f => f.facetType));
+                    let newFacetCount = 0;
+
+                    if (!existingKanjiTypes.has('Kanji-Component-Meaning')) {
+                        batch.set(this.facetsColRef(uid).doc(), {
+                            kuId: kanjiKuId,
+                            facetType: 'Kanji-Component-Meaning',
+                            srsStage: 0,
+                            nextReviewAt: now,
+                            createdAt: now,
+                            history: [],
+                            ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
+                            data: { content: kanjiChar, meaning: data?.meaning },
+                        });
+                        newFacetCount++;
+                    }
+
+                    if (!existingKanjiTypes.has('Kanji-Component-Reading')) {
+                        batch.set(this.facetsColRef(uid).doc(), {
+                            kuId: kanjiKuId,
+                            facetType: 'Kanji-Component-Reading',
+                            srsStage: 0,
+                            nextReviewAt: now,
+                            createdAt: now,
+                            history: [],
+                            ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
+                            data: { content: kanjiChar, onyomi: data?.onyomi, kunyomi: data?.kunyomi },
+                        });
+                        newFacetCount++;
+                    }
+
+                    kanjiLinkedKuIds.push({ kuId: kanjiKuId, newFacetCount });
+                    kanjiLinked++;
                 }
-                // At this point we should have a KU for the Kanji Component, so skip the rest of the loop
                 continue;
             }
 
-            let modifiedData: any = undefined;
-            if (data) {
-                modifiedData = { ...data };
+            // Dedup: skip standard facets that already exist for the parent KU
+            if (existingParentTypes.has(key)) {
+                this.logger.log(`Skipping duplicate facet ${key} for KU ${kuId}`);
+                continue;
             }
+
+            let modifiedData = data ? { ...data } : undefined;
 
             if (key === 'audio' && modifiedData?.contextExample && modifiedData?.content) {
                 try {
@@ -277,20 +326,34 @@ export class ReviewsService {
             count++;
         }
 
-        if (count > 0) {
+        await batch.commit();
+
+        // Update parent UKU (vocab/grammar) if any facets or kanji components were selected
+        if (count > 0 || kanjiLinked > 0) {
             try {
-                await this.knowledgeUnitsService.update(kuId, {
+                await this.userKnowledgeUnitsService.update(uid, kuId, {
                     status: 'reviewing',
-                    // Atomically increment existing value by count
-                    facet_count: FieldValue.increment(count)
+                    ...(count > 0 ? { facet_count: FieldValue.increment(count) } : {}),
                 });
-                this.logger.log(`Updated parent KU ${kuId}: status=reviewing, facet_count+=${count}`);
+                this.logger.log(`Updated UKU for uid=${uid} kuId=${kuId}: status=reviewing${count > 0 ? `, facet_count+=${count}` : ''}`);
             } catch (e) {
-                this.logger.error(`Failed to update parent KU ${kuId}`, e);
+                this.logger.error(`Failed to update UKU for uid=${uid} kuId=${kuId}`, e);
             }
         }
 
-        await batch.commit();
+        // Update each Kanji UKU to reviewing in parallel
+        await Promise.all(kanjiLinkedKuIds.map(async ({ kuId: kanjiKuId, newFacetCount }) => {
+            try {
+                await this.userKnowledgeUnitsService.update(uid, kanjiKuId, {
+                    status: 'reviewing',
+                    ...(newFacetCount > 0 ? { facet_count: FieldValue.increment(newFacetCount) } : {}),
+                });
+                this.logger.log(`Updated Kanji UKU for uid=${uid} kuId=${kanjiKuId}: status=reviewing${newFacetCount > 0 ? `, facet_count+=${newFacetCount}` : ''}`);
+            } catch (e) {
+                this.logger.error(`Failed to update Kanji UKU for uid=${uid} kuId=${kanjiKuId}`, e);
+            }
+        }));
+
         return { success: true, count };
     } // END generateReviewFacets
 

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -233,7 +233,7 @@ export class ReviewsService {
     ) {
         // Pre-fetch existing facets for the parent KU to prevent duplicates on re-submission
         const existingParentFacets = await this.getFacetsByKuId(uid, kuId);
-        const existingParentTypes = new Set(existingParentFacets.map(f => f.facetType));
+        const existingParentTypes = new Set<string>(existingParentFacets.map(f => f.facetType));
 
         const batch = this.db.batch();
         let count = 0;                        // review facets created for the parent KU

--- a/backend/src/scenarios/scenarios.controller.ts
+++ b/backend/src/scenarios/scenarios.controller.ts
@@ -35,7 +35,14 @@ export class ScenariosController {
   }
 
   @Get()
-  async getAllScenarios(@UserId() uid: string, @Query('days') days?: string) {
+  async getAllScenarios(
+    @UserId() uid: string,
+    @Query('days') days?: string,
+    @Query('sourceKuId') sourceKuId?: string,
+  ) {
+    if (sourceKuId) {
+      return this.scenariosService.getScenariosBySourceKuId(uid, sourceKuId);
+    }
     const limitDays = days ? parseInt(days, 10) : undefined;
     if (limitDays !== undefined && isNaN(limitDays)) {
       throw new BadRequestException('Invalid days parameter');

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -47,6 +47,18 @@ export class ScenariosService {
     return snapshot.docs.map(doc => doc.data() as Scenario);
   }
 
+  async getScenariosBySourceKuId(userId: string, sourceKuId: string): Promise<Pick<Scenario, 'id' | 'title' | 'sourceContextSentence' | 'createdAt'>[]> {
+    const snapshot = await this.collectionRef
+      .where('userId', '==', userId)
+      .where('sourceKuId', '==', sourceKuId)
+      .orderBy('createdAt', 'desc')
+      .get();
+    return snapshot.docs.map(doc => {
+      const d = doc.data() as Scenario;
+      return { id: doc.id, title: d.title, sourceContextSentence: d.sourceContextSentence, createdAt: d.createdAt };
+    });
+  }
+
   getTemplates(): ScenarioTemplate[] {
     return SCENARIO_TEMPLATES;
   }
@@ -104,7 +116,8 @@ export class ScenariosService {
         isActive: true,
         sourceType: dto.sourceType,
         sourceContextSentence: dto.sourceContextSentence,
-        targetVocab: dto.targetVocab
+        targetVocab: dto.targetVocab,
+        sourceKuId: dto.sourceKuId
       };
 
       // console.log(newScenario);

--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Firestore, Timestamp, Transaction } from 'firebase-admin/firestore';
 import {
     FIRESTORE_CONNECTION,
-    KNOWLEDGE_UNITS_COLLECTION,
     REVIEW_FACETS_COLLECTION,
     USER_STATS_COLLECTION,
     USER_KUS_SUBCOLLECTION,
@@ -19,20 +18,14 @@ export class StatsService {
 
     async getDashboardStats(uid: string) {
         // ... existing queries ...
-        const learnQuery = this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-            .where("userId", "==", uid)
-            .where("status", "==", "learning")
-            .count()
-            .get();
-
         const ukuLearnQuery = this.db.collection('users').doc(uid)
             .collection(USER_KUS_SUBCOLLECTION)
             .where("status", "==", "learning")
             .count()
             .get();
 
-        const reviewQuery = this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-            .where("userId", "==", uid)
+        const reviewQuery = this.db.collection('users').doc(uid)
+            .collection(USER_KUS_SUBCOLLECTION)
             .where("status", "==", "reviewing")
             .count()
             .get();
@@ -49,8 +42,7 @@ export class StatsService {
         // New: Fetch User Stats Document
         const userStatsQuery = this.db.collection(USER_STATS_COLLECTION).doc(uid).get();
 
-        const [learnSnapshot, ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc] = await Promise.all([
-            learnQuery,
+        const [ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc] = await Promise.all([
             ukuLearnQuery,
             reviewQuery,
             reviewsDueQuery,
@@ -131,7 +123,7 @@ export class StatsService {
         }
 
         return {
-            learnCount: learnSnapshot.data().count + ukuLearnSnapshot.data().count,
+            learnCount: ukuLearnSnapshot.data().count,
             reviewCount: totalActive,
             reviewsDue: reviewsDueCount,
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -245,8 +245,6 @@ export interface KnowledgeUnitBase {
   /** @deprecated migrating to User state models */
   createdAt: Timestamp;
   /** @deprecated migrating to User state models */
-  status: "learning" | "reviewing";
-  /** @deprecated migrating to User state models */
   facet_count: number;
   /** @deprecated migrating to User state models */
   history?: any[];
@@ -355,7 +353,7 @@ export interface UserKnowledgeUnit {
   personalNotes: string;
   userNotes?: string;
   createdAt: Timestamp;
-  status: "learning" | "reviewing";
+  status: "learning" | "reviewing" | "mastered";
   facet_count: number;
   history?: any[];
 }

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -104,6 +104,7 @@ export interface Scenario {
     sourceType?: 'library' | 'custom' | 'context-example';
     sourceContextSentence?: string;
     targetVocab?: string;
+    sourceKuId?: string;
     isActive?: boolean;
 }
 
@@ -148,6 +149,9 @@ export class GenerateScenarioDto {
     sourceType?: 'library' | 'custom' | 'context-example';
     sourceContextSentence?: string;
     targetVocab?: string;
+    sourceKuId?: string;
+    userRole?: string;
+    aiRole?: string;
 }
 
 // FIX: DTOs must be Classes for NestJS reflection/validation to work

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -48,6 +48,9 @@ export class UserKnowledgeUnitsService {
         personalNotes: uku.personalNotes,
         userNotes: uku.userNotes,
         createdAt: (kuData.createdAt as Timestamp).toDate().toISOString(),
+        // UKU state fields — projected onto the KU shape for the client
+        ukuStatus: uku.status,
+        ukuFacetCount: uku.facet_count,
       } as unknown as KnowledgeUnit);
     }
 
@@ -64,6 +67,16 @@ export class UserKnowledgeUnitsService {
       .where('status', '==', 'learning')
       .get();
     return this._joinKUs(uid, snapshot);
+  }
+
+  async update(uid: string, kuId: string, data: Record<string, any>): Promise<void> {
+    const uku = await this.findByKuId(uid, kuId);
+    if (!uku) {
+      this.logger.warn(`update: no UKU found for uid=${uid} kuId=${kuId}`);
+      return;
+    }
+    await this.userKusRef(uid).doc(uku.id).update(data);
+    this.logger.log(`Updated UKU ${uku.id} for uid=${uid} kuId=${kuId}`);
   }
 
   async create(uid: string, kuId: string): Promise<UserKnowledgeUnit> {

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -30,6 +30,9 @@ export default function LearnItemPage() {
     {},
   );
   const [userGrammarLessons, setUserGrammarLessons] = useState<UserGrammarLesson[]>([]);
+  const [existingFacets, setExistingFacets] = useState<any[] | null>(null);
+  // scenarios keyed by sourceContextSentence so each context example can show its link
+  const [kuScenarios, setKuScenarios] = useState<Record<string, { id: string; title: string }>>({});
 
   const fetchVocabLesson = async (ku: KnowledgeUnit) => {
     setIsLoading(true);
@@ -73,24 +76,18 @@ export default function LearnItemPage() {
         lessonData.component_kanji &&
         lessonData.component_kanji.length > 0
       ) {
-        const kanjiChars = lessonData.component_kanji.map((k) => k.kanji);
-        const response = await apiFetch(
-          "/api/knowledge-units/get-all?status=learning&content=" +
-            kanjiChars.join(","),
-        );
+        const kanjiChars = new Set(lessonData.component_kanji.map((k) => k.kanji));
+        const response = await apiFetch("/api/knowledge-units/get-all?status=user");
 
         if (!response.ok) throw new Error(response.statusText);
 
-        const data = (await response.json()) as KnowledgeUnit[]; // Cast here
-
-        const kanjiKus = data.map(
-          (thing: KnowledgeUnit) => ({ ...thing }) as KnowledgeUnit,
-        );
+        const data = (await response.json()) as KnowledgeUnit[];
 
         const statuses: Record<string, string> = {};
-
-        kanjiKus.forEach((kanjiKu) => {
-          statuses[kanjiKu.content] = kanjiKu.status;
+        data.forEach((ku) => {
+          if (kanjiChars.has(ku.content) && (ku as any).ukuStatus) {
+            statuses[ku.content] = (ku as any).ukuStatus;
+          }
         });
 
         setKanjiStatuses(statuses);
@@ -154,12 +151,30 @@ export default function LearnItemPage() {
         setKu(kuData);
 
         // 2. Branch Logic
-        if (kuData.type === "Vocab") {
-          await fetchVocabLesson(kuData);
-        } else if (kuData.type === "Kanji") {
-          await fetchKanjiLesson(kuData);
-        } else if (kuData.type === "Grammar") {
-          await fetchGrammarLesson(kuData);
+        const [, facetsRes, scenariosRes] = await Promise.all([
+          kuData.type === "Vocab"
+            ? fetchVocabLesson(kuData)
+            : kuData.type === "Kanji"
+              ? fetchKanjiLesson(kuData)
+              : fetchGrammarLesson(kuData),
+          apiFetch(`/api/reviews/facets?kuId=${kuData.id}`),
+          apiFetch(`/api/scenarios?sourceKuId=${kuData.id}`),
+        ]);
+
+        if (facetsRes.ok) {
+          const facets = await facetsRes.json();
+          setExistingFacets(Array.isArray(facets) ? facets : []);
+        } else {
+          setExistingFacets([]);
+        }
+
+        if (scenariosRes.ok) {
+          const scenarios = await scenariosRes.json() as { id: string; title: string; sourceContextSentence?: string }[];
+          const byContextSentence: Record<string, { id: string; title: string }> = {};
+          scenarios.forEach(s => {
+            if (s.sourceContextSentence) byContextSentence[s.sourceContextSentence] = { id: s.id, title: s.title };
+          });
+          setKuScenarios(byContextSentence);
         }
       } catch (err: any) {
         setError(err.message);
@@ -217,16 +232,17 @@ export default function LearnItemPage() {
         const index = parseInt(indexStr, 10);
         const ex = vocabLesson.context_examples?.[index];
 
-        if (ex) {
+        if (ex && !kuScenarios[ex.sentence]) {
           const p = apiFetch("/api/scenarios/generate", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              difficulty: "N4", // Default baseline for context examples
+              difficulty: "N4",
               theme: "Practice vocabulary in context",
               sourceType: "context-example",
               sourceContextSentence: ex.sentence,
               targetVocab: ku.content,
+              sourceKuId: ku.id,
             }),
           }).then(async (res) => {
             if (!res.ok) {
@@ -383,7 +399,12 @@ export default function LearnItemPage() {
       await Promise.all(promises);
 
       window.dispatchEvent(new CustomEvent("refreshStats"));
-      router.push("/learn");
+      setSelectedFacets({});
+      const updated = await apiFetch(`/api/reviews/facets?kuId=${ku.id}`);
+      if (updated.ok) {
+        const facets = await updated.json();
+        setExistingFacets(Array.isArray(facets) ? facets : []);
+      }
     } catch (err: any) {
       setError(err.message || "An unknown error occurred.");
     } finally {
@@ -416,82 +437,135 @@ export default function LearnItemPage() {
     }
   };
 
-  const renderFacetChecklist = () => (
-    <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg">
-      <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
-        Choose What to Learn
-      </h2>
-      <div className="space-y-4">
-        {lesson?.type === "Vocab" && (
-          <>
-            <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-              <input
-                type="checkbox"
-                className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                checked={!!selectedFacets["Definition-to-Content"]} // the !! makes sure that the evaluation is boolean and not undefined or null
-                onChange={() => handleCheckboxChange("Definition-to-Content")}
-              />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                Content
-              </span>
-            </label>
-            <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-              <input
-                type="checkbox"
-                className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                checked={!!selectedFacets["Content-to-Definition"]} // the !! makes sure that the evaluation is boolean and not undefined or null
-                onChange={() => handleCheckboxChange("Content-to-Definition")}
-              />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                Meaning
-              </span>
-            </label>
-            {ku?.type === 'Vocab' && ku.data.reading !== ku?.content && (
-              <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-                <input
-                  type="checkbox"
-                  className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                  checked={!!selectedFacets["Content-to-Reading"]}
-                  onChange={() => handleCheckboxChange("Content-to-Reading")}
-                />
-                <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                  Reading
-                </span>
-              </label>
-            )}
+  const renderFacetChecklist = (existingFacetTypes: Set<string>) => {
+    const isAddMore = existingFacetTypes.size > 0;
 
-            {lesson.type === "Vocab" && (lesson as VocabLesson).context_examples && (lesson as VocabLesson).context_examples!.length > 0 && (
-              <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-                <input
-                  type="checkbox"
-                  className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                  checked={!!selectedFacets["audio"]}
-                  onChange={() => handleCheckboxChange("audio")}
-                />
-                <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                  Audio Comprehension
-                </span>
-              </label>
-            )}
+    // Determine which standard options remain unconfigured
+    const hasReadingFacet = ku?.type === "Vocab" && (ku as any).data?.reading !== ku?.content;
+    const hasAudio = lesson?.type === "Vocab" && ((lesson as VocabLesson).context_examples?.length ?? 0) > 0;
+    const hasContextExamples = lesson?.type === "Vocab" && ((lesson as VocabLesson).context_examples?.length ?? 0) > 0;
+    const availableKanjiComponents = lesson?.type === "Vocab"
+      ? ((lesson as VocabLesson).component_kanji ?? []).filter(k => !kanjiStatuses[k.kanji])
+      : [];
 
-            {/* --- REFACTOR: Conditional Component Kanji Display --- */}
-            {lesson.component_kanji &&
-              lesson.component_kanji.map((kanji, index) => {
+    const newVocabKeys = lesson?.type === "Vocab" ? (["Definition-to-Content", "Content-to-Definition",
+      ...(hasReadingFacet ? ["Content-to-Reading"] : []),
+      ...(hasAudio ? ["audio"] : []),
+      "AI-Generated-Question",
+    ] as string[]).filter(k => !existingFacetTypes.has(k)) : [];
+
+    const newKanjiKeys = lesson?.type === "Kanji" ? (["Kanji-Component-Meaning", "Kanji-Component-Reading", "AI-Generated-Question"] as string[])
+      .filter(k => !existingFacetTypes.has(k)) : [];
+
+    const anythingLeft = lesson?.type === "Vocab"
+      ? newVocabKeys.length > 0 || availableKanjiComponents.length > 0 || hasContextExamples
+      : lesson?.type === "Kanji"
+        ? newKanjiKeys.length > 0
+        : !existingFacetTypes.has("AI-Generated-Question");
+
+    const noneSelected = Object.values(selectedFacets).every(v => !v);
+
+    const FACET_LABELS: Record<string, string> = {
+      "Definition-to-Content": "Content",
+      "Content-to-Definition": "Meaning",
+      "Content-to-Reading": "Reading",
+      "audio": "Audio Comprehension",
+      "Kanji-Component-Meaning": "Meaning (Kanji → Meaning)",
+      "Kanji-Component-Reading": "Reading (Kanji → On/Kun)",
+      "AI-Generated-Question": "AI-Generated Questions",
+      "sentence-assembly": "Sentence Assembly",
+    };
+
+    return (
+      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+          {isAddMore ? "Select Additional Items to Review" : "Choose What to Learn"}
+        </h2>
+
+        {existingFacets && existingFacets.length > 0 && (
+          <div className="mb-6">
+            <div className="space-y-4">
+              {existingFacets.map((f: any) => {
+                const label = FACET_LABELS[f.facetType];
+                if (!label) return null;
+                return (
+                  <label key={f.id} className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md opacity-60 cursor-not-allowed">
+                    <input
+                      type="checkbox"
+                      className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600"
+                      checked={true}
+                      disabled
+                      onChange={() => {}}
+                    />
+                    <span className="ml-3 text-lg text-gray-900 dark:text-white">{label}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {isAddMore && !anythingLeft ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            All available facets are already configured.
+          </p>
+        ) : (
+        <div className="space-y-4">
+          {lesson?.type === "Vocab" && (
+            <>
+              {!existingFacetTypes.has("Definition-to-Content") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["Definition-to-Content"]}
+                    onChange={() => handleCheckboxChange("Definition-to-Content")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Content</span>
+                </label>
+              )}
+              {!existingFacetTypes.has("Content-to-Definition") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["Content-to-Definition"]}
+                    onChange={() => handleCheckboxChange("Content-to-Definition")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Meaning</span>
+                </label>
+              )}
+              {hasReadingFacet && !existingFacetTypes.has("Content-to-Reading") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["Content-to-Reading"]}
+                    onChange={() => handleCheckboxChange("Content-to-Reading")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Reading</span>
+                </label>
+              )}
+              {hasAudio && !existingFacetTypes.has("audio") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["audio"]}
+                    onChange={() => handleCheckboxChange("audio")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Audio Comprehension</span>
+                </label>
+              )}
+
+              {(lesson as VocabLesson).component_kanji?.map((kanji, index) => {
                 const status = kanjiStatuses[kanji.kanji];
                 return (
-                  <div
-                    key={`${kanji.kanji}-${index}`}
-                    className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md"
-                  >
-                    <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                      Component Kanji
-                    </h3>
+                  <div key={`${kanji.kanji}-${index}`} className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
+                    <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Component Kanji</h3>
                     <p className="text-gray-600 dark:text-gray-400 mb-3">
-                      The kanji is{" "}
-                      <span className="font-bold text-lg">{kanji.kanji}</span>,
-                      which generally means "{kanji.meaning}".
+                      The kanji is <span className="font-bold text-lg">{kanji.kanji}</span>, which generally means "{kanji.meaning}".
                     </p>
-
                     {status ? (
                       <div className="p-2 bg-gray-400 dark:bg-gray-700 rounded-md">
                         <p className="text-lg text-gray-800 dark:text-gray-200">
@@ -503,116 +577,123 @@ export default function LearnItemPage() {
                     ) : (
                       <>
                         <p className="text-gray-600 dark:text-gray-400 mb-3">
-                          In this word, it uses the reading{" "}
-                          <span className="font-bold text-lg">
-                            {kanji.reading}
-                          </span>
-                          .
+                          In this word, it uses the reading <span className="font-bold text-lg">{kanji.reading}</span>.
                         </p>
                         <label className="flex items-center p-2 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
                           <input
                             type="checkbox"
                             className="h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                            checked={
-                              !!selectedFacets[`Kanji-Component-${kanji.kanji}`]
-                            }
-                            onChange={() =>
-                              handleCheckboxChange(
-                                `Kanji-Component-${kanji.kanji}`,
-                              )
-                            }
+                            checked={!!selectedFacets[`Kanji-Component-${kanji.kanji}`]}
+                            onChange={() => handleCheckboxChange(`Kanji-Component-${kanji.kanji}`)}
                           />
-                          <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                            Add {kanji.kanji}
-                          </span>
+                          <span className="ml-3 text-lg text-gray-900 dark:text-white">Add {kanji.kanji}</span>
                         </label>
                       </>
                     )}
                   </div>
                 );
               })}
-            {/* --- END REFACTOR --- */}
 
-            {/* --- Context Example Scenarios --- */}
-            {lesson.type === "Vocab" && (lesson as VocabLesson).context_examples && ((lesson as VocabLesson).context_examples?.length || 0) > 0 && (
-              <div className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
-                <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                  Context Example Scenarios
-                </h3>
-                <p className="text-gray-600 dark:text-gray-400 mb-3 block">
-                  Select examples to instantly architect roleplay scenarios where you must use the word <strong>{ku?.content}</strong> in context.
-                </p>
-                <div className="space-y-3">
-                  {(lesson as VocabLesson).context_examples?.map((ex, index) => (
-                    <label key={index} className="flex items-start p-3 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        className="mt-1 h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                        checked={!!selectedFacets[`Context-Example-${index}`]}
-                        onChange={() => handleCheckboxChange(`Context-Example-${index}`)}
-                      />
-                      <span className="ml-3 text-lg text-gray-900 dark:text-white flex flex-col">
-                        <span>{ex.sentence}</span>
-                        <span className="text-sm text-gray-600 dark:text-gray-400">{ex.translation}</span>
-                      </span>
-                    </label>
-                  ))}
+              {hasContextExamples && (
+                <div className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
+                  <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Context Example Scenarios</h3>
+                  <p className="text-gray-600 dark:text-gray-400 mb-3 block">
+                    Select examples to instantly architect roleplay scenarios where you must use the word <strong>{ku?.content}</strong> in context.
+                  </p>
+                  <div className="space-y-3">
+                    {(lesson as VocabLesson).context_examples?.map((ex, index) => {
+                      const existing = kuScenarios[ex.sentence];
+                      if (existing) {
+                        return (
+                          <div key={index} className="flex items-start p-3 rounded-md bg-gray-400 dark:bg-gray-700">
+                            <span className="mt-1 h-5 w-5 flex items-center justify-center text-green-600 dark:text-green-400 font-bold text-sm flex-shrink-0">✓</span>
+                            <div className="ml-3 flex flex-col">
+                              <span className="text-lg text-gray-900 dark:text-white">{ex.sentence}</span>
+                              <span className="text-sm text-gray-600 dark:text-gray-400">{ex.translation}</span>
+                              <a
+                                href={`/scenarios/${existing.id}`}
+                                className="mt-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                              >
+                                → View scenario
+                              </a>
+                            </div>
+                          </div>
+                        );
+                      }
+                      return (
+                        <label key={index} className="flex items-start p-3 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="mt-1 h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                            checked={!!selectedFacets[`Context-Example-${index}`]}
+                            onChange={() => handleCheckboxChange(`Context-Example-${index}`)}
+                          />
+                          <span className="ml-3 text-lg text-gray-900 dark:text-white flex flex-col">
+                            <span>{ex.sentence}</span>
+                            <span className="text-sm text-gray-600 dark:text-gray-400">{ex.translation}</span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            )}
-            {/* --- End Context Example Scenarios --- */}
-          </>
-        )}
+              )}
+            </>
+          )}
 
-        {lesson?.type === "Kanji" && (
-          <>
+          {lesson?.type === "Kanji" && (
+            <>
+              {!existingFacetTypes.has("Kanji-Component-Meaning") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["Kanji-Component-Meaning"]}
+                    onChange={() => handleCheckboxChange("Kanji-Component-Meaning")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Meaning (Kanji {"->"} Meaning)</span>
+                </label>
+              )}
+              {!existingFacetTypes.has("Kanji-Component-Reading") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["Kanji-Component-Reading"]}
+                    onChange={() => handleCheckboxChange("Kanji-Component-Reading")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">Reading (Kanji {"->"} On/Kun)</span>
+                </label>
+              )}
+            </>
+          )}
+
+          {!existingFacetTypes.has("AI-Generated-Question") && (
             <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
               <input
                 type="checkbox"
                 className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                checked={!!selectedFacets["Kanji-Component-Meaning"]}
-                onChange={() => handleCheckboxChange("Kanji-Component-Meaning")}
+                checked={!!selectedFacets["AI-Generated-Question"]}
+                onChange={() => handleCheckboxChange("AI-Generated-Question")}
               />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                Meaning (Kanji {"->"} Meaning)
-              </span>
+              <span className="ml-3 text-lg text-gray-900 dark:text-white">AI-Generated Questions</span>
             </label>
-            <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-              <input
-                type="checkbox"
-                className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                checked={!!selectedFacets["Kanji-Component-Reading"]}
-                onChange={() => handleCheckboxChange("Kanji-Component-Reading")}
-              />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">
-                Reading (Kanji {"->"} On/Kun)
-              </span>
-            </label>
-          </>
+          )}
+        </div>
         )}
 
-        <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-          <input
-            type="checkbox"
-            className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-            checked={!!selectedFacets["AI-Generated-Question"]}
-            onChange={() => handleCheckboxChange("AI-Generated-Question")}
-          />
-          <span className="ml-3 text-lg text-gray-900 dark:text-white">
-            AI-Generated Questions
-          </span>
-        </label>
+        {!(isAddMore && !anythingLeft) && (
+          <button
+            onClick={handleSubmitFacets}
+            disabled={isSubmitting || !lesson || noneSelected}
+            className="mt-6 w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700 disabled:bg-gray-500 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "Saving..." : isAddMore ? "Add Selected Facets" : "Start Learning Selected Items"}
+          </button>
+        )}
       </div>
-
-      <button
-        onClick={handleSubmitFacets}
-        disabled={isSubmitting || !lesson}
-        className="mt-6 w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700 disabled:bg-gray-500 disabled:cursor-wait"
-      >
-        {isSubmitting ? "Saving..." : "Start Learning Selected Items"}
-      </button>
-    </div>
-  );
+    );
+  };
 
   // Used to determine if the call to this page came from the review facet
   const searchParams = useSearchParams();
@@ -679,26 +760,24 @@ export default function LearnItemPage() {
           />
         )}
 
-        {!isLoading && !error && lesson && source !== "review" && ku?.type !== "Grammar" && (
-          <>
-            {renderFacetChecklist()}
-          </>
-        )}
-
-        {!isLoading && !error && lesson && source !== "review" && ku?.type === "Grammar" && (
-          <div className="mt-6">
-            {error && (
-              <div className="mb-4 text-red-600 text-sm">{error}</div>
-            )}
-            <button
-              onClick={handleSubmitFacets}
-              disabled={isSubmitting || !lesson}
-              className="w-full py-4 text-lg bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSubmitting ? "Saving..." : "Start Learning Selected Items"}
-            </button>
-          </div>
-        )}
+        {!isLoading && !error && lesson && source !== "review" && (() => {
+          const existingFacetTypes = new Set<string>((existingFacets ?? []).map((f: any) => f.facetType));
+          if (ku?.type !== "Grammar") {
+            return renderFacetChecklist(existingFacetTypes);
+          }
+          return (
+            <div>
+              {error && <div className="mb-4 text-red-600 text-sm">{error}</div>}
+              <button
+                onClick={handleSubmitFacets}
+                disabled={isSubmitting || !lesson}
+                className="w-full py-4 text-lg bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? "Saving..." : existingFacets && existingFacets.length > 0 ? "Add Selected Facets" : "Start Learning Selected Items"}
+              </button>
+            </div>
+          );
+        })()}
       </main>
     </>
   );

--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -5,89 +5,155 @@ import Link from "next/link";
 import { KnowledgeUnit } from "@/types";
 import { apiFetch } from "@/lib/api-client";
 
+type KUWithStatus = KnowledgeUnit & {
+  ukuStatus?: "learning" | "reviewing" | "mastered";
+  ukuFacetCount?: number;
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  learning: "#E08A46", // shodo-persimmon
+  reviewing: "#2E4B75", // shodo-indigo
+  mastered: "#C7A04D", // shodo-gold
+};
+
+const STATUS_BORDER_COLORS: Record<string, string> = {
+  learning: "#B36E38", // persimmon -20%
+  reviewing: "#253C5E", // indigo -20%
+  mastered: "#9F803E", // gold -20%
+};
+
+const TYPE_STYLES: Record<string, string> = {
+  Vocab: "text-shodo-ink-light",
+  Kanji: "text-shodo-stamp-red",
+  Grammar: "text-shodo-matcha",
+};
+
+// Hex values from tailwind.config.ts — used via style prop to guarantee rendering
+const TYPE_COLORS: Record<string, string> = {
+  Vocab: "#2E4B75", // shodo-indigo
+  Kanji: "#595048", // shodo-ink-light (deep ink-brown)
+  Grammar: "#7B8D42", // shodo-matcha
+};
+
 export default function LearnListPage() {
-  const [learningItems, setLearningItems] = useState<KnowledgeUnit[]>([]);
+  const [items, setItems] = useState<KUWithStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
 
-    const fetchLearningItems = async () => {
-      // TODO use backend service instead of calling Firestore directly
+    apiFetch("/api/knowledge-units/get-all?status=user", { signal: controller.signal })
+      .then(res => {
+        if (!res.ok) throw new Error(res.statusText);
+        return res.json();
+      })
+      .then((data: KUWithStatus[]) => setItems(data))
+      .catch(err => { if (err.name !== "AbortError") setError(err.message || "Failed to fetch"); })
+      .finally(() => setIsLoading(false));
 
-      try {
-        const response = await apiFetch(
-          "/api/knowledge-units/get-all?status=learning",
-          {
-            signal: controller.signal,
-          },
-        );
-
-        if (!response.ok) throw new Error(response.statusText);
-
-        const data = (await response.json()) as KnowledgeUnit[]; // Cast here
-
-        const items = data.map(
-          (thing: KnowledgeUnit) => ({ ...thing }) as KnowledgeUnit,
-        );
-
-        setLearningItems(items);
-      } catch (err: any) {
-        if (err.name === "AbortError") {
-          return;
-        }
-        setError(err.message || "Failed to fetch");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchLearningItems();
     return () => controller.abort();
   }, []);
 
-  const renderList = () => {
-    if (isLoading) {
-      return <p className="text-gray-400">Loading learning items...</p>;
-    }
-    if (error) {
-      return <p className="text-red-400">Error: {error}</p>;
-    }
-    if (learningItems.length === 0) {
-      return <p className="text-gray-400">Your learning queue is empty.</p>;
-    }
+  const learning = items.filter(k => k.ukuStatus === "learning");
+  const reviewing = items.filter(k => k.ukuStatus === "reviewing");
+  const mastered = items.filter(k => k.ukuStatus === "mastered");
 
-    return (
-      <ul className="space-y-4">
-        {learningItems.map((ku) => (
-          <li key={ku.id}>
+  const renderSection = (title: string, rows: KUWithStatus[], emptyText: string) => (
+    <section>
+      <h2 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint mb-2 px-1">
+        {title} <span className="ml-1 text-shodo-ink-faint font-normal">({rows.length})</span>
+      </h2>
+      {rows.length === 0 ? (
+        <p className="text-sm text-shodo-ink-faint px-1 pb-4">{emptyText}</p>
+      ) : (
+        <div className="rounded-lg border border-shodo-paper-dark overflow-hidden mb-6">
+          {rows.map((ku, i) => (
             <Link
+              key={ku.id}
               href={`/learn/${ku.id}`}
-              className="block p-6 bg-gray-800 rounded-lg shadow-lg hover:bg-gray-700 transition-colors"
+              style={{ borderLeftColor: TYPE_COLORS[ku.type] ?? "#A69E96" }}
+              className={`flex items-center gap-3 pl-3 pr-4 py-2.5 border-l-4 hover:bg-shodo-paper-dark transition-colors
+                ${i < rows.length - 1 ? "border-b border-shodo-paper-dark" : ""}
+                dark:hover:bg-gray-700`}
             >
-              <div className="flex justify-between items-center mb-2">
-                <span className="text-3xl font-bold text-white">
-                  {ku.content}
-                </span>
-                <span className="font-mono text-sm bg-gray-900 text-gray-100 px-2 py-1 rounded">
-                  {ku.type}
-                </span>
-              </div>
-              {ku.personalNotes && (
-                <p className="mt-2 text-gray-300 italic">{ku.personalNotes}</p>
-              )}
+              {/* Japanese content — coloured by type */}
+              <span
+                style={{ color: TYPE_COLORS[ku.type] }}
+                className="text-xl font-bold min-w-[5rem] dark:text-white"
+              >
+                {ku.content}
+              </span>
+
+              {/* Reading / definition hint — always flex-1 to anchor fixed columns */}
+              <span className="flex-1 truncate text-sm text-shodo-ink-light dark:text-gray-400">
+                {ku.type === "Vocab" && (ku as any).data?.reading && (ku as any).data.reading !== ku.content
+                  ? (ku as any).data.reading
+                  : ku.type === "Grammar" && (ku as any).data?.title
+                    ? (ku as any).data.title
+                    : ku.type === "Kanji" && (ku as any).data?.meaning
+                      ? (ku as any).data.meaning
+                      : ""}
+              </span>
+
+              {/* Facet count — fixed width, always present to anchor layout */}
+              <span className="text-xs text-shodo-ink-faint w-16 text-right tabular-nums whitespace-nowrap">
+                {ku.ukuFacetCount != null && ku.ukuFacetCount > 0
+                  ? `${ku.ukuFacetCount} ${ku.ukuFacetCount === 1 ? "facet" : "facets"}`
+                  : ""}
+              </span>
+
+              {/* JLPT level — fixed width */}
+              <span className="text-xs text-shodo-ink-faint w-6 text-center">
+                {(ku as any).data?.jlptLevel ?? ""}
+              </span>
+
+              {/* Type — fixed width, always rightmost before badge */}
+              <span className={`text-xs font-medium w-16 text-right ${TYPE_STYLES[ku.type] ?? "text-shodo-ink-light"}`}>
+                {ku.type}
+              </span>
+
+              {/* Status badge */}
+              <span
+                style={{
+                  backgroundColor: STATUS_COLORS[ku.ukuStatus ?? "learning"],
+                  borderColor: STATUS_BORDER_COLORS[ku.ukuStatus ?? "learning"],
+                }}
+                className="text-xs px-2 py-0.5 rounded-full font-medium capitalize w-20 text-center text-white border"
+              >
+                {ku.ukuStatus ?? "learning"}
+              </span>
             </Link>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+          ))}
+        </div>
+      )}
+    </section>
+  );
 
   return (
-    <main className="container mx-auto max-w-4xl p-8">
-      <h1 className="text-4xl font-bold text-white mb-6">Learning Queue</h1>
-      <div className="bg-gray-800 p-6 rounded-lg shadow-lg">{renderList()}</div>
+    <main className="container mx-auto max-w-3xl p-6">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold text-shodo-ink dark:text-white">My Library</h1>
+        <p className="text-sm text-shodo-ink-light dark:text-gray-400 mt-1">
+          {isLoading ? "Loading…" : `${items.length} items`}
+        </p>
+      </header>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="text-shodo-ink-faint text-sm">Loading…</p>
+      ) : (
+        <>
+          {renderSection("Lesson Pending", learning, "Nothing waiting for a lesson.")}
+          {renderSection("In Review", reviewing, "Nothing in review yet.")}
+          {renderSection("Mastered", mastered, "Nothing mastered yet — keep going!")}
+        </>
+      )}
     </main>
   );
 }

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -370,6 +370,15 @@ export default function ScenarioPage({
         </button>
       )}
 
+      {scenario?.sourceKuId && (
+        <a
+          href={`/learn/${scenario.sourceKuId}`}
+          className="mb-2 text-sm text-slate-500 hover:text-indigo-600 transition-colors flex items-center gap-1"
+        >
+          ← Back to Lesson
+        </a>
+      )}
+
       {/* Header Info */}
       <header className="border-b border-slate-200 pb-6">
         <div className="flex justify-between items-start mb-4">

--- a/frontend/src/app/scenarios/page.tsx
+++ b/frontend/src/app/scenarios/page.tsx
@@ -18,6 +18,8 @@ export default function ScenariosDashboard() {
   // Generation Form State
   const [theme, setTheme] = useState("");
   const [difficulty, setDifficulty] = useState<ScenarioDifficulty>("N5");
+  const [userRole, setUserRole] = useState("");
+  const [aiRole, setAiRole] = useState("");
 
   useEffect(() => {
     fetchScenarios();
@@ -49,7 +51,9 @@ export default function ScenariosDashboard() {
         },
         body: JSON.stringify({
           difficulty,
-          theme: theme || undefined, // Send undefined if empty to let AI decide
+          theme: theme || undefined,
+          userRole: userRole || undefined,
+          aiRole: aiRole || undefined,
         }),
       });
 
@@ -133,6 +137,32 @@ export default function ScenariosDashboard() {
                 <option value="N2">N2 (Business)</option>
                 <option value="N1">N1 (Fluent)</option>
               </select>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-600 mb-1">
+                Your Role <span className="text-slate-400 font-normal">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={userRole}
+                onChange={(e) => setUserRole(e.target.value)}
+                placeholder="e.g. Software Engineer"
+                className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600 mb-1">
+                AI Role <span className="text-slate-400 font-normal">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={aiRole}
+                onChange={(e) => setAiRole(e.target.value)}
+                placeholder="e.g. Colleague"
+                className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+              />
             </div>
           </div>
           <div className="flex justify-end">

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -102,6 +102,7 @@ export interface Scenario {
   sourceType?: 'library' | 'custom' | 'context-example';
   sourceContextSentence?: string;
   targetVocab?: string;
+  sourceKuId?: string;
   isActive?: boolean;
 }
 
@@ -151,6 +152,9 @@ export class GenerateScenarioDto {
   sourceType?: 'library' | 'custom' | 'context-example';
   sourceContextSentence?: string;
   targetVocab?: string;
+  sourceKuId?: string;
+  userRole?: string;
+  aiRole?: string;
 }
 
 export class ChatTurnDto {


### PR DESCRIPTION
## Review Facets Overhaul + Lesson ↔ Scenario Linkage                                                                  
                                                                                                                         
  ### Summary
                                                                                                                         
  - **Fix**: Kanji component status detection was broken after `status` moved from global KU to UKU. Lesson page now uses
   `?status=user` + client-side filter on `ukuStatus` instead of the broken `?status=learning&content=` query.
  - **Fix**: Vocab parent UKU now correctly stays at `status=learning` when only Kanji components are selected (condition
   was `count > 0` only; changed to `count > 0 || kanjiLinked > 0`).                                                     
  - **Fix**: `Kanji-Component-Meaning` and `Kanji-Component-Reading` review facets were never being created when a kanji
  component was selected from a Vocab lesson. Both are now auto-created in the same batch write.                         
  - **Fix**: `batch.commit()` was being called after UKU updates — facets could be partially absent if UKU writes
  succeeded first. Moved commit before all UKU updates.                                                                  
  - **Fix**: Duplicate facets could be created if the user submitted the same lesson twice or visited a Kanji lesson
  after selecting that kanji from a Vocab lesson. `generateReviewFacets` now pre-fetches existing facets for the parent  
  KU and each kanji component KU before writing.            
  - **Fix**: Kanji UKU updates were sequential (`for...await`). Changed to `Promise.all` with per-kanji `newFacetCount`  
  so `facet_count` is only incremented for facets that are actually new.                                                 
  - **Feature**: `GET /api/reviews/facets?kuId=` — query existing facets for a KU.
  - **Feature**: Lesson page facet checklist is now conditional — already-configured facet types render as disabled      
  checked items (subsection "Already configured"); unconfigured types remain selectable under "Select Additional Items to
   Review". Submitting stays on the lesson page and re-fetches facets to update UI.                                      
  - **Feature**: Library page (`/learn`) now shows Kanji `data.meaning` in the hint column.                              
  - **Feature**: `sourceKuId` tracked on scenarios generated from context examples. `GET /api/scenarios?sourceKuId=`
  returns slim stubs for that KU. Requires a new Firestore composite index on `(userId, sourceKuId, createdAt)`.         
  - **Feature**: Lesson page shows "✓ View scenario →" per context example when a scenario already exists for that
  sentence, blocking duplicate generation.                                                                               
  - **Feature**: Scenario page (`/scenarios/[id]`) shows "← Back to Lesson" breadcrumb when `sourceKuId` is present.
                                                                                                                         
  ### Files changed                                                                                                      
  
  **Backend**                                                                                                            
  - `backend/src/reviews/reviews.service.ts` — `generateReviewFacets` rewrite (dedup, kanji facets, parallel UKU updates,
   commit order fix)                                                                                                     
  - `backend/src/reviews/reviews.controller.ts` — `?kuId=` query param on `GET /facets`
  - `backend/src/scenarios/scenarios.service.ts` — `sourceKuId` written on generation; `getScenariosBySourceKuId` method 
  - `backend/src/scenarios/scenarios.controller.ts` — `?sourceKuId=` query param on `GET /`                              
  - `backend/src/types/scenario.ts` — `sourceKuId?: string` on `Scenario` and `GenerateScenarioDto`                      
                                                                                                                         
  - `frontend/src/app/learn/[kuId]/page.tsx` — conditional facet checklist, post-submit re-fetch, context example        
  scenario state, kanji status fix                                                                                       
  - `frontend/src/app/learn/page.tsx` — Kanji meaning in hint column                                                     
  - `frontend/src/app/scenarios/[id]/page.tsx` — "← Back to Lesson" breadcrumb
  - `frontend/src/types/scenario.ts` — `sourceKuId?: string` on `Scenario` and `GenerateScenarioDto`                     
                                                                                                                         
  **Infra**                                                                                                              
  - New Firestore composite index: `scenarios` collection, fields `userId ASC, sourceKuId ASC, createdAt DESC`           
                                                                                                                         
  ### Test plan                                                                                                          
  - [ ] Select only kanji components from a Vocab lesson → parent UKU stays `learning`, kanji UKUs move to `reviewing`,
  `Kanji-Component-Meaning`/`Reading` facets created                                                                     
  - [ ] Visit the same Vocab lesson again and re-submit → no duplicate facets created                                    
  - [ ] Visit the Kanji lesson for a component already selected from Vocab → no duplicate facets, `facet_count` not
  incremented again                                                                                                      
  - [ ] Submit a lesson that already has all facet types configured → checklist shows all as disabled; button is absent  
  or inactive                                                                                                            
  - [ ] Submit a partial set, return to lesson → only remaining unconfigured types are selectable                        
  - [ ] Generate a scenario from a context example → "✓ View scenario →" link appears for that example; re-submitting the
   lesson doesn't create a second scenario                                                                               
  - [ ] Open the generated scenario → "← Back to Lesson" link is present and navigates correctly                         
  - [ ] Library page: Kanji items show meaning in hint column      