### PR TITLE
fix: better scenarios, roleplay gating

### DIFF
--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -2,8 +2,7 @@
 
 import React, { useState, useEffect, useRef, FormEvent } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { ReviewItem, ReviewFacet, KnowledgeUnit } from "@/types";
+import { ReviewItem, ReviewFacet, KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson } from "@/types";
 import * as wanakana from "wanakana";
 import { logger } from "@/lib/logger";
 import { QuestionFeedbackModal } from "@/components/QuestionFeedbackModal";
@@ -12,11 +11,13 @@ import { getSrsLevelName, getSrsLevelIndex } from "@/utils/srs";
 import { apiFetch } from "@/lib/api-client";
 import SentenceAssemblyCard from "@/components/review/SentenceAssemblyCard";
 import SentenceClozeCard from "@/components/review/SentenceClozeCard";
+import VocabLessonView from "@/components/lessons/VocabLessonView";
+import KanjiLessonView from "@/components/lessons/KanjiLessonView";
+import GrammarLessonView from "@/components/lessons/GrammarLessonView";
 
 type AnswerState = "unanswered" | "evaluating" | "correct" | "incorrect";
 
 export default function ReviewPage() {
-  const router = useRouter();
   const [reviewQueue, setReviewQueue] = useState<ReviewItem[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -56,6 +57,11 @@ export default function ReviewPage() {
   // --- Edit Modal State ---
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editingKu, setEditingKu] = useState<KnowledgeUnit | null>(null);
+
+  // --- Inline Lesson Panel State ---
+  const [showLesson, setShowLesson] = useState(false);
+  const [lessonForReview, setLessonForReview] = useState<Lesson | null>(null);
+  const [isFetchingLesson, setIsFetchingLesson] = useState(false);
 
   // --- Audio State ---
   const audioCache = useRef<Record<string, string>>({});
@@ -419,6 +425,35 @@ export default function ReviewPage() {
     advanceToNext();
   };
 
+  const handleShowLesson = async () => {
+    if (showLesson) {
+      setShowLesson(false);
+      return;
+    }
+    if (lessonForReview) {
+      setShowLesson(true);
+      return;
+    }
+    if (!currentItem) return;
+    setIsFetchingLesson(true);
+    try {
+      const res = await apiFetch("/api/lessons/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kuId: currentItem.facet.kuId }),
+      });
+      if (res.ok) {
+        const data = await res.json() as Lesson;
+        setLessonForReview(data);
+        setShowLesson(true);
+      }
+    } catch (e) {
+      console.error("Failed to fetch lesson for review", e);
+    } finally {
+      setIsFetchingLesson(false);
+    }
+  };
+
   const goToNextItem = () => {
     // If it's a new AI question and we haven't shown feedback yet
     const isNew = isNewAiQuestion(currentItem);
@@ -438,6 +473,8 @@ export default function ReviewPage() {
     setPendingSrsResult(null);
     setShowFeedbackModal(false);
     setLevelStatus(null);
+    setShowLesson(false);
+    setLessonForReview(null);
     // Use functional update to ensure we use the latest state
     setCurrentIndex((prevIndex) => prevIndex + 1);
   };
@@ -767,15 +804,11 @@ export default function ReviewPage() {
               </button>
               <button
                 type="button"
-                onClick={() => {
-                  if (currentItem) {
-                    router.push(`/learn/${currentItem.facet.kuId}?source=review`);
-                  }
-                }}
-                disabled={answerState !== "unanswered" || isDynamicLoading}
+                onClick={handleShowLesson}
+                disabled={isFetchingLesson}
                 className="flex-1 px-6 py-3 bg-[#0A5C36] text-white text-lg font-semibold rounded-md shadow-md hover:bg-[#084a2b] focus:outline-none focus:ring-2 focus:ring-green-800 focus:ring-offset-2 focus:ring-offset-gray-800 disabled:bg-gray-800 disabled:text-gray-500"
               >
-                Skip & Review Lesson
+                {isFetchingLesson ? "Loading..." : showLesson ? "Hide Lesson" : "Review Lesson"}
               </button>
             </div>
 
@@ -855,12 +888,14 @@ export default function ReviewPage() {
 
           {answerState === "incorrect" && currentItem && (
             <div className="mt-4">
-              <Link
-                href={`/learn/${currentItem.facet.kuId}?source=review`}
-                className="inline-block px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b]"
+              <button
+                type="button"
+                onClick={handleShowLesson}
+                disabled={isFetchingLesson}
+                className="px-4 py-2 bg-[#0A5C36] text-white font-semibold rounded-md hover:bg-[#084a2b] disabled:opacity-50"
               >
-                Review lesson on {currentItem.facet.data?.content}
-              </Link>
+                {isFetchingLesson ? "Loading..." : showLesson ? "Hide Lesson" : `Review lesson on ${currentItem.facet.data?.content}`}
+              </button>
             </div>
           )}
 
@@ -879,6 +914,35 @@ export default function ReviewPage() {
               Next
             </button>
           </div>
+        </div>
+      )}
+
+      {/* --- Inline Lesson Panel --- */}
+      {showLesson && lessonForReview && (
+        <div className="mt-6 bg-shodo-paper border border-shodo-ink/20 rounded-lg p-6 shadow-md">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold text-shodo-ink">Lesson</h2>
+            <button
+              type="button"
+              onClick={() => setShowLesson(false)}
+              className="text-shodo-ink-faint hover:text-shodo-ink text-sm"
+            >
+              Close
+            </button>
+          </div>
+          {lessonForReview.type === "Vocab" && (
+            <VocabLessonView lesson={lessonForReview as VocabLesson} readOnly />
+          )}
+          {lessonForReview.type === "Kanji" && (
+            <KanjiLessonView lesson={lessonForReview as KanjiLesson} />
+          )}
+          {lessonForReview.type === "Grammar" && (
+            <GrammarLessonView
+              lesson={lessonForReview as GrammarLesson}
+              selectedFacets={{}}
+              onToggleFacet={() => {}}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -10,6 +10,8 @@ import { apiFetch } from "@/lib/api-client";
 
 const API_BASE_URL = "http://localhost:3000/api";
 
+const ROLEPLAY_MIN_SRS_STAGE = 1; // at least one successful review per facet before role-playing
+
 function kuSrsBadge(maxSrsStage: number | null | undefined): { text: string; className: string } | null {
   if (maxSrsStage === undefined) return null; // no kuId, no badge
   if (maxSrsStage === null) return { text: 'Enrolled', className: 'bg-slate-100 text-slate-500' };
@@ -39,7 +41,8 @@ export default function ScenarioPage({
 
   // UI State
   const [showTranslations, setShowTranslations] = useState(false);
-  const [kuStatus, setKuStatus] = useState<Record<string, { maxSrsStage: number | null }>>({});
+  const [kuStatus, setKuStatus] = useState<Record<string, { maxSrsStage: number | null; minSrsStage: number | null }>>({});
+  const [kuStatusLoading, setKuStatusLoading] = useState(false);
 
   // Hint state
   const [hintUnlocked, setHintUnlocked] = useState(false);
@@ -136,10 +139,11 @@ export default function ScenarioPage({
   // Fetch live KU status for the drill vocab grid
   useEffect(() => {
     if (scenario?.state !== 'drill' && scenario?.state !== 'simulate') return;
+    setKuStatusLoading(true);
     apiFetch(`${API_BASE_URL}/scenarios/${id}/ku-status`)
       .then(r => r.ok ? r.json() : {})
-      .then(setKuStatus)
-      .catch(() => {});
+      .then(data => { setKuStatus(data); setKuStatusLoading(false); })
+      .catch(() => setKuStatusLoading(false));
   }, [id, scenario?.state]);
 
   const [advancing, setAdvancing] = useState(false);
@@ -323,6 +327,11 @@ export default function ScenarioPage({
     );
   if (error || !scenario)
     return <div className="p-10 text-center text-red-500">{error}</div>;
+
+  // Readiness gate for drill → simulate transition
+  const linkedKUs = scenario.extractedKUs.filter(ku => ku.kuId);
+  const readyKUs = linkedKUs.filter(ku => (kuStatus[ku.kuId!]?.minSrsStage ?? -1) >= ROLEPLAY_MIN_SRS_STAGE);
+  const isReadyForRoleplay = !kuStatusLoading && linkedKUs.length > 0 && readyKUs.length === linkedKUs.length;
 
   // If viewing history, show a simplified report card for that attempt
   if (viewingHistory) {
@@ -869,35 +878,56 @@ export default function ScenarioPage({
               </button>
             ) : (
               <div className="flex justify-between items-center">
-                <div className="text-sm text-slate-500">
-                  {scenario.extractedKUs.length} items extracted
+                {scenario.state === "drill" ? (
+                  <div className="text-sm">
+                    {kuStatusLoading ? (
+                      <span className="text-slate-400">Checking vocab progress...</span>
+                    ) : (
+                      <span className={readyKUs.length === linkedKUs.length ? "text-green-600 font-medium" : "text-slate-500"}>
+                        {readyKUs.length}/{linkedKUs.length} vocab reviewed
+                      </span>
+                    )}
+                  </div>
+                ) : (
+                  <div className="text-sm text-slate-500">
+                    {scenario.extractedKUs.length} items extracted
+                  </div>
+                )}
+                <div className="flex flex-col items-end gap-1">
+                  <button
+                    onClick={handleAdvance}
+                    disabled={
+                      advancing ||
+                      (scenario.state === "drill" && !isReadyForRoleplay) ||
+                      (scenario.state === "simulate" && chatHistory.length === 0)
+                    }
+                    title={scenario.state === "drill" && !isReadyForRoleplay ? `${readyKUs.length}/${linkedKUs.length} vocab items need at least one successful review first` : undefined}
+                    className={`px-8 py-3 rounded-lg font-bold transition-colors shadow-sm ${
+                      scenario.state === "drill"
+                        ? isReadyForRoleplay
+                          ? "bg-purple-600 hover:bg-purple-700 text-white"
+                          : "bg-slate-300 text-slate-500 cursor-not-allowed"
+                        : scenario.state === "simulate"
+                          ? scenario.isObjectiveMet
+                            ? "bg-green-600 hover:bg-green-700 text-white"
+                            : "bg-amber-500 hover:bg-amber-600 text-white"
+                          : "bg-green-600 hover:bg-green-700 text-white"
+                    } ${advancing || (scenario.state === "simulate" && chatHistory.length === 0) ? "opacity-50 cursor-not-allowed" : ""}`}
+                  >
+                    {advancing
+                      ? "Processing..."
+                      : scenario.state === "drill"
+                        ? "Start Roleplay →"
+                        : scenario.state === "simulate"
+                          ? scenario.isObjectiveMet
+                            ? "Complete Mission"
+                            : "End Session Early"
+                          : "Completed"}
+                  </button>
+                  {scenario.state === "drill" && !isReadyForRoleplay && !kuStatusLoading && (
+                    <span className="text-xs text-slate-400">Review vocab to unlock</span>
+                  )}
                 </div>
-                <button
-                  onClick={handleAdvance}
-                  disabled={
-                    advancing ||
-                    (scenario.state === "simulate" && chatHistory.length === 0)
-                  }
-                  className={`px-8 py-3 rounded-lg font-bold transition-colors shadow-sm ${
-                    scenario.state === "drill"
-                      ? "bg-purple-600 hover:bg-purple-700 text-white"
-                      : scenario.state === "simulate"
-                        ? scenario.isObjectiveMet
-                          ? "bg-green-600 hover:bg-green-700 text-white"
-                          : "bg-amber-500 hover:bg-amber-600 text-white"
-                        : "bg-green-600 hover:bg-green-700 text-white"
-                  } ${advancing || (scenario.state === "simulate" && chatHistory.length === 0) ? "opacity-50 cursor-not-allowed" : ""}`}
-                >
-                  {advancing
-                    ? "Processing..."
-                    : scenario.state === "drill"
-                      ? "Start Roleplay →"
-                      : scenario.state === "simulate"
-                        ? scenario.isObjectiveMet
-                          ? "Complete Mission"
-                          : "End Session Early"
-                        : "Completed"}
-                </button>
               </div>
             )}
           </div>

--- a/frontend/src/app/scenarios/page.tsx
+++ b/frontend/src/app/scenarios/page.tsx
@@ -11,7 +11,7 @@ const API_BASE_URL = "http://localhost:3000/api";
 
 export default function ScenariosDashboard() {
   const router = useRouter();
-  const [scenarios, setScenarios] = useState<Scenario[]>([]);
+  const [recentScenarios, setRecentScenarios] = useState<Scenario[]>([]);
   const [loading, setLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
 
@@ -28,10 +28,7 @@ export default function ScenariosDashboard() {
   const fetchScenarios = async () => {
     try {
       const res = await apiFetch(`${API_BASE_URL}/scenarios?days=3`);
-      if (res.ok) {
-        const data = await res.json();
-        setScenarios(data);
-      }
+      if (res.ok) setRecentScenarios(await res.json());
     } catch (error) {
       console.error("Failed to fetch scenarios", error);
     } finally {
@@ -75,7 +72,7 @@ export default function ScenariosDashboard() {
     try {
       const res = await apiFetch(`${API_BASE_URL}/scenarios/${id}/deactivate`, { method: "POST" });
       if (res.ok) {
-        setScenarios(prev => prev.map(s => s.id === id ? { ...s, isActive: false } : s));
+        setRecentScenarios(prev => prev.map(s => s.id === id ? { ...s, isActive: false } : s));
       } else {
         alert("Failed to deactivate scenario.");
       }
@@ -84,8 +81,8 @@ export default function ScenariosDashboard() {
     }
   };
 
-  const activeContextScenarios = scenarios.filter(s => s.sourceType === 'context-example' && s.isActive !== false);
-  const otherScenarios = scenarios.filter(s => s.sourceType !== 'context-example' || s.isActive === false);
+  const activeContextScenarios = recentScenarios.filter(s => s.sourceType === 'context-example' && s.isActive !== false);
+  const otherScenarios = recentScenarios.filter(s => s.sourceType !== 'context-example' || s.isActive === false);
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">

--- a/frontend/src/components/lessons/EditableSection.tsx
+++ b/frontend/src/components/lessons/EditableSection.tsx
@@ -63,20 +63,19 @@ export default function EditableSection({
 
   // --- DEFAULT VIEW ---
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 relative border border-shodo-ink/5">
+    <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 relative border border-shodo-ink/10">
       {!readOnly && onSave && (
         <button
           onClick={handleEdit}
-          className="absolute top-2 right-2 px-3 py-1 bg-gray-200 text-xs rounded-md"
+          className="absolute top-2 right-2 px-3 py-1 bg-shodo-paper text-shodo-ink-light text-xs rounded-md hover:bg-shodo-paper-warm"
         >
           Edit
         </button>
       )}
-      <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
         {title}
       </h2>
-      {/* This just displays the raw content. You'd format this better. */}
-      <p className="text-lg text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+      <p className="text-lg text-shodo-ink-light whitespace-pre-wrap">
         {String(content)}
       </p>
     </div>

--- a/frontend/src/components/lessons/KanjiLessonView.tsx
+++ b/frontend/src/components/lessons/KanjiLessonView.tsx
@@ -8,50 +8,50 @@ interface KanjiLessonViewProps {
 export default function KanjiLessonView({ lesson }: KanjiLessonViewProps) {
   return (
     <>
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 border border-shodo-ink/10">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Meaning
         </h2>
-        <p className="text-lg text-gray-700 dark:text-gray-300">
+        <p className="text-lg text-shodo-ink-light">
           {lesson.meaning}
         </p>
       </div>
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 border border-shodo-ink/10">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Radicals
         </h2>
         <ul className="flex flex-wrap gap-4">
           {lesson.radical ? (
-            <li className="p-4 bg-gray-200 dark:bg-gray-700 rounded-md text-center">
-              <span className="text-3xl text-gray-900 dark:text-white">
+            <li className="p-4 bg-shodo-paper-warm rounded-md text-center">
+              <span className="text-3xl text-shodo-ink">
                 {lesson.radical.character}
               </span>
-              <p className="text-md text-gray-600 dark:text-gray-400">
+              <p className="text-md text-shodo-ink-light">
                 {lesson.radical.meaning}
               </p>
             </li>
           ) : (
-            <p className="text-gray-500 dark:text-gray-400 italic">
+            <p className="text-shodo-ink-faint italic">
               No radical provided.
             </p>
           )}
         </ul>
       </div>
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 border border-shodo-ink/10">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Meaning Mnemonic
         </h2>
-        <p className="text-lg text-gray-700 dark:text-gray-300 italic">
+        <p className="text-lg text-shodo-ink-light italic">
           {lesson.personalMnemonic || lesson.mnemonic_meaning}
         </p>
       </div>
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 border border-shodo-ink/10">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Readings
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <h3 className="text-xl font-semibold text-gray-500 dark:text-gray-400 mb-2">
+            <h3 className="text-xl font-semibold text-shodo-ink-faint mb-2">
               On'yomi (Katakana)
             </h3>
             <ul className="space-y-2">
@@ -59,22 +59,22 @@ export default function KanjiLessonView({ lesson }: KanjiLessonViewProps) {
                 lesson.onyomi.map((r, i) => (
                   <li
                     key={`${r}-${i}`}
-                    className="p-3 bg-gray-200 dark:bg-gray-700 rounded-md"
+                    className="p-3 bg-shodo-paper-warm rounded-md"
                   >
-                    <span className="text-2xl text-gray-900 dark:text-white">
+                    <span className="text-2xl text-shodo-ink">
                       {r}
                     </span>
                   </li>
                 ))
               ) : (
-                <p className="text-gray-500 dark:text-gray-400 italic">
+                <p className="text-shodo-ink-faint italic">
                   No on'yomi provided.
                 </p>
               )}
             </ul>
           </div>
           <div>
-            <h3 className="text-xl font-semibold text-gray-500 dark:text-gray-400 mb-2">
+            <h3 className="text-xl font-semibold text-shodo-ink-faint mb-2">
               Kun'yomi (Hiragana)
             </h3>
             <ul className="space-y-2">
@@ -82,15 +82,15 @@ export default function KanjiLessonView({ lesson }: KanjiLessonViewProps) {
                 lesson.kunyomi.map((r, i) => (
                   <li
                     key={`${r}-${i}`}
-                    className="p-3 bg-gray-200 dark:bg-gray-700 rounded-md"
+                    className="p-3 bg-shodo-paper-warm rounded-md"
                   >
-                    <span className="text-2xl text-gray-900 dark:text-white">
+                    <span className="text-2xl text-shodo-ink">
                       {r}
                     </span>
                   </li>
                 ))
               ) : (
-                <p className="text-gray-500 dark:text-gray-400 italic">
+                <p className="text-shodo-ink-faint italic">
                   No kun'yomi provided.
                 </p>
               )}
@@ -98,11 +98,11 @@ export default function KanjiLessonView({ lesson }: KanjiLessonViewProps) {
           </div>
         </div>
       </div>
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-sm mb-8 border border-shodo-ink/10">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Reading Mnemonic
         </h2>
-        <p className="text-lg text-gray-700 dark:text-gray-300 italic">
+        <p className="text-lg text-shodo-ink-light italic">
           {lesson.personalMnemonic || lesson.mnemonic_reading}
         </p>
       </div>

--- a/frontend/src/components/lessons/VocabLessonView.tsx
+++ b/frontend/src/components/lessons/VocabLessonView.tsx
@@ -31,21 +31,21 @@ export default function VocabLessonView({
       />
 
       {/* Definitions Section */}
-      <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+      <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
           Definitions
         </h2>
         <ul className="list-disc list-inside space-y-2">
           {(
             lesson.definitions || (lesson.definition ? [lesson.definition] : [])
           ).map((def, i) => (
-            <li key={i} className="text-lg text-gray-700 dark:text-gray-300">
+            <li key={i} className="text-lg text-shodo-ink-light">
               {def}
             </li>
           ))}
           {(!lesson.definitions || lesson.definitions.length === 0) &&
             !lesson.definition && (
-              <p className="text-gray-500 dark:text-gray-400 italic">
+              <p className="text-shodo-ink-faint italic">
                 No definitions available.
               </p>
             )}
@@ -63,8 +63,8 @@ export default function VocabLessonView({
 
       {/* --- Context Examples --- */}
       {!hideContext && (
-        <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-          <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+        <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
+          <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
             Context Examples
           </h2>
           <ul className="space-y-4">
@@ -72,10 +72,10 @@ export default function VocabLessonView({
               lesson.context_examples.map((ex, i) => (
                 <li
                   key={i}
-                  className="p-4 bg-gray-200 dark:bg-gray-700 rounded-md"
+                  className="p-4 bg-shodo-paper-warm rounded-md"
                 >
                   {/* Japanese Sentence with Furigana */}
-                  <p className="text-2xl text-gray-900 dark:text-white mb-2">
+                  <p className="text-2xl text-shodo-ink mb-2">
                     <FuriganaText text={ex.sentence} />
                   </p>
 
@@ -86,7 +86,7 @@ export default function VocabLessonView({
                 </li>
               ))
             ) : (
-              <p className="text-gray-500 dark:text-gray-400 italic">
+              <p className="text-shodo-ink-faint italic">
                 No context examples provided.
               </p>
             )}
@@ -96,8 +96,8 @@ export default function VocabLessonView({
 
       {/* --- Component Kanji --- */}
       {!hideComponentKanji && (
-        <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
-          <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
+        <div className="bg-shodo-paper-dark p-6 rounded-lg shadow-lg mb-8 border border-shodo-ink/5">
+          <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">
             Component Kanji
           </h2>
           <ul className="space-y-2">
@@ -105,23 +105,23 @@ export default function VocabLessonView({
               lesson.component_kanji.map((k, i) => (
                 <li
                   key={`${k.kanji}-${i}`}
-                  className="flex items-center space-x-4 p-3 bg-gray-200 dark:bg-gray-700 rounded-md"
+                  className="flex items-center space-x-4 p-3 bg-shodo-paper-warm rounded-md"
                 >
-                  <span className="text-3xl text-gray-900 dark:text-white">
+                  <span className="text-3xl text-shodo-ink">
                     {k.kanji}
                   </span>
                   <div>
-                    <p className="text-lg text-gray-700 dark:text-gray-300">
+                    <p className="text-lg text-shodo-ink-light">
                       {k.reading}
                     </p>
-                    <p className="text-md text-gray-600 dark:text-gray-400">
+                    <p className="text-md text-shodo-ink-light">
                       {k.meaning}
                     </p>
                   </div>
                 </li>
               ))
             ) : (
-              <p className="text-gray-500 dark:text-gray-400 italic">
+              <p className="text-shodo-ink-faint italic">
                 No component kanji provided.
               </p>
             )}


### PR DESCRIPTION
  - Threshold: 3 (Familiar) → 1 (any single successful review)                                                           
  - Gate metric: maxSrsStage → minSrsStage — the weakest facet must pass, not the strongest. A KU with three facets at   
  stages 0, 0, 5 now correctly blocks roleplay.                                                                          
  - Backend: getKuStatus now returns both maxSrsStage (still used by the badge display) and minSrsStage (used by the
  gate)                                                                                                                  
  - Counter label: "vocab at Familiar+" → "vocab reviewed" to match the lower bar
