### PR TITLE
feat: Global/user final migration, scenario hints and KU status badges

### DIFF
--- a/frontend/src/app/concepts/[id]/page.tsx
+++ b/frontend/src/app/concepts/[id]/page.tsx
@@ -141,7 +141,10 @@ export default function ConceptPage() {
         <p className="text-xs font-semibold uppercase tracking-widest text-shodo-accent mb-2">
           Grammar Concept
         </p>
-        <h1 className="text-4xl font-bold text-shodo-ink mb-5">{data.title}</h1>
+        <h1 className="text-4xl font-bold text-shodo-ink mb-1">{data.title}</h1>
+        {data.reading && (
+          <p className="text-lg text-shodo-ink/50 mb-5">{data.reading}</p>
+        )}
         <p className="text-base text-shodo-ink/70 leading-relaxed">{data.overview}</p>
       </section>
 

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -8,6 +8,8 @@ import KanjiLessonView from "@/components/lessons/KanjiLessonView";
 import GrammarLessonView from "@/components/lessons/GrammarLessonView";
 import { apiFetch } from "@/lib/api-client";
 
+const stripFurigana = (s: string) => s.replace(/\[[^\]]*\]/g, '').trim();
+
 export default function LearnItemPage() {
   const router = useRouter();
   const params = useParams();
@@ -31,6 +33,7 @@ export default function LearnItemPage() {
   );
   const [userGrammarLessons, setUserGrammarLessons] = useState<UserGrammarLesson[]>([]);
   const [existingFacets, setExistingFacets] = useState<any[] | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
   // scenarios keyed by sourceContextSentence so each context example can show its link
   const [kuScenarios, setKuScenarios] = useState<Record<string, { id: string; title: string }>>({});
 
@@ -394,6 +397,9 @@ export default function LearnItemPage() {
       promises.push(reviewPromise);
     }
 
+    // Count review items being added (exclude Context-Example scenario generations only)
+    const learningItemCount = reviewFacetKeys.length;
+
     try {
       await Promise.all(promises);
 
@@ -403,6 +409,11 @@ export default function LearnItemPage() {
       if (updated.ok) {
         const facets = await updated.json();
         setExistingFacets(Array.isArray(facets) ? facets : []);
+      }
+
+      if (learningItemCount > 0) {
+        setToast(`${learningItemCount} ${learningItemCount === 1 ? "item" : "items"} added to your Review Queue`);
+        setTimeout(() => setToast(null), 4000);
       }
     } catch (err: any) {
       setError(err.message || "An unknown error occurred.");
@@ -607,8 +618,8 @@ export default function LearnItemPage() {
                           <div key={index} className="flex items-start p-3 rounded-md bg-gray-400 dark:bg-gray-700">
                             <span className="mt-1 h-5 w-5 flex items-center justify-center text-green-600 dark:text-green-400 font-bold text-sm flex-shrink-0">✓</span>
                             <div className="ml-3 flex flex-col">
-                              <span className="text-lg text-gray-900 dark:text-white">{ex.sentence}</span>
-                              <span className="text-sm text-gray-600 dark:text-gray-400">{ex.translation}</span>
+                              <span className="text-lg text-gray-900 dark:text-white">{stripFurigana(ex.sentence)}</span>
+                              <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
                               <a
                                 href={`/scenarios/${existing.id}`}
                                 className="mt-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
@@ -628,8 +639,8 @@ export default function LearnItemPage() {
                             onChange={() => handleCheckboxChange(`Context-Example-${index}`)}
                           />
                           <span className="ml-3 text-lg text-gray-900 dark:text-white flex flex-col">
-                            <span>{ex.sentence}</span>
-                            <span className="text-sm text-gray-600 dark:text-gray-400">{ex.translation}</span>
+                            <span>{stripFurigana(ex.sentence)}</span>
+                            <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
                           </span>
                         </label>
                       );
@@ -701,6 +712,11 @@ export default function LearnItemPage() {
   // --- Main Render ---
   return (
     <>
+      {toast && (
+        <div className="fixed top-4 right-4 z-50 bg-green-600 text-white px-6 py-3 rounded-lg shadow-lg font-semibold animate-in fade-in slide-in-from-top-2">
+          {toast}
+        </div>
+      )}
       <main className="container mx-auto max-w-4xl p-8">
         <header className="mb-8">
           <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-2 break-all">

--- a/frontend/src/app/manage/page.tsx
+++ b/frontend/src/app/manage/page.tsx
@@ -217,13 +217,13 @@ export default function KnowledgeManagementPage() {
                 </button>
               </div>
 
-              {ku.data && ku.data.reading && (
+              {ku.type === "Vocab" && ku.data.reading && (
                 <p className="text-lg text-gray-300 break-all">
                   <span className="font-semibold">Reading:</span>{" "}
                   {ku.data.reading}
                 </p>
               )}
-              {ku.data && ku.data.definition && (
+              {ku.type === "Vocab" && ku.data.definition && (
                 <p className="text-lg text-gray-300 break-all">
                   <span className="font-semibold">Definition:</span>{" "}
                   {ku.data.definition}

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, use, useRef } from "react";
+import { useState, useEffect, use, useRef, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Scenario, ChatMessage, ScenarioAttempt } from "@/types/scenario";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
@@ -8,8 +8,17 @@ import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
 import { Volume2, Mic, MicOff } from "lucide-react";
 import { apiFetch } from "@/lib/api-client";
 
-// Configuration for API URL - adjust if using env vars
 const API_BASE_URL = "http://localhost:3000/api";
+
+function kuSrsBadge(maxSrsStage: number | null | undefined): { text: string; className: string } | null {
+  if (maxSrsStage === undefined) return null; // no kuId, no badge
+  if (maxSrsStage === null) return { text: 'Enrolled', className: 'bg-slate-100 text-slate-500' };
+  if (maxSrsStage === 0) return { text: 'New', className: 'bg-slate-100 text-slate-500' };
+  if (maxSrsStage <= 2) return { text: `Apprentice · ${maxSrsStage}`, className: 'bg-blue-100 text-blue-700' };
+  if (maxSrsStage <= 4) return { text: `Familiar · ${maxSrsStage}`, className: 'bg-amber-100 text-amber-700' };
+  if (maxSrsStage <= 6) return { text: `Proficient · ${maxSrsStage}`, className: 'bg-green-100 text-green-700' };
+  return { text: 'Mastered', className: 'bg-purple-100 text-purple-700' };
+}
 
 export default function ScenarioPage({
   params,
@@ -30,6 +39,12 @@ export default function ScenarioPage({
 
   // UI State
   const [showTranslations, setShowTranslations] = useState(false);
+  const [kuStatus, setKuStatus] = useState<Record<string, { maxSrsStage: number | null }>>({});
+
+  // Hint state
+  const [hintUnlocked, setHintUnlocked] = useState(false);
+  const [hintVisible, setHintVisible] = useState(false);
+  const lastInteractionAtRef = useRef<number>(Date.now());
 
   // Audio Hooks
   const { playBlob, isPlaying: isAudioPlaying } = useAudioPlayer();
@@ -118,8 +133,34 @@ export default function ScenarioPage({
     }
   }, [scenario]);
 
+  // Fetch live KU status for the drill vocab grid
+  useEffect(() => {
+    if (scenario?.state !== 'drill' && scenario?.state !== 'simulate') return;
+    apiFetch(`${API_BASE_URL}/scenarios/${id}/ku-status`)
+      .then(r => r.ok ? r.json() : {})
+      .then(setKuStatus)
+      .catch(() => {});
+  }, [id, scenario?.state]);
+
   const [advancing, setAdvancing] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+
+  // Next user line from the script, used as hint text
+  const nextHintLine = useMemo(() => {
+    if (!scenario || scenario.state !== "simulate") return null;
+    const userSpeaker = scenario.roles?.user;
+    const userTurnCount = chatHistory.filter((m) => m.speaker === "user").length;
+    const userLines = scenario.dialogue.filter((l) => l.speaker === userSpeaker);
+    return userLines[userTurnCount] ?? null;
+  }, [chatHistory, scenario]);
+
+  // Unlock hint button 30s after last interaction, reset on each send
+  useEffect(() => {
+    if (scenario?.state !== "simulate") return;
+    setHintUnlocked(false);
+    const timer = setTimeout(() => setHintUnlocked(true), 30_000);
+    return () => clearTimeout(timer);
+  }, [chatHistory.length, scenario?.state]);
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -130,6 +171,8 @@ export default function ScenarioPage({
 
     if (!userMessage.trim() || isSending) return;
 
+    setHintUnlocked(false);
+    setHintVisible(false);
     setIsSending(true);
     const currentMessage = userMessage;
     setUserMessage("");
@@ -651,6 +694,12 @@ export default function ScenarioPage({
 
           {/* Input Area */}
           <div className="p-4 bg-white border-t border-slate-200">
+            {hintVisible && nextHintLine && (
+              <div className="mb-3 px-4 py-2 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800 animate-in fade-in slide-in-from-bottom-1">
+                <span className="font-semibold text-amber-600 text-xs uppercase tracking-wide mr-2">Hint</span>
+                {nextHintLine.translation}
+              </div>
+            )}
             <form onSubmit={handleSendMessage} className="flex gap-2">
               <input
                 type="text"
@@ -675,6 +724,15 @@ export default function ScenarioPage({
                     size={20}
                     className={isListening ? "fill-current" : ""}
                   />
+                </button>
+              )}
+              {hintUnlocked && nextHintLine && (
+                <button
+                  type="button"
+                  onClick={() => setHintVisible((v) => !v)}
+                  className="px-4 py-3 rounded-lg font-bold text-sm border border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100 transition-colors animate-in fade-in"
+                >
+                  {hintVisible ? "Hide" : "Hint"}
                 </button>
               )}
               <button
@@ -771,31 +829,27 @@ export default function ScenarioPage({
             Key Vocabulary
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {scenario.extractedKUs.map((ku, idx) => (
-              <div
-                key={idx}
-                className="bg-white border border-slate-200 rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden"
-              >
-                {/* Status Indicator */}
-                {ku.kuId && (
-                  <div className="absolute top-0 right-0 bg-green-100 text-green-700 text-xs px-2 py-1 rounded-bl-lg font-bold">
-                    Tracked
-                  </div>
-                )}
-
-                <div className="text-center">
-                  <div className="text-sm text-slate-500 mb-1">
-                    {ku.reading}
-                  </div>
-                  <div className="text-2xl font-bold text-slate-800 mb-2">
-                    {ku.content}
-                  </div>
-                  <div className="text-sm text-slate-600 font-medium">
-                    {ku.meaning}
+            {scenario.extractedKUs.map((ku, idx) => {
+              const status = ku.kuId ? kuStatus[ku.kuId] : undefined;
+              const badge = kuSrsBadge(status?.maxSrsStage ?? (ku.kuId ? null : undefined));
+              return (
+                <div
+                  key={idx}
+                  className="bg-white border border-slate-200 rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden"
+                >
+                  {badge && (
+                    <div className={`absolute top-0 right-0 text-xs px-2 py-1 rounded-bl-lg font-semibold ${badge.className}`}>
+                      {badge.text}
+                    </div>
+                  )}
+                  <div className="text-center">
+                    <div className="text-sm text-slate-500 mb-1">{ku.reading}</div>
+                    <div className="text-2xl font-bold text-slate-800 mb-2">{ku.content}</div>
+                    <div className="text-sm text-slate-600 font-medium">{ku.meaning}</div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </section>
       )}

--- a/frontend/src/app/scenarios/library/page.tsx
+++ b/frontend/src/app/scenarios/library/page.tsx
@@ -9,6 +9,16 @@ import { apiFetch } from "@/lib/api-client";
 // TODO: Align with dashboard config
 const API_BASE_URL = "http://localhost:3000/api";
 
+const JLPT_LEVELS: { value: ScenarioDifficulty; label: string }[] = [
+  { value: "N5", label: "N5 — Beginner" },
+  { value: "N4", label: "N4 — Basic" },
+  { value: "N3", label: "N3 — Intermediate" },
+  { value: "N2", label: "N2 — Business" },
+  { value: "N1", label: "N1 — Advanced" },
+];
+
+const LEVEL_RANK: Record<string, number> = { N5: 1, N4: 2, N3: 3, N2: 4, N1: 5 };
+
 interface ScenarioTemplate {
   id: string;
   title: string;
@@ -49,6 +59,7 @@ function ScenarioLibraryContent() {
   const [templates, setTemplates] = useState<ScenarioTemplate[]>([]);
   const [archives, setArchives] = useState<Scenario[]>([]);
   const [loading, setLoading] = useState(true);
+  const [userJlptLevel, setUserJlptLevel] = useState<ScenarioDifficulty | null>(null);
 
   // Modal State
   const [selectedTemplate, setSelectedTemplate] =
@@ -61,13 +72,19 @@ function ScenarioLibraryContent() {
     const fetchData = async () => {
       setLoading(true);
       try {
-        // Fetch Templates
-        const tplRes = await apiFetch(`${API_BASE_URL}/scenarios/templates`);
+        const [tplRes, archRes, userRes] = await Promise.all([
+          apiFetch(`${API_BASE_URL}/scenarios/templates`),
+          apiFetch(`${API_BASE_URL}/scenarios`),
+          apiFetch(`${API_BASE_URL}/users/me`),
+        ]);
         if (tplRes.ok) setTemplates(await tplRes.json());
-
-        // Fetch Archives (All history)
-        const archRes = await apiFetch(`${API_BASE_URL}/scenarios`);
         if (archRes.ok) setArchives(await archRes.json());
+        if (userRes.ok) {
+          const userData = await userRes.json();
+          if (userData.preferences?.jlptLevel) {
+            setUserJlptLevel(userData.preferences.jlptLevel as ScenarioDifficulty);
+          }
+        }
       } catch (error) {
         console.error("Failed to load library data", error);
       } finally {
@@ -225,9 +242,7 @@ function ScenarioLibraryContent() {
                   <button
                     onClick={() => {
                       setSelectedTemplate(tpl);
-                      setSelectedDifficulty(
-                        tpl.defaultLevel as ScenarioDifficulty,
-                      );
+                      setSelectedDifficulty(tpl.defaultLevel as ScenarioDifficulty);
                     }}
                     className="mt-6 w-full py-2 bg-indigo-50 text-indigo-600 font-medium rounded-lg hover:bg-indigo-100 transition-colors"
                   >
@@ -344,11 +359,33 @@ function ScenarioLibraryContent() {
                   }
                   className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
                 >
-                  <option value="N5">N5 (Beginner)</option>
-                  <option value="N4">N4 (Basic)</option>
-                  <option value="N3">N3 (Intermediate)</option>
-                  <option value="N2">N2 (Business)</option>
+                  {JLPT_LEVELS.map(({ value, label }) => {
+                    const isUserLevel = value === userJlptLevel;
+                    const isRecommended = value === selectedTemplate?.defaultLevel;
+                    if (isUserLevel && isRecommended) {
+                      return <option key={value} value={value}>{value} — Your Current Level</option>;
+                    }
+                    const tag = isUserLevel ? "Your Level" : isRecommended ? "Recommended" : null;
+                    return (
+                      <option key={value} value={value}>
+                        {label}{tag ? ` — ${tag}` : ""}
+                      </option>
+                    );
+                  })}
                 </select>
+                {(() => {
+                  if (!userJlptLevel || selectedDifficulty === userJlptLevel) return null;
+                  const selectedRank = LEVEL_RANK[selectedDifficulty] ?? 0;
+                  const userRank = LEVEL_RANK[userJlptLevel] ?? 0;
+                  const msg = selectedRank > userRank
+                    ? "The generated scenario may be too hard at your current level."
+                    : "The generated scenario may be too easy for your current level.";
+                  return (
+                    <p className="mt-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+                      {msg}
+                    </p>
+                  );
+                })()}
               </div>
             </div>
             <div className="flex gap-3 pt-4">

--- a/frontend/src/components/EditKnowledgeUnitModal.tsx
+++ b/frontend/src/components/EditKnowledgeUnitModal.tsx
@@ -28,10 +28,17 @@ export default function EditKnowledgeUnitModal({
   useEffect(() => {
     if (knowledgeUnit) {
       setContent(knowledgeUnit.content || "");
-      setReading(knowledgeUnit.data?.reading || "");
-      setDefinition(knowledgeUnit.data?.definition || "");
-      setJlptLevel(knowledgeUnit.data?.jlptLevel || "");
-      setWanikaniLevel(knowledgeUnit.data?.wanikaniLevel || "");
+      if (knowledgeUnit.type === "Vocab") {
+        setReading(knowledgeUnit.data?.reading || "");
+        setDefinition(knowledgeUnit.data?.definition || "");
+        setJlptLevel(knowledgeUnit.data?.jlptLevel || "");
+        setWanikaniLevel(knowledgeUnit.data?.wanikaniLevel || "");
+      } else {
+        setReading("");
+        setDefinition("");
+        setJlptLevel("");
+        setWanikaniLevel("");
+      }
       setUserNotes(knowledgeUnit.userNotes || "");
       setPersonalNotes(knowledgeUnit.personalNotes || "");
     }
@@ -41,10 +48,11 @@ export default function EditKnowledgeUnitModal({
 
   const hasChanges = () => {
     if (!knowledgeUnit) return false;
-    const currentReading = knowledgeUnit.data?.reading || "";
-    const currentDefinition = knowledgeUnit.data?.definition || "";
-    const currentJlptLevel = knowledgeUnit.data?.jlptLevel || "";
-    const currentWanikaniLevel = knowledgeUnit.data?.wanikaniLevel || "";
+    const vocabData = knowledgeUnit.type === "Vocab" ? knowledgeUnit.data : null;
+    const currentReading = vocabData?.reading || "";
+    const currentDefinition = vocabData?.definition || "";
+    const currentJlptLevel = vocabData?.jlptLevel || "";
+    const currentWanikaniLevel = vocabData?.wanikaniLevel || "";
     const currentUserNotes = knowledgeUnit.userNotes || "";
     const currentPersonalNotes = knowledgeUnit.personalNotes || "";
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -329,6 +329,7 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
   type: "Concept";
   data: {
     title: string;
+    reading?: string;
     overview: string;
     mechanics: Array<{
       goalTitle: string;

--- a/frontend/src/types/jest-extended.d.ts
+++ b/frontend/src/types/jest-extended.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@testing-library/jest-dom" />


### PR DESCRIPTION
## Summary                                                                                                             
                                                            
  - **Lesson global migration** — `userId` field removed from all `lessons/{kuId}` documents. User-specific edits (e.g.  
  `meaning_explanation`) now write to a `users/{uid}/user-lessons/{kuId}` overlay sub-collection; `findByKuId` merges the
   overlay on read. Existing docs with a stale `userId` field are lazily cleaned via a background `FieldValue.delete()`  
  - **User email in profile** — `UserRoot.email` now populated from the Firebase Auth JWT on every `GET /api/users/me`
  call; backfilled lazily for existing users who haven't yet had it stored.                                           
  - **Scenario roleplay hint** — In `simulate` state, a "Hint" button appears after 30 s of inactivity. It shows the     
  English translation of the next expected user line from the scenario script. Resets automatically on every send.  
  - **KU SRS status badges** — New `GET /api/scenarios/:id/ku-status` endpoint returns the max SRS stage per KU. The     
  vocabulary grid in `drill`/`simulate` state now shows colour-coded badges (Enrolled · New · Apprentice · Familiar ·
  Proficient · Mastered) instead of a static "Tracked" label.                                                            
  - **TypeScript hygiene** — Fixed discriminated-union narrowing errors in `manage/page.tsx` and
  `EditKnowledgeUnitModal.tsx`; added `jest-extended.d.ts` triple-slash reference so `@testing-library/jest-dom` matchers
   resolve correctly in all test files.                                                                                  
                                       
  ## Test plan                                                                                                           
                                                                                                                         
  - [ ] Generate a new Vocab/Kanji lesson — confirm `lessons/{kuId}` doc has no `userId` field
  - [ ] Open an existing lesson that was generated before this change — confirm `userId` is stripped from Firestore on   
  first load                                                                                                          
  - [ ] Edit `meaning_explanation` on a lesson — confirm write goes to `users/{uid}/user-lessons/{kuId}` and the change  
  is visible on reload                                                                                                 
  - [ ] Sign in as a user — confirm `email` appears in `users/{uid}` Firestore doc after first `GET /api/users/me`       
  - [ ] In a scenario `simulate` session: wait 30 s without sending → hint button appears; send a message → button
  disappears; verify hint text matches the next user line from the script                                                
  - [ ] In a scenario `drill` view: check KU badges reflect correct SRS stage; check an un-reviewed KU shows "Enrolled", 
  a reviewed KU shows the correct band and stage number                                                                 
  - [ ] `npx tsc --noEmit` in both `backend/` and `frontend/` — zero errors  