### PR TITLE
fix: make concepts async

### DIFF
--- a/backend/src/concepts/concepts.controller.ts
+++ b/backend/src/concepts/concepts.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Logger, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Logger, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
 import { ConceptsService } from './concepts.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
@@ -11,16 +11,19 @@ export class ConceptsController {
   constructor(private readonly conceptsService: ConceptsService) {}
 
   @Post('generate')
-  async generate(
+  @HttpCode(202)
+  generate(
     @UserId() uid: string,
     @Body('topic') topic: string,
     @Body('notes') notes?: string,
   ) {
-    this.logger.log(`POST /concepts/generate — uid=${uid} topic="${topic}" notes=${notes ? `"${notes.slice(0, 80)}…"` : 'none'}`);
-    const result = await this.conceptsService.generate(uid, topic, notes);
-    await this.conceptsService.enroll(uid, result.id);
-    this.logger.log(`POST /concepts/generate — done, id=${result.id}`);
-    return result;
+    this.logger.log(`POST /concepts/generate — uid=${uid} topic="${topic}" (async)`);
+    this.conceptsService.generate(uid, topic, notes)
+      .then(result => this.conceptsService.enroll(uid, result.id)
+        .then(() => this.logger.log(`POST /concepts/generate — done, id=${result.id}`))
+      )
+      .catch(err => this.logger.error(`POST /concepts/generate — failed for uid=${uid} topic="${topic}"`, err));
+    return { status: 'generating' };
   }
 
   /**

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -46,7 +46,7 @@ You MUST return a valid JSON object matching this schema exactly:
   "data": {
     "title": "<Human-readable title>",
     "reading": "<Kana reading of the core concept — e.g. 'まい' for 枚, 'をおねがいします' for ～をお願いします. Omit if the title contains no kanji or kana that need a reading.>",
-    "overview": "<Two-sentence maximum introduction>",
+    "overview": "<Multi-sentence introduction, soft maximum is four sentence but you can use more for more complex concepts>",
     "mechanics": [
       {
         "goalTitle": "<Action-oriented title, e.g. Describe a noun using a habitual or future action>",

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -7,6 +7,7 @@ import { QuestionsModule } from 'src/questions/questions.module';
 import { KnowledgeUnitsModule } from 'src/knowledge-units/knowledge-units.module';
 import { StatsModule } from '../stats/stats.module';
 import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
+import { ScenariosModule } from '../scenarios/scenarios.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge
     KnowledgeUnitsModule,
     StatsModule,
     UserKnowledgeUnitsModule,
+    ScenariosModule,
   ],
   controllers: [ReviewsController],
   providers: [ReviewsService],

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -18,6 +18,7 @@ import { ReviewFacet } from '@/types';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { StatsService } from '../stats/stats.service';
+import { ScenariosService } from '../scenarios/scenarios.service';
 import { buildAnswerEvaluatorPrompt } from '../prompts/evaluation.prompts';
 
 @Injectable()
@@ -45,6 +46,7 @@ export class ReviewsService {
         private readonly knowledgeUnitsService: KnowledgeUnitsService,
         private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
         private readonly statsService: StatsService,
+        private readonly scenariosService: ScenariosService,
     ) { }
 
     private facetsColRef(uid: string): CollectionReference {
@@ -141,6 +143,18 @@ export class ReviewsService {
                 this.logger.log(`Marked UKU mastered for uid=${uid} kuId=${txResult.kuId}`);
             } catch (e) {
                 this.logger.error(`Failed to mark UKU mastered for uid=${uid} kuId=${txResult.kuId}`, e);
+            }
+        }
+
+        // Post-transaction: check if a linked scenario's vocab is now all drill-ready
+        if (txResult.newStage >= 1 && txResult.kuId) {
+            try {
+                const uku = await this.userKnowledgeUnitsService.findByKuId(uid, txResult.kuId);
+                if (uku?.source?.type === 'scenario') {
+                    await this.scenariosService.checkAndSetVocabReady(uid, uku.source.id);
+                }
+            } catch (e) {
+                this.logger.error(`Failed to check vocabReady for uid=${uid} kuId=${txResult.kuId}`, e);
             }
         }
 

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -18,6 +18,8 @@ import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildChatSy
 
 import { ScenarioTemplate, SCENARIO_TEMPLATES } from './templates';
 
+const VOCAB_READY_MIN_STAGE = 1;
+
 @Injectable()
 export class ScenariosService {
   private readonly logger = new Logger(ScenariosService.name);
@@ -515,6 +517,22 @@ export class ScenariosService {
     this.logger.log(`AI Role: ${aiRole}, User Role: ${userRole}`);
 
     return { aiRole, userRole };
+  }
+
+  async checkAndSetVocabReady(uid: string, scenarioId: string): Promise<void> {
+    const scenario = await this.getScenario(uid, scenarioId);
+    if (!scenario || scenario.state !== 'drill' || scenario.vocabReady === true) return;
+
+    const linkedKuIds = scenario.extractedKUs.filter(ku => ku.kuId).map(ku => ku.kuId!);
+    if (linkedKuIds.length === 0) return;
+
+    const kuStatus = await this.getKuStatus(uid, scenarioId);
+    const allReady = linkedKuIds.every(kuId => (kuStatus[kuId]?.minSrsStage ?? -1) >= VOCAB_READY_MIN_STAGE);
+
+    if (allReady) {
+      await this.scenariosColRef(uid).doc(scenarioId).update({ vocabReady: true });
+      this.logger.log(`Set vocabReady=true for scenario ${scenarioId} uid=${uid}`);
+    }
   }
 
   async getKuStatus(uid: string, scenarioId: string): Promise<Record<string, { maxSrsStage: number | null; minSrsStage: number | null }>> {

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -123,6 +123,9 @@ export interface Scenario {
 
     progress?: Record<string, LevelProgress>;
     currentLevelStatus?: ProgressStatus;
+
+    /** Set to true when all linked vocab KUs have minSrsStage >= VOCAB_READY_MIN_STAGE. Written by ReviewsService post-SRS-update. Used for dashboard queries. */
+    vocabReady?: boolean;
 }
 
 export interface ScenarioTemplate {

--- a/frontend/src/app/concepts/page.tsx
+++ b/frontend/src/app/concepts/page.tsx
@@ -22,6 +22,7 @@ export default function ConceptsDashboard() {
   const [notes, setNotes] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [generateError, setGenerateError] = useState<string | null>(null);
+  const [generatePending, setGeneratePending] = useState(false);
 
   // Recent activity state
   const [recentConcepts, setRecentConcepts] = useState<UserConceptEntry[]>([]);
@@ -39,6 +40,7 @@ export default function ConceptsDashboard() {
     e.preventDefault();
     setIsGenerating(true);
     setGenerateError(null);
+    setGeneratePending(false);
 
     try {
       const res = await apiFetch("/api/concepts/generate", {
@@ -47,12 +49,19 @@ export default function ConceptsDashboard() {
         body: JSON.stringify({ topic: topic.trim(), notes: notes.trim() || undefined }),
       });
 
+      if (res.status === 202) {
+        setTopic("");
+        setNotes("");
+        setGeneratePending(true);
+        return;
+      }
+
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || "Generation failed");
-
       router.push(`/concepts/${data.id}`);
     } catch (err) {
-      setGenerateError(err instanceof Error ? err.message : "An unknown error occurred");
+      setGenerateError(err instanceof Error ? err.message : "Generation failed — please try again");
+    } finally {
       setIsGenerating(false);
     }
   };
@@ -107,6 +116,11 @@ export default function ConceptsDashboard() {
             />
           </div>
 
+          {generatePending && (
+            <p className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+              Your concept is being generated — check <a href="/concepts/library" className="underline font-medium">My Concepts</a> in a couple of minutes.
+            </p>
+          )}
           {generateError && (
             <p className="text-sm text-shodo-accent">{generateError}</p>
           )}

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -107,6 +107,7 @@ export interface Scenario {
 
   progress?: Record<string, LevelProgress>;
   currentLevelStatus?: ProgressStatus;
+  vocabReady?: boolean;
 }
 
 export interface ScenarioTemplate {


### PR DESCRIPTION
Backend (concepts.controller.ts)                                                                                       
  generate is now synchronous from the controller's perspective — it fires generate() → enroll() as a chained promise,   
  logs completion or error, and immediately returns { status: 'generating' } with HTTP 202. No async/await in the        
  controller body, so it can never time out waiting for Gemini.                                                          
                                                                                                                         
  Frontend (concepts/page.tsx)                                                                                           
  - Added generatePending state
  - On 202: clears the form fields, sets generatePending = true, returns early — no navigation, no error                 
  - isGenerating now reliably resets in finally regardless of outcome                                   
  - Pending state renders a green banner with a link to My Concepts                                                      
  - Error state unchanged for any non-202 failure (shouldn't happen now, but kept as a fallback)                         
                                                                                                                         
  The router import is still there but no longer used for the generate path — you may want to clean it up if it's not    
  used elsewhere, but it won't cause any issues.                                          