### PR TITLE
fix: better AI error handling in reviews plus others

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,6 +114,7 @@ Create a new pipeline in `ConceptsService` to generate these units. Instruct the
 - (Done) User KU metadata is stored in `users/{uid}/user-kus` as `UserKnowledgeUnit` documents referencing global KUs via `kuId`. Managed by `UserKnowledgeUnitsService`.
 - (Done) Users can sign up and log in via passwordless email-link auth.
 - (Done) When a user interacts with a scenario and clicks "Start Drilling", `UserKnowledgeUnit` documents are created in their sub-collection — this populates their Learning Queue.
+- (Done) Scenarios migrated from top-level `scenarios` collection to `users/{uid}/scenarios` sub-collection (issue #133).
 - (Done) Questions have been overhauled — see **Question Corpus** section below and Migration History.
 
 ## User Management, Authentication & Multi-Tenancy
@@ -173,8 +174,7 @@ Per-user data lives in **Firestore sub-collections** under `users/{uid}/<collect
 **Global collections** (`knowledge-units`, `concepts`, `questions`, `lessons/{kuId}`) have no `userId` on new documents. `createdBy` is used for audit only where present.
 
 **Exceptions still using `userId` field scoping:**
-- `scenarios` top-level collection — per-user but not yet migrated to sub-collection (issue #133).
-- `lessons` for Vocab/Kanji types — legacy documents still carry a `userId` field.
+- `lessons` for Vocab/Kanji types — legacy documents still carry a `userId` field (lazy migration: field is deleted on read).
 - `api-logs` — no user scoping.
 
 ---
@@ -187,11 +187,12 @@ Per-user data lives in **Firestore sub-collections** under `users/{uid}/<collect
 | `users/{uid}/user-kus` | Yes — sub-collection path | Per-user KU metadata; `kuId` references global KU |
 | `users/{uid}/review-facets` | Yes — sub-collection path | Per-user SRS facets (non-admin users) |
 | `review-facets` | Yes (field) | Admin (`user_default`) SRS facets only; `userId` field still required |
-| `lessons` | **No** (Grammar); Yes (field, Vocab/Kanji) | Global `GrammarLesson` docs stored at `lessons/{kuId}` — no `userId`. Vocab/Kanji lessons still scoped by `userId` field. |
+| `lessons` | **No** | All lesson types stored globally at `lessons/{kuId}` — no `userId`. Legacy Vocab/Kanji docs may still carry a `userId` field; lazily deleted on read. User edits live in `users/{uid}/user-lessons/{kuId}` overlay (merged on read). |
+| `users/{uid}/user-lessons` | Yes — sub-collection path | Per-user lesson overrides (`meaning_explanation`, etc.). Written by `updateLesson`; merged on top of the global doc in `generateLesson` and `findByKuId`. |
 | `users/{uid}/user-grammar-lessons` | Yes — sub-collection path | Per-user per-encounter `UserGrammarLesson` docs. Doc ID: `{kuId}_{sourceType}_{sourceId}` (deterministic, prevents duplicates per source). |
 | `questions` | **No** | Global question corpus — no `userId` on new docs. `rank` and `rejectionCount` fields drive selection. |
 | `users/{uid}/question-states` | Yes — sub-collection path | Per-user `UserQuestionState`: `rejected`, `consecutiveFailures`, `kuId` |
-| `scenarios` | Yes (field) | Roleplay scenario state. `sourceKuId` field links back to the vocabulary KU that triggered generation from a context example. Requires composite index on `(userId, sourceKuId, createdAt)`. |
+| `users/{uid}/scenarios` | Yes — sub-collection path | Roleplay scenario state. Admin (`user_default`) uses root `scenarios` collection. `sourceKuId` field links back to the vocabulary KU that triggered generation from a context example. Requires composite index on `(sourceKuId, createdAt)`. |
 | `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
 | `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
 | `concepts` | **No** | Global grammar concept corpus — no `userId` on docs; `createdBy` field for audit only |

--- a/backend/src/concepts/concepts.service.ts
+++ b/backend/src/concepts/concepts.service.ts
@@ -123,7 +123,7 @@ export class ConceptsService {
       });
     }
 
-    const created = await this.reviewsService.createFacetBatch(uid, facets);
+    const created = await this.reviewsService.createFacetBatch(uid, facets, { type: 'concept', id: conceptId });
 
     await this.userConceptsRef(uid)
       .where('conceptId', '==', conceptId)

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -16,6 +16,7 @@ export const USER_KUS_SUBCOLLECTION = 'user-kus';
 export const USER_CONCEPTS_SUBCOLLECTION = 'user-concepts';
 export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
 export const USER_GRAMMAR_LESSONS_SUBCOLLECTION = 'user-grammar-lessons';
+export const USER_LESSONS_SUBCOLLECTION = 'user-lessons';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;
 

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, Logger, NotFoundException } from '@nestjs/common';
-import { FIRESTORE_CONNECTION, LESSONS_COLLECTION, KNOWLEDGE_UNITS_COLLECTION, USER_GRAMMAR_LESSONS_SUBCOLLECTION } from '../firebase/firebase.module';
+import { FIRESTORE_CONNECTION, LESSONS_COLLECTION, KNOWLEDGE_UNITS_COLLECTION, USER_GRAMMAR_LESSONS_SUBCOLLECTION, USER_LESSONS_SUBCOLLECTION, FieldValue } from '../firebase/firebase.module';
 import { Firestore, BulkWriter, Timestamp } from 'firebase-admin/firestore';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
@@ -34,16 +34,22 @@ export class LessonsService {
     const content = ku.content;
 
     const lessonDbRef = this.db.collection(LESSONS_COLLECTION).doc(kuId);
-
+    const overlayRef = this.db.collection('users').doc(uid).collection(USER_LESSONS_SUBCOLLECTION).doc(kuId);
 
     // Check for lesson in 'lessons' collection
-    const lessonDoc = await lessonDbRef.get();
+    const [lessonDoc, overlayDoc] = await Promise.all([lessonDbRef.get(), overlayRef.get()]);
     // Return existing lesson if it's completed OR if it has no status (legacy lesson)
     if (lessonDoc.exists && (lessonDoc.data()?.status === 'completed' || !lessonDoc.data()?.status)) {
-      this.logger.log(
-        `Returning existing lesson for KU ${kuId} from lessons collection`,
-      );
-      return lessonDoc.data() as Lesson;
+      this.logger.log(`Returning existing lesson for KU ${kuId} from lessons collection`);
+      const data = lessonDoc.data()!;
+      if (data.userId) {
+        void lessonDbRef.update({ userId: FieldValue.delete() });
+        delete data.userId;
+      }
+      if (overlayDoc.exists) {
+        return { ...data, ...overlayDoc.data() } as Lesson;
+      }
+      return data as Lesson;
     }
 
     this.logger.log(`No existing lesson for KU ${kuId}. Generating new lesson`);
@@ -92,7 +98,6 @@ export class LessonsService {
     try {
       lessonJson = JSON.parse(lessonString) as Lesson;
       (lessonJson as VocabLesson | KanjiLesson).kuId = kuId;
-      (lessonJson as any).userId = uid;
 
       // --- MERGE USER DEFINITIONS (if Vocab) ---
       // Rely on the KnowledgeUnit type, which is the source of truth
@@ -167,21 +172,9 @@ export class LessonsService {
   }
 
   async updateLesson(uid: string, kuId: string, section: string, content: string) {
-    // 1. Find the lesson document
-    const snapshot = await this.db.collection(LESSONS_COLLECTION)
-      .where('kuId', '==', kuId)
-      .where('userId', '==', uid)
-      .limit(1)
-      .get();
+    const lessonDoc = await this.db.collection(LESSONS_COLLECTION).doc(kuId).get();
+    if (!lessonDoc.exists) throw new NotFoundException('Lesson not found');
 
-    if (snapshot.empty) {
-      throw new NotFoundException('Lesson not found');
-    }
-
-    const doc = snapshot.docs[0];
-
-    // 2. Parse content if it looks like JSON (for array fields)
-    // This prevents saving "[{...}]" as a string literal in Firestore
     let valueToSave: any = content;
     try {
       const trimmed = content.trim();
@@ -190,38 +183,29 @@ export class LessonsService {
         valueToSave = JSON.parse(content);
       }
     } catch (e) {
-      // If parse fails, assume it's just a regular string
       valueToSave = content;
     }
 
-    // 3. Update
-    await doc.ref.update({
-      [section]: valueToSave
-    });
+    const overlayRef = this.db.collection('users').doc(uid).collection(USER_LESSONS_SUBCOLLECTION).doc(kuId);
+    await overlayRef.set({ [section]: valueToSave }, { merge: true });
 
     return { success: true };
   }
 
   async findByKuId(uid: string, kuId: string): Promise<Lesson | null> {
-    // Grammar lessons are global (no userId); read the doc directly
-    const directDoc = await this.db.collection(LESSONS_COLLECTION).doc(kuId).get();
-    if (directDoc.exists && directDoc.data()?.type === 'Grammar') {
-      return { ...directDoc.data() } as GrammarLesson;
+    const [lessonDoc, overlayDoc] = await Promise.all([
+      this.db.collection(LESSONS_COLLECTION).doc(kuId).get(),
+      this.db.collection('users').doc(uid).collection(USER_LESSONS_SUBCOLLECTION).doc(kuId).get(),
+    ]);
+
+    if (!lessonDoc.exists) return null;
+
+    const lesson = lessonDoc.data() as Lesson;
+    if (overlayDoc.exists) {
+      return { ...lesson, ...overlayDoc.data() } as Lesson;
     }
-
-    const snapshot = await this.db.collection(LESSONS_COLLECTION)
-      .where('kuId', '==', kuId)
-      .where('userId', '==', uid)
-      .limit(1)
-      .get();
-
-    if (snapshot.empty) {
-      return null;
-    }
-
-    const doc = snapshot.docs[0];
-    return { id: doc.id, ...doc.data() } as unknown as Lesson;
-  } // END findByKuId
+    return lesson;
+  }
 
   async createUserGrammarLesson(
     uid: string,
@@ -293,7 +277,6 @@ export class LessonsService {
           // Set status to generating
           await lessonRef.set({
             kuId: item.id,
-            userId: uid,
             status: 'generating',
             createdAt: new Date(),
           }, { merge: true });

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -45,6 +45,7 @@ You MUST return a valid JSON object matching this schema exactly:
   "relatedUnits": [],
   "data": {
     "title": "<Human-readable title>",
+    "reading": "<Kana reading of the core concept — e.g. 'まい' for 枚, 'をおねがいします' for ～をお願いします. Omit if the title contains no kanji or kana that need a reading.>",
     "overview": "<Two-sentence maximum introduction>",
     "mechanics": [
       {

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -252,7 +252,7 @@ export class ReviewsService {
                 if (parts.length === 3) {
                     const kanjiChar = parts[2];
                     const kanjiKuId = await this.knowledgeUnitsService.ensureKanjiStub(kanjiChar, data);
-                    await this.userKnowledgeUnitsService.create(uid, kanjiKuId);
+                    await this.userKnowledgeUnitsService.create(uid, kanjiKuId, { type: 'lesson', id: kuId });
 
                     // Dedup: only create facets that don't already exist on the Kanji KU
                     const existingKanjiFacets = await this.getFacetsByKuId(uid, kanjiKuId);
@@ -267,6 +267,7 @@ export class ReviewsService {
                             nextReviewAt: now,
                             createdAt: now,
                             history: [],
+                            source: { type: 'lesson', id: kuId },
                             ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                             data: { content: kanjiChar, meaning: data?.meaning },
                         });
@@ -281,6 +282,7 @@ export class ReviewsService {
                             nextReviewAt: now,
                             createdAt: now,
                             history: [],
+                            source: { type: 'lesson', id: kuId },
                             ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                             data: { content: kanjiChar, onyomi: data?.onyomi, kunyomi: data?.kunyomi },
                         });
@@ -319,6 +321,7 @@ export class ReviewsService {
                 nextReviewAt: now,
                 createdAt: now,
                 history: [],
+                source: { type: 'lesson', id: kuId },
                 ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                 ...(modifiedData ? { data: modifiedData } : {}),
             });
@@ -414,6 +417,7 @@ export class ReviewsService {
     async createFacetBatch(
         uid: string,
         facets: Array<{ kuId: string; facetType: ReviewFacet['facetType']; data?: any }>,
+        source?: ReviewFacet['source'],
     ): Promise<number> {
         const batch = this.db.batch();
         const now = Timestamp.now();
@@ -427,6 +431,7 @@ export class ReviewsService {
                 nextReviewAt: now,
                 createdAt: now,
                 history: [],
+                ...(source ? { source } : {}),
                 ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                 ...(facet.data ? { data: facet.data } : {}),
             });

--- a/backend/src/scenarios/scenarios.controller.ts
+++ b/backend/src/scenarios/scenarios.controller.ts
@@ -45,6 +45,7 @@ export class ScenariosController {
     @UserId() uid: string,
     @Query('days') days?: string,
     @Query('sourceKuId') sourceKuId?: string,
+    @Query('state') state?: string,
   ) {
     if (sourceKuId) {
       return this.scenariosService.getScenariosBySourceKuId(uid, sourceKuId);
@@ -53,7 +54,12 @@ export class ScenariosController {
     if (limitDays !== undefined && isNaN(limitDays)) {
       throw new BadRequestException('Invalid days parameter');
     }
-    return this.scenariosService.getAllScenarios(uid, limitDays);
+    return this.scenariosService.getAllScenarios(uid, limitDays, state);
+  }
+
+  @Get(':id/ku-status')
+  async getKuStatus(@UserId() uid: string, @Param('id') id: string) {
+    return this.scenariosService.getKuStatus(uid, id);
   }
 
   @Get(':id')

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -12,6 +12,7 @@ import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledg
 import { LessonsService } from '../lessons/lessons.service';
 import { UserService } from '../users/user.service';
 import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
+import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildChatSystemPrompt } from '../prompts/scenario.prompts';
 
@@ -20,7 +21,6 @@ import { ScenarioTemplate, SCENARIO_TEMPLATES } from './templates';
 @Injectable()
 export class ScenariosService {
   private readonly logger = new Logger(ScenariosService.name);
-  private collectionRef: CollectionReference;
 
   constructor(
     @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
@@ -29,13 +29,17 @@ export class ScenariosService {
     private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
     private readonly lessonsService: LessonsService,
     private readonly userService: UserService,
-  ) {
-    this.collectionRef = this.db.collection(SCENARIOS_COLLECTION);
+  ) {}
+
+  private scenariosColRef(uid: string): CollectionReference {
+    if (uid === ADMIN_USER_ID) {
+      return this.db.collection(SCENARIOS_COLLECTION);
+    }
+    return this.db.collection('users').doc(uid).collection(SCENARIOS_COLLECTION);
   }
 
-  async getAllScenarios(userId: string, limitDays?: number): Promise<Scenario[]> {
-    let query = this.collectionRef
-      .where('userId', '==', userId)
+  async getAllScenarios(userId: string, limitDays?: number, state?: string): Promise<Scenario[]> {
+    let query = this.scenariosColRef(userId)
       .orderBy('createdAt', 'desc');
 
     if (limitDays) {
@@ -45,13 +49,18 @@ export class ScenariosService {
       query = query.where('createdAt', '>', timestamp);
     }
 
+    if (state) {
+      query = query.where('state', '==', state);
+    }
+
     const snapshot = await query.get();
     return snapshot.docs.map(doc => doc.data() as Scenario);
   }
 
   async getScenariosBySourceKuId(userId: string, sourceKuId: string): Promise<Pick<Scenario, 'id' | 'title' | 'sourceContextSentence' | 'createdAt'>[]> {
-    const snapshot = await this.collectionRef
-      .where('userId', '==', userId)
+    // NOTE: Requires Firestore composite index on (sourceKuId ASC, createdAt DESC)
+    // for the 'scenarios' collection group (covers both root and users/{uid}/scenarios).
+    const snapshot = await this.scenariosColRef(userId)
       .where('sourceKuId', '==', sourceKuId)
       .orderBy('createdAt', 'desc')
       .get();
@@ -66,11 +75,9 @@ export class ScenariosService {
   }
 
   async getScenario(uid: string, id: string): Promise<Scenario | null> {
-    const doc = await this.collectionRef.doc(id).get();
+    const doc = await this.scenariosColRef(uid).doc(id).get();
     if (!doc.exists) return null;
-    const data = doc.data() as Scenario;
-    if (data.userId !== uid) return null;
-    return data;
+    return doc.data() as Scenario;
   }
 
   async generateScenario(userId: string, dto: GenerateScenarioDto): Promise<string> {
@@ -80,6 +87,7 @@ export class ScenariosService {
       ...dto,
       difficulty: dto.difficulty ?? userPrefs?.jlptLevel ?? 'N4',
       userRole: dto.userRole ?? userPrefs?.preferredUserRole,
+      sourceContextSentence: dto.sourceContextSentence?.replace(/\[[^\]]*\]/g, '').trim(),
     };
 
     const prompt = buildArchitectPrompt(resolvedDto);
@@ -88,7 +96,7 @@ export class ScenariosService {
       const jsonString = await this.geminiService.generateScenario(prompt);
       const data = JSON.parse(jsonString);
 
-      const docRef = this.collectionRef.doc();
+      const docRef = this.scenariosColRef(userId).doc();
       const id = docRef.id;
 
       // Helper to clean "helpful" formatting like "本屋 (Bookstore)" or "ほんや (honya)"
@@ -170,7 +178,7 @@ export class ScenariosService {
 
               if (globalKu) {
                 this.logger.log(`Linking "${ku.content}" to existing global KU ${globalKu.id}`);
-                await this.userKnowledgeUnitsService.create(uid, globalKu.id);
+                await this.userKnowledgeUnitsService.create(uid, globalKu.id, { type: 'scenario', id: scenario.id });
                 updatedKUs.push({ ...ku, kuId: globalKu.id, status: 'learning' });
               } else {
                 this.logger.log(`No global KU found for "${ku.content}" — creating new KU with level hint ${ku.jlptLevel ?? 'none'}`);
@@ -179,7 +187,7 @@ export class ScenariosService {
                   definition: ku.meaning,
                   jlptLevel: ku.jlptLevel,
                 });
-                await this.userKnowledgeUnitsService.create(uid, newKuId);
+                await this.userKnowledgeUnitsService.create(uid, newKuId, { type: 'scenario', id: scenario.id });
                 updatedKUs.push({ ...ku, kuId: newKuId, status: 'learning' });
               }
             } catch (error) {
@@ -196,7 +204,7 @@ export class ScenariosService {
           for (const note of scenario.grammarNotes) {
             try {
               const kuId = await this.knowledgeUnitsService.ensureGrammarKU(note);
-              await this.userKnowledgeUnitsService.create(uid, kuId);
+              await this.userKnowledgeUnitsService.create(uid, kuId, { type: 'scenario', id: scenario.id });
               await this.lessonsService.createUserGrammarLesson(
                 uid,
                 kuId,
@@ -244,7 +252,7 @@ export class ScenariosService {
     }
 
     this.logger.log(`Updating state for scenario ${id} to ${newState}`);
-    await this.collectionRef.doc(id).update(updateData);
+    await this.scenariosColRef(uid).doc(id).update(updateData);
   }
 
 
@@ -273,14 +281,14 @@ export class ScenariosService {
       updateData.pastAttempts = FieldValue.arrayUnion(attempt);
     }
 
-    await this.collectionRef.doc(id).update(updateData);
+    await this.scenariosColRef(uid).doc(id).update(updateData);
   }
 
   async deactivateScenario(uid: string, id: string): Promise<void> {
     this.logger.log(`Deactivating scenario ${id}`);
     const scenario = await this.getScenario(uid, id);
     if (!scenario) throw new NotFoundException('Scenario not found');
-    await this.collectionRef.doc(id).update({ isActive: false });
+    await this.scenariosColRef(uid).doc(id).update({ isActive: false });
   }
 
   async handleChat(uid: string, id: string, userMessage: string): Promise<ChatMessage[]> {
@@ -355,7 +363,7 @@ export class ScenariosService {
       updateData.isActive = false; // Auto-deactivate
     }
 
-    await this.collectionRef.doc(id).update(updateData);
+    await this.scenariosColRef(uid).doc(id).update(updateData);
 
     // 6. Return Full History (so frontend can sync)
     // We assume the frontend has the previous state, but returning full history is safer for sync
@@ -472,5 +480,33 @@ export class ScenariosService {
     this.logger.log(`AI Role: ${aiRole}, User Role: ${userRole}`);
 
     return { aiRole, userRole };
+  }
+
+  async getKuStatus(uid: string, scenarioId: string): Promise<Record<string, { maxSrsStage: number | null; minSrsStage: number | null }>> {
+    const scenario = await this.getScenario(uid, scenarioId);
+    if (!scenario) throw new NotFoundException('Scenario not found');
+
+    const kuIds = scenario.extractedKUs
+      .filter(ku => ku.kuId)
+      .map(ku => ku.kuId!);
+
+    if (kuIds.length === 0) return {};
+
+    const facetsRef = uid === ADMIN_USER_ID
+      ? this.db.collection(REVIEW_FACETS_COLLECTION)
+      : this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+
+    const result: Record<string, { maxSrsStage: number | null; minSrsStage: number | null }> = {};
+
+    await Promise.all(kuIds.map(async (kuId) => {
+      const snap = await facetsRef.where('kuId', '==', kuId).get();
+      const stages = snap.docs.map(d => (d.data().srsStage as number) ?? 0);
+      result[kuId] = {
+        maxSrsStage: stages.length > 0 ? Math.max(...stages) : null,
+        minSrsStage: stages.length > 0 ? Math.min(...stages) : null,
+      };
+    }));
+
+    return result;
   }
 }

--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -5,10 +5,9 @@ import {
     REVIEW_FACETS_COLLECTION,
     USER_STATS_COLLECTION,
     USER_KUS_SUBCOLLECTION,
+    SCENARIOS_COLLECTION,
 } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
-
-// Removed ADMIN_USER_ID
 
 @Injectable()
 export class StatsService {
@@ -42,11 +41,20 @@ export class StatsService {
         // New: Fetch User Stats Document
         const userStatsQuery = this.db.collection(USER_STATS_COLLECTION).doc(uid).get();
 
-        const [ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc] = await Promise.all([
+        const scenariosCol = uid === ADMIN_USER_ID
+            ? this.db.collection(SCENARIOS_COLLECTION)
+            : this.db.collection('users').doc(uid).collection(SCENARIOS_COLLECTION);
+        const simulateScenariosQuery = scenariosCol
+            .where('state', '==', 'simulate')
+            .count()
+            .get();
+
+        const [ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc, simulateScenariosSnapshot] = await Promise.all([
             ukuLearnQuery,
             reviewQuery,
             reviewsDueQuery,
-            userStatsQuery
+            userStatsQuery,
+            simulateScenariosQuery,
         ]);
 
         const reviewsDueCount = reviewsSnapshot.data().count;
@@ -126,6 +134,7 @@ export class StatsService {
             learnCount: ukuLearnSnapshot.data().count,
             reviewCount: totalActive,
             reviewsDue: reviewsDueCount,
+            simulateCount: simulateScenariosSnapshot.data().count,
 
             // New Widget Data
             next24HoursCount: next24HoursCount,

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -38,6 +38,7 @@ export interface ApiLog {
  */
 export interface UserRoot {
   id: string; // The Firestore document ID (which corresponds to the user's auth UID)
+  email?: string;
 
   /**
    * Statistical data related to the user's reviews, engagement, and progression.
@@ -293,6 +294,7 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
   type: "Concept";
   data: {
     title: string;
+    reading?: string;
     overview: string;
     mechanics: Array<{
       goalTitle: string;
@@ -360,6 +362,10 @@ export interface UserKnowledgeUnit {
   status: "learning" | "reviewing" | "mastered";
   facet_count: number;
   history?: any[];
+  source?: {
+    type: 'scenario' | 'lesson';
+    id: string;
+  };
 }
 
 export interface UserConcept {
@@ -406,6 +412,10 @@ export interface ReviewFacet {
   /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
   data?: any;
+  source?: {
+    type: 'lesson' | 'concept';
+    id: string;
+  };
 }
 
 export interface ReviewItem {

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -79,10 +79,19 @@ export class UserKnowledgeUnitsService {
     this.logger.log(`Updated UKU ${uku.id} for uid=${uid} kuId=${kuId}`);
   }
 
-  async create(uid: string, kuId: string): Promise<UserKnowledgeUnit> {
+  async create(
+    uid: string,
+    kuId: string,
+    source?: UserKnowledgeUnit['source'],
+  ): Promise<UserKnowledgeUnit> {
     const existing = await this.findByKuId(uid, kuId);
     if (existing) {
       this.logger.log(`UKU already exists for uid=${uid} kuId=${kuId}`);
+      if (source && !existing.source) {
+        await this.userKusRef(uid).doc(existing.id).update({ source });
+        this.logger.log(`Backfilled source on existing UKU ${existing.id}`);
+        return { ...existing, source };
+      }
       return existing;
     }
 
@@ -94,10 +103,11 @@ export class UserKnowledgeUnitsService {
       createdAt: now,
       status: 'learning',
       facet_count: 0,
+      ...(source ? { source } : {}),
     };
 
     const ref = await this.userKusRef(uid).add(payload);
-    this.logger.log(`Created UKU id=${ref.id} for uid=${uid} kuId=${kuId}`);
+    this.logger.log(`Created UKU id=${ref.id} for uid=${uid} kuId=${kuId} source=${source?.type ?? 'none'}`);
     return { id: ref.id, ...payload };
   }
 }

--- a/backend/src/users/user.controller.ts
+++ b/backend/src/users/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, UseGuards, Logger } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Req, UseGuards, Logger } from '@nestjs/common';
 import { UserService } from './user.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
@@ -20,9 +20,9 @@ export class UserController {
    * Idempotent — safe to call every time the app loads.
    */
   @Get('me')
-  async getOrInitializeMe(@UserId() uid: string) {
+  async getOrInitializeMe(@UserId() uid: string, @Req() req: any) {
     this.logger.log(`GET /users/me called for uid: ${uid}`);
-    const user = await this.userService.findOrCreate(uid);
+    const user = await this.userService.findOrCreate(uid, req.user?.email);
     return user;
   }
 

--- a/backend/src/users/user.service.ts
+++ b/backend/src/users/user.service.ts
@@ -53,20 +53,24 @@ export class UserService {
    *
    * Safe to call on every request — no overwrites, no side-effects for existing users.
    */
-  async findOrCreate(uid: string): Promise<UserRoot> {
+  async findOrCreate(uid: string, email?: string): Promise<UserRoot> {
     const userRef = this.db.collection('users').doc(uid);
     const userDoc = await userRef.get();
 
     if (userDoc.exists) {
       this.logger.log(`UserRoot found for uid: ${uid}`);
-      return { id: uid, ...userDoc.data() } as UserRoot;
+      const data = userDoc.data()!;
+      if (email && !data.email) {
+        void userRef.update({ email });
+        data.email = email;
+      }
+      return { id: uid, ...data } as UserRoot;
     }
 
     this.logger.log(`UserRoot not found for uid: ${uid}. Creating default document.`);
     const defaultUser = this.buildDefaultUserRoot(uid);
+    if (email) defaultUser.email = email;
 
-    // Use set() — the doc doesn't exist so there's no overwrite risk.
-    // We intentionally don't use merge here because we're creating from scratch.
     await userRef.set(defaultUser);
 
     this.logger.log(`Default UserRoot created for uid: ${uid}`);

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -280,8 +280,9 @@ export default function ReviewPage() {
       // *Now* we dispatch the event from the client.
       window.dispatchEvent(new Event("refreshStats"));
     } catch (err) {
-      if (err instanceof Error) setError(err.message);
-      else setError("An unknown error occurred");
+      // SRS update failure is non-blocking — the user already saw their result and can continue.
+      // Show a soft warning rather than a hard error so the review flow isn't disrupted.
+      setError("SRS update failed — your answer was recorded but your schedule may not have updated. You can continue reviewing.");
     }
   };
 
@@ -470,6 +471,7 @@ export default function ReviewPage() {
     setUserAnswer("");
     setAnswerState("unanswered");
     setAiExplanation("");
+    setError(null);
     setPendingSrsResult(null);
     setShowFeedbackModal(false);
     setLevelStatus(null);
@@ -666,6 +668,7 @@ export default function ReviewPage() {
   const questionText = getQuestion(currentItem);
   const isDynamicLoading =
     currentItem.facet.facetType === "AI-Generated-Question" &&
+    !error &&
     (isFetchingDynamicQuestion || !questionText);
 
   return (
@@ -677,8 +680,64 @@ export default function ReviewPage() {
       </header>
 
       {error && (
-        <div className="bg-red-800 border border-red-600 text-red-100 p-4 rounded-md mb-6">
-          {error}
+        <div className={`border p-4 rounded-md mb-6 flex flex-col gap-3 ${
+          error.startsWith("SRS update failed")
+            ? "bg-yellow-900 border-yellow-600 text-yellow-100"
+            : "bg-red-900 border-red-600 text-red-100"
+        }`}>
+          <div className="flex justify-between items-start gap-4">
+            <p className="text-sm leading-snug">{error}</p>
+            <button
+              type="button"
+              onClick={() => setError(null)}
+              className="text-current opacity-60 hover:opacity-100 shrink-0 text-lg leading-none"
+              aria-label="Dismiss"
+            >
+              ✕
+            </button>
+          </div>
+          {/* Contextual escape hatches */}
+          <div className="flex gap-3 flex-wrap">
+            {answerState === "unanswered" && currentItem.facet.facetType === "AI-Generated-Question" && (
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  setDynamicQuestion(null);
+                  setDynamicAnswer(null);
+                  setDynamicAltAnswers([]);
+                  setDynamicContext(null);
+                  lastFetchedIndex.current = null;
+                  fetchDynamicQuestion(
+                    currentItem.facet.data?.topic || currentItem.facet.data?.content || '',
+                    currentItem.facet.id,
+                    currentItem.facet.kuId,
+                  );
+                }}
+                className="text-sm px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded font-medium"
+              >
+                Retry question
+              </button>
+            )}
+            {answerState === "unanswered" && (
+              <button
+                type="button"
+                onClick={() => { setError(null); advanceToNext(); }}
+                className="text-sm px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded font-medium"
+              >
+                Skip item
+              </button>
+            )}
+            {(answerState === "correct" || answerState === "incorrect") && (
+              <button
+                type="button"
+                onClick={() => { setError(null); goToNextItem(); }}
+                className="text-sm px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded font-medium"
+              >
+                Continue
+              </button>
+            )}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Summary
                                                                                                                         
  - Lesson edit persistence bug — generateLesson was returning the global lessons/{kuId} doc on cache hit without merging
   the users/{uid}/user-lessons/{kuId} overlay, so user edits to lesson sections were lost on page refresh. Fixed by     
  fetching both docs in parallel at the top of the cache-hit branch.                                                     
  - Scenarios count in header — StatsService.getDashboardStats now queries for state == 'simulate' scenarios and returns
  simulateCount. Header Scenarios link displays the live count.                                                          
  - Scenario roleplay gate — "Start Roleplay →" in drill state is disabled until every linked vocab KU has minSrsStage >=
   1 (at least one successful review on every facet — the weakest facet sets the bar, not the strongest). GET            
  /api/scenarios/:id/ku-status now returns both maxSrsStage (badge display) and minSrsStage (gate). Shows X/Y vocab 
  reviewed counter and "Review vocab to unlock" hint. GET /api/scenarios accepts a ?state= filter param.                 
  - Lesson views restyled — VocabLessonView, KanjiLessonView, EditableSection replaced all bg-gray-{n} dark:bg-gray-{n} /
   text-gray-{n} dark:text-white patterns with explicit shodo palette classes. Eliminates OS dark-mode interference.
  - Inline lesson panel in review — "Skip & Review Lesson" renamed to "Review Lesson" and no longer navigates away from
  the review session. Fetches the lesson inline and renders the appropriate read-only *LessonView below the review card.
  Toggles to "Hide Lesson" when open. Resets on advance.
  - Review error handling — A failed dynamic question fetch previously left isDynamicLoading = true, disabling Skip and
  leaving the user stuck. Fixed by gating isDynamicLoading on !error. Error box is now dismissible and shows contextual
  escape hatches: "Retry question" / "Skip item" / "Continue" depending on state. SRS update failures use amber warning
  styling (non-blocking) with a message that the schedule may not have updated. advanceToNext clears the error.

  Test plan

  - Edit a lesson field, refresh page — edit should persist
  - Header Scenarios badge shows correct count of in-progress roleplay sessions
  - Scenario in drill state with unreviewed vocab — "Start Roleplay →" disabled, counter shows 0/N
  - After reviewing all vocab to stage ≥ 1 — button enables
  - Lesson views on /learn look correct (warm paper tones, not dark gray)
  - "Review Lesson" in review session shows lesson inline without navigating away
  - Review error handling — hard to trigger against Gemini; revisit if 500s occur in production
