### PR TITLE
feat: add hints and KU status badges to scenarios

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { applyFurigana, loadFurigana } from "@/lib/furigana";
  */
 export default function Header() {
   const { user } = useAuth();
-  const [stats, setStats] = useState({ learnCount: 0, reviewsDue: 0 });
+  const [stats, setStats] = useState({ learnCount: 0, reviewsDue: 0, simulateCount: 0 });
 
   const fetchStats = useCallback(async () => {
     try {
@@ -100,9 +100,9 @@ export default function Header() {
           </Link>
           <Link
             href="/scenarios"
-            className="px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
+            className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
           >
-            Scenarios
+            Scenarios ({stats.simulateCount})
           </Link>
           <Link
             href="/concepts"


### PR DESCRIPTION
## Summary                                                                                                             
                                                                                                                         
  - **Lesson global migration** — `userId` removed from Vocab/Kanji lesson docs; user edits now live in                  
  `users/{uid}/user-lessons/{kuId}` overlay. Lazy migration strips `userId` from existing docs on first read.            
  - **User email in profile** — `email` sourced from decoded Firebase JWT and written to `users/{uid}` on first `GET     
  /api/users/me`; lazily backfilled for existing users.                                                                  
  - **Scenario roleplay hint** — In `simulate` state a Hint button appears after 30 s of inactivity. Shows the English   
  - **KU SRS status badges** — New `GET /api/scenarios/:id/ku-status` endpoint returns max SRS stage per KU. Scenario    
  drill/simulate view replaces static "Tracked" badge with colour-coded stage badge (Enrolled · New · Apprentice ·       
  Familiar · Proficient · Mastered).                                                                                     
  - **Scenarios count in header** — `GET /api/stats` now returns `simulateCount`; header "Scenarios" link displays the   
  count of active `simulate`-state sessions.                                                                             
  - **TypeScript hygiene** — Discriminated union guards (`ku.type === 'Vocab'`) in `manage/page.tsx` and                 
  `EditKnowledgeUnitModal.tsx`; `jest-extended.d.ts` triple-slash reference fixes `toBeInTheDocument` type errors        
  globally.                                                                                                              
                                                            
  ## Test plan                                                                                                           
                                                            
  - [x] Generate new Vocab/Kanji lesson — no `userId` field on `lessons/{kuId}` doc in Firestore
  - [x] Open a lesson that was generated before the migration — `userId` stripped from Firestore doc, lesson still       
  displays correctly                                                                                              
  - [x] Edit a lesson field — write goes to `users/{uid}/user-lessons/{kuId}`, not the global doc                        
  - [x] Sign in with a new account — `email` appears in `users/{uid}` Firestore doc after first page load
  - [x] Sign in with an existing account that has no `email` field — email backfilled on next `GET /api/users/me`        
  - [x] In a `simulate` scenario: send a message, wait 30 s — Hint button appears; click it — English translation shown; 
  send next message — hint hidden                                                                                        
  - [x] Verify hint line index advances correctly after each user send                                                   
  - [ ] Scenario in `drill` state — SRS badge colours correct per stage; `null` stage shows "Enrolled"; no badge for KUs 
  without a `kuId`                                                                                                       
  - [x] Header "Scenarios (n)" reflects the correct count of `simulate`-state scenarios                                  
  - [x] `npx tsc --noEmit` in `backend/` and `frontend/` — zero errors  