### PR TITLE
feat scenarion progress tracking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,12 +276,54 @@ The following work is required to complete proper multi-user support. Each item 
 
 Rank nominally 0–100 but is not hard-clamped; `>= 30` is the only gate used in queries.
 
+### Verb vs noun question type branching
+
+`generateVocabQuestion` inspects `meaning` (fetched from the KU) before picking a question type:
+- **Verb** (`meaning` starts with `"to "`) → picks randomly from `VOCAB_QUESTION_OPTIONS` (conjugation, particle, translation, fill-in-the-blank).
+- **Non-verb** (nouns, adjectives, anything else) → picks randomly from `NOUN_QUESTION_OPTIONS` (noun-particle, translation).
+
+`noun-particle` questions blank out `<noun><particle>` together (e.g. `図書館で`, `歯を`). The `context` field follows the format "Specify [label] as [role]" to uniquely identify the correct particle. `accepted_alternatives` is always empty. `NOUN_PARTICLE_FEW_SHOT_TURNS` (five `{user, model}` pairs) are passed as real conversation turns in `contents` — NOT embedded in the system prompt — because `generateQuestionAI` uses `responseSchema` (controlled generation mode), where JSON in the system instruction is misinterpreted.
+
+`GeminiService.generateQuestionAI` accepts an optional `fewShotTurns?: Array<{ user: string; model: string }>` parameter. When provided, each pair is prepended to `contents` as `role: 'user'` / `role: 'model'` turns before the actual question message.
+
 ### Key endpoints
 - `GET /api/questions/generate?topic=&facetId=&kuId=` — returns `{ question, answer, context, accepted_alternatives, questionId, isNew }`. `isNew: true` means no `UserQuestionState` exists yet for this user; the frontend uses this to decide whether to show the feedback modal.
 - `PATCH /api/questions/:id/feedback` — body `{ feedback: 'keep' | 'request-new' | 'report' }`.
 
 ### Migration note for existing question documents
 Legacy docs lack `rank` and `rejectionCount`. They are served correctly on first use (`rank ?? 50` at read time) but fall below the suitability threshold after their first correct answer or feedback write (`FieldValue.increment` initialises missing fields from 0). Run a one-time backfill of `{ rank: 50, rejectionCount: 0 }` across the `questions` collection to restore them.
+
+---
+
+## Scenario Progress Tracking
+
+Each `Scenario` document tracks the user's best performance per JLPT level:
+
+```typescript
+progress?: Record<string, LevelProgress>  // keyed by ScenarioDifficulty e.g. 'N5'
+currentLevelStatus?: ProgressStatus        // denormalised for Firestore queries
+```
+
+`ProgressStatus = 'reviewing' | 'failing' | 'passing' | 'passed'` — derived from `bestStars`:
+- 0 stars → `reviewing`, 1–2 → `failing`, 3–4 → `passing`, 5 → `passed` (sticky — never regresses)
+
+`LevelProgress` stores `{ status, bestStars, lastAttemptAt, attempts[] }`. Each `Attempt` records `{ attemptedAt, stars: 1|2|3|4|5 }`.
+
+Written in `ScenariosService.writeProgressUpdate` (called from the `advanceState` completed branch after evaluation). Uses Firestore dot-notation (`progress.N5`) so multiple level entries coexist in the map without clobbering.
+
+`currentLevelStatus` mirrors `progress[scenario.difficultyLevel].status` and is written on the same update. Intended for dashboard queries such as `where('currentLevelStatus', '==', 'passing')`.
+
+### Assessment screen tiered messaging
+
+| Stars | Header | Guidance |
+|---|---|---|
+| 1–2 | "Keep Practising" (red) | Review grammar notes and vocab, retry when ready |
+| 3–4 | "Good Effort!" (amber) | Study notes again, come back aiming for 5 stars |
+| 5 | "Mission Complete!" (green) | Try next JLPT level from the scenario library |
+
+### `vocabReady` flag (planned)
+
+Once all vocab KUs linked to a `drill`-state scenario have `minSrsStage >= 1`, a `vocabReady: true` flag should be written to the scenario document. Trigger: `ReviewsService` SRS update — look up the UKU's `source.type === 'scenario'` to find the scenario, run `getKuStatus`, write the flag if all pass. Needed for dashboard queries like "scenarios ready to start roleplay".
 
 ---
 

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -422,7 +422,8 @@ export class GeminiService implements OnModuleInit {
   async generateQuestionAI(
     userMessage: string,
     systemPrompt: string,
-    logContext?: Record<string, any>
+    logContext?: Record<string, any>,
+    fewShotTurns?: Array<{ user: string; model: string }>,
   ) {
     let startTime = performance.now();
     let errorOccurred = false;
@@ -450,9 +451,14 @@ export class GeminiService implements OnModuleInit {
 
 
     try {
+      const fewShotContents = (fewShotTurns ?? []).flatMap(({ user, model }) => [
+        { role: 'user' as const, parts: [{ text: user }] },
+        { role: 'model' as const, parts: [{ text: model }] },
+      ]);
+
       const response = await this.client.models.generateContent({
         model: this.modelName,
-        contents: [{ parts: [{ text: userMessage }] }],
+        contents: [...fewShotContents, { parts: [{ text: userMessage }] }],
         config: {
           systemInstruction: { parts: [{ text: systemPrompt }] },
           responseMimeType: "application/json",

--- a/backend/src/prompts/quiz.prompts.ts
+++ b/backend/src/prompts/quiz.prompts.ts
@@ -9,7 +9,7 @@ import { NO_ROMAJI, JSON_ONLY_OUTPUT } from './fragments';
 export type ConceptMechanic = ConceptKnowledgeUnit['data']['mechanics'][number];
 
 // ---------------------------------------------------------------------------
-// Vocab questions
+// Vocab questions (verbs and adjectives)
 // ---------------------------------------------------------------------------
 
 export const VOCAB_QUESTION_OPTIONS: Record<string, string> = {
@@ -72,6 +72,65 @@ export function buildVocabQuestionUserMessage(
   if (meaning) msg += `\nMeaning: ${meaning}`;
   return msg;
 }
+
+// ---------------------------------------------------------------------------
+// Noun questions
+// ---------------------------------------------------------------------------
+
+export const NOUN_QUESTION_OPTIONS: Record<string, string> = {
+  'noun-particle': 'noun + particle fill-in-the-blank',
+  'translation': 'Create a sentence in English for the user to translate into Japanese. The English sentence must naturally force the use of the Target Input.',
+};
+
+export type NounQuestionType = keyof typeof NOUN_QUESTION_OPTIONS;
+
+/**
+ * System prompt for noun + particle fill-in-the-blank questions.
+ * The blank encompasses <noun><particle> so the user must supply both the word and
+ * its grammatically correct particle for the specific context.
+ * accepted_alternatives is always empty — the sentence uniquely determines the particle.
+ * Pass NOUN_PARTICLE_FEW_SHOT_TURNS as fewShotTurns to generateQuestionAI.
+ */
+export function buildNounParticleQuestionPrompt(): string {
+  return `You are an expert Japanese tutor and quiz generator.
+You will be given a Japanese noun (the 'topic') with its reading and meaning.
+Your task is to write a single Japanese sentence that uses that noun with a specific particle, then blank out the noun+particle pair together so the user must supply both.
+
+Rules:
+1. The blank '[____]' replaces the noun AND its particle together — e.g. the answer might be 図書館で, 駅から, 友達と, 歯を.
+2. The 'context' field MUST follow this exact format: "Specify [English label] as [semantic role]" — where the semantic role describes the particle's function precisely enough that only one particle is correct.
+3. 'accepted_alternatives' MUST always be an empty array. The sentence structure uniquely determines the correct particle.
+4. Do NOT use は or が as the particle. Use action particles only: を, に, で, から, へ, と, まで.
+5. Use N4/N5 vocabulary for the surrounding sentence so the user focuses on the target noun and particle, not on decoding the rest.
+6. ${NO_ROMAJI}`;
+}
+
+/** Few-shot conversation turns for noun+particle questions.
+ *  Pass to generateQuestionAI as the fewShotTurns argument.
+ *  Each pair is a (user message, model JSON response) that demonstrates the expected format.
+ */
+export const NOUN_PARTICLE_FEW_SHOT_TURNS: Array<{ user: string; model: string }> = [
+  {
+    user: 'Topic: 図書館\nReading: としょかん\nMeaning: library',
+    model: '{"question":"週末はよく[____]本を読みます。","context":"Specify the library as the place where reading happens","answer":"図書館で","accepted_alternatives":[]}',
+  },
+  {
+    user: 'Topic: 駅\nReading: えき\nMeaning: train station',
+    model: '{"question":"毎朝[____]歩いて会社に向かいます。","context":"Specify the train station as the starting point of the walk","answer":"駅から","accepted_alternatives":[]}',
+  },
+  {
+    user: 'Topic: 友達\nReading: ともだち\nMeaning: friend',
+    model: '{"question":"昨日[____]映画を見に行きました。","context":"Specify the friend as the person you went with","answer":"友達と","accepted_alternatives":[]}',
+  },
+  {
+    user: 'Topic: 音楽\nReading: おんがく\nMeaning: music',
+    model: '{"question":"毎朝シャワーを浴びながら[____]聴きます。","context":"Specify music as the thing being listened to","answer":"音楽を","accepted_alternatives":[]}',
+  },
+  {
+    user: 'Topic: 学校\nReading: がっこう\nMeaning: school',
+    model: '{"question":"明日は早く[____]行かなければなりません。","context":"Specify the school as the destination","answer":"学校に","accepted_alternatives":[]}',
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Concept mechanic questions

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -16,6 +16,9 @@ import {
   buildVocabQuestionPrompt,
   buildVocabQuestionUserMessage,
   pickRandomQuestionType,
+  NOUN_QUESTION_OPTIONS,
+  buildNounParticleQuestionPrompt,
+  NOUN_PARTICLE_FEW_SHOT_TURNS,
   CONCEPT_QUESTION_OPTIONS,
   buildConceptQuestionPrompt,
   ConceptMechanic,
@@ -159,9 +162,6 @@ export class QuestionsService {
   }
 
   private async generateVocabQuestion(uid: string, topic: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
-    const selectedType = pickRandomQuestionType(VOCAB_QUESTION_OPTIONS);
-    const systemPrompt = buildVocabQuestionPrompt(selectedType);
-
     let reading: string | undefined;
     let meaning: string | undefined;
     if (kuId) {
@@ -178,9 +178,27 @@ export class QuestionsService {
       }
     }
 
+    const isVerb = meaning?.toLowerCase().trimStart().startsWith('to ') ?? false;
+    this.logger.log(`Question type selection: kuId=${kuId} meaning="${meaning}" isVerb=${isVerb}`);
+
+    let systemPrompt: string;
+    let fewShotTurns: Array<{ user: string; model: string }> | undefined;
+
+    if (isVerb) {
+      systemPrompt = buildVocabQuestionPrompt(pickRandomQuestionType(VOCAB_QUESTION_OPTIONS));
+    } else {
+      const selectedType = pickRandomQuestionType(NOUN_QUESTION_OPTIONS);
+      if (selectedType === 'noun-particle') {
+        systemPrompt = buildNounParticleQuestionPrompt();
+        fewShotTurns = NOUN_PARTICLE_FEW_SHOT_TURNS;
+      } else {
+        systemPrompt = buildVocabQuestionPrompt(selectedType);
+      }
+    }
+
     const userMessage = buildVocabQuestionUserMessage(topic, reading, meaning);
 
-    const questionString = await this.geminiService.generateQuestionAI(userMessage, systemPrompt, {});
+    const questionString = await this.geminiService.generateQuestionAI(userMessage, systemPrompt, {}, fewShotTurns);
 
     if (!questionString) throw new Error('AI response was empty.');
 

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException
 } from '@nestjs/common';
 import { Firestore, CollectionReference, Timestamp, FieldValue } from 'firebase-admin/firestore';
-import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt } from '../types/scenario';
+import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt, ProgressStatus, LevelProgress, Attempt } from '../types/scenario';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { LessonsService } from '../lessons/lessons.service';
@@ -244,6 +244,7 @@ export class ScenariosService {
           const evaluation = await this.generateEvaluation(scenario);
           if (evaluation) {
             updateData.evaluation = evaluation;
+            this.writeProgressUpdate(scenario, evaluation.rating, updateData);
           }
         } catch (e) {
           this.logger.error("Failed to generate scenario evaluation", e);
@@ -445,6 +446,40 @@ export class ScenariosService {
     return evaluation;
   }
 
+
+  private progressStatusFromStars(stars: number): ProgressStatus {
+    if (stars <= 0) return 'reviewing';
+    if (stars <= 2) return 'failing';
+    if (stars <= 4) return 'passing';
+    return 'passed';
+  }
+
+  private writeProgressUpdate(scenario: Scenario, rawRating: number, updateData: Record<string, any>): void {
+    const level = scenario.difficultyLevel;
+    const stars = Math.max(1, Math.min(5, Math.round(rawRating))) as 1 | 2 | 3 | 4 | 5;
+    const now = Timestamp.now();
+
+    const existing: LevelProgress = scenario.progress?.[level] ?? {
+      status: 'reviewing',
+      bestStars: 0,
+      lastAttemptAt: null,
+      attempts: [],
+    };
+
+    const newAttempt: Attempt = { attemptedAt: now, stars };
+    const newBestStars = Math.max(existing.bestStars, stars);
+    const newStatus = this.progressStatusFromStars(newBestStars);
+
+    const updated: LevelProgress = {
+      status: newStatus,
+      bestStars: newBestStars,
+      lastAttemptAt: now,
+      attempts: [...existing.attempts, newAttempt],
+    };
+
+    updateData[`progress.${level}`] = updated;
+    updateData.currentLevelStatus = newStatus;
+  }
 
   private determineRoles(participants: string[]): { aiRole: string; userRole: string } {
     if (!participants || participants.length === 0) {

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -60,6 +60,20 @@ export interface ScenarioAttempt {
     evaluation: ScenarioEvaluation;
 }
 
+export type ProgressStatus = 'reviewing' | 'failing' | 'passing' | 'passed';
+
+export interface Attempt {
+    attemptedAt: Timestamp;
+    stars: 1 | 2 | 3 | 4 | 5;
+}
+
+export interface LevelProgress {
+    status: ProgressStatus;
+    bestStars: number; // 0 = no attempt yet
+    lastAttemptAt: Timestamp | null;
+    attempts: Attempt[];
+}
+
 export interface Scenario {
     id: string;
     /** @deprecated - migrating to User state models */
@@ -106,6 +120,9 @@ export interface Scenario {
     targetVocab?: string;
     sourceKuId?: string;
     isActive?: boolean;
+
+    progress?: Record<string, LevelProgress>;
+    currentLevelStatus?: ProgressStatus;
 }
 
 export interface ScenarioTemplate {

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -479,24 +479,23 @@ export default function ScenarioPage({
       {scenario.state === "completed" && scenario.evaluation ? (
         <section className="space-y-8">
           <div className="bg-white border border-slate-200 rounded-xl overflow-hidden shadow-sm animate-in fade-in slide-in-from-bottom-4">
-            <div className="bg-green-600 text-white p-6 text-center">
-              <div className="text-4xl mb-2">🎉</div>
-              <h2 className="text-3xl font-bold mb-2">Mission Debrief</h2>
-              <div className="flex justify-center gap-1 text-amber-300 text-2xl">
-                {[...Array(5)].map((_, i) => (
-                  <span
-                    key={i}
-                    className={
-                      i < scenario.evaluation!.rating
-                        ? "opacity-100"
-                        : "opacity-30"
-                    }
-                  >
-                    ★
-                  </span>
-                ))}
-              </div>
-            </div>
+            {(() => {
+              const rating = scenario.evaluation!.rating;
+              const headerBg = rating <= 2 ? "bg-red-600" : rating <= 4 ? "bg-amber-500" : "bg-green-600";
+              const emoji = rating <= 2 ? "😓" : rating <= 4 ? "👍" : "🎉";
+              const title = rating <= 2 ? "Keep Practising" : rating <= 4 ? "Good Effort!" : "Mission Complete!";
+              return (
+                <div className={`${headerBg} text-white p-6 text-center`}>
+                  <div className="text-4xl mb-2">{emoji}</div>
+                  <h2 className="text-3xl font-bold mb-2">{title}</h2>
+                  <div className="flex justify-center gap-1 text-amber-300 text-2xl">
+                    {[...Array(5)].map((_, i) => (
+                      <span key={i} className={i < rating ? "opacity-100" : "opacity-30"}>★</span>
+                    ))}
+                  </div>
+                </div>
+              );
+            })()}
 
             <div className="p-8 space-y-8">
               {/* General Feedback */}
@@ -557,6 +556,26 @@ export default function ScenarioPage({
                   </div>
                 </div>
               )}
+
+              {/* Tiered guidance */}
+              {(() => {
+                const rating = scenario.evaluation!.rating;
+                if (rating <= 2) return (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-800">
+                    You're still learning this one. Work through the grammar notes and vocabulary below, then come back and try again when you feel ready.
+                  </div>
+                );
+                if (rating <= 4) return (
+                  <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
+                    You did well, but there's room to improve. Study the notes and vocabulary again, then come back aiming for {rating === 3 ? "4 or even 5" : "5"} stars.
+                  </div>
+                );
+                return (
+                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm text-green-800">
+                    Outstanding! You've fully mastered this scenario. When you're ready, you can try a harder version — look for the option to regenerate at the next JLPT level from the scenarios library.
+                  </div>
+                );
+              })()}
 
               <div className="pt-6 border-t border-slate-100 flex justify-between items-center">
                 {scenario.evaluation.outcome === "failed" ? (

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -104,6 +104,9 @@ export interface Scenario {
   targetVocab?: string;
   sourceKuId?: string;
   isActive?: boolean;
+
+  progress?: Record<string, LevelProgress>;
+  currentLevelStatus?: ProgressStatus;
 }
 
 export interface ScenarioTemplate {
@@ -144,6 +147,20 @@ export interface ScenarioAttempt {
   completedAt: Timestamp;
   chatHistory: ChatMessage[];
   evaluation: ScenarioEvaluation;
+}
+
+export type ProgressStatus = 'reviewing' | 'failing' | 'passing' | 'passed';
+
+export interface Attempt {
+  attemptedAt: Timestamp;
+  stars: 1 | 2 | 3 | 4 | 5;
+}
+
+export interface LevelProgress {
+  status: ProgressStatus;
+  bestStars: number; // 0 = no attempt yet
+  lastAttemptAt: Timestamp | null;
+  attempts: Attempt[];
 }
 
 export class GenerateScenarioDto {


### PR DESCRIPTION
Scenario progress tracking + AI question type branching                                                                
                                                                                                                         
  Scenario progress tracking
                                                                                                                         
  Adds ProgressStatus, Attempt, and LevelProgress types to both type files, and progress?: Record<string, LevelProgress> 
  / currentLevelStatus?: ProgressStatus to the Scenario interface.
                                                                                                                         
  When a completed scenario is evaluated, ScenariosService.writeProgressUpdate records the attempt, updates bestStars    
  (never regresses — 5 stars stays passed), and writes the result via Firestore dot-notation (progress.N5) so multiple
  JLPT levels coexist. currentLevelStatus is denormalised for future dashboard queries.                                  
                                                            
  The assessment screen now adapts by star count: red "Keep Practising" header (1–2), amber "Good Effort!" (3–4), green  
  "Mission Complete!" (5), each with contextual guidance text.
                                                                                                                         
  AI question type branching — noun+particle                

  generateVocabQuestion now inspects the KU meaning field before picking a question type. Verbs (meaning starts with "to 
  ") draw from the existing VOCAB_QUESTION_OPTIONS. Non-verbs draw from a new NOUN_QUESTION_OPTIONS (noun-particle,
  translation) — conjugation and plain fill-in-the-blank are excluded.                                                   
                                                            
  noun-particle questions blank out <noun><particle> together (e.g. 歯を, 図書館で). The context field follows "Specify  
  [label] as [role]" to pin the correct particle; accepted_alternatives is always empty.
                                                                                                                         
  GeminiService.generateQuestionAI gains an optional fewShotTurns parameter. The five noun-particle examples are passed  
  as real role: user/model conversation turns rather than embedded in the system prompt — necessary because
  responseSchema (controlled generation) mode ignores JSON objects in the system instruction. A log line on each         
  generation records kuId + meaning + isVerb for diagnosing branching.
