### PR TITLE
fix: concept questions and examples

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,6 +276,12 @@ The following work is required to complete proper multi-user support. Each item 
 
 Rank nominally 0–100 but is not hard-clamped; `>= 30` is the only gate used in queries.
 
+### Concept KU routing
+
+Before falling through to `generateVocabQuestion`, `generateAndSave` checks whether the `kuId` belongs to a Concept. It first tries `knowledgeUnitsService.findOne` (in case a Concept-typed KU ever lands in `knowledge-units`), then falls back to a direct Firestore read of the `concepts` collection — because `ConceptsService.createFacets` sets `kuId = conceptId`, pointing into `concepts` not `knowledge-units`. If the document exists and has mechanics, a random mechanic is picked and `generateConceptQuestion` is called. Only after both lookups fail does execution fall through to the vocab path.
+
+Concept questions: `buildConceptQuestionPrompt` enforces that the `question` field is written entirely in English; any Japanese sentence shown to the user is embedded as a quoted string within the English instruction.
+
 ### Verb vs noun question type branching
 
 `generateVocabQuestion` inspects `meaning` (fetched from the KU) before picking a question type:
@@ -321,9 +327,13 @@ Written in `ScenariosService.writeProgressUpdate` (called from the `advanceState
 | 3–4 | "Good Effort!" (amber) | Study notes again, come back aiming for 5 stars |
 | 5 | "Mission Complete!" (green) | Try next JLPT level from the scenario library |
 
-### `vocabReady` flag (planned)
+### `vocabReady` flag
 
-Once all vocab KUs linked to a `drill`-state scenario have `minSrsStage >= 1`, a `vocabReady: true` flag should be written to the scenario document. Trigger: `ReviewsService` SRS update — look up the UKU's `source.type === 'scenario'` to find the scenario, run `getKuStatus`, write the flag if all pass. Needed for dashboard queries like "scenarios ready to start roleplay".
+Once all vocab KUs linked to a `drill`-state scenario have `minSrsStage >= 1`, `vocabReady: true` is written to the scenario document.
+
+Trigger: post-transaction block in `ReviewsService.updateFacetSrs` — after a successful SRS stage increment, looks up the UKU by `kuId`; if `uku.source.type === 'scenario'`, calls `ScenariosService.checkAndSetVocabReady(uid, scenarioId)`. That method early-exits if already `true` or `state !== 'drill'`, then uses `getKuStatus` to check all linked KU facets. Errors are caught and logged (non-blocking). Constant `VOCAB_READY_MIN_STAGE = 1` in `scenarios.service.ts`.
+
+Intended use: dashboard queries such as `where('state','==','drill').where('vocabReady','==',true)`. Requires a Firestore composite index on `users/{uid}/scenarios`.
 
 ---
 
@@ -421,7 +431,7 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 **UI overhaul — profile, avatar, nav restructure (2026-04)**
 
 - Added `frontend/src/components/UserAvatar.tsx` — initials-based avatar circle with deterministic colour derived from email hash.
-- Added `frontend/src/components/AvatarMenu.tsx` — avatar button on the far right of the header that opens a dropdown containing Profile & Settings, Library, Manage, and Sign Out. Manage and Library links removed from the main nav row.
+- Added `frontend/src/components/AvatarMenu.tsx` — avatar button on the far right of the header that opens a dropdown containing Profile & Settings, furigana toggle, Library, Manage, and Sign Out. Manage and Library links removed from the main nav row. The furigana toggle is a pill switch that calls `applyFurigana` + `PATCH /api/users/me/preferences` without closing the menu.
 - Added `frontend/src/app/profile/page.tsx` — user profile page showing avatar, email, and a Furigana toggle that persists to the backend.
 - Added `frontend/src/lib/furigana.ts` — shared `applyFurigana` / `loadFurigana` utilities (previously duplicated inline in `Header.tsx`).
 - `Header.tsx` restructured: furigana toggle removed from header bar (Alt+F shortcut retained, now also PATCHes the backend); Concepts link added between Scenarios and the avatar.
@@ -432,8 +442,9 @@ Previously, the Next.js `frontend` app hosted Next API Routes (`/src/app/api/...
 - New `ConceptKnowledgeUnit` type — fully typed `data` shape replacing the previous `[key: string]: any` open bag:
   - `title`, `overview` (≤ 2 sentences, no English grammar meta-language)
   - `mechanics[]` — intent-driven entries with `goalTitle`, `englishIntent`, `rule`, `simpleExample` (fragment + literal translation + `highlight`), `naturalExample` (full sentence embedding the fragment + `highlight`)
-  - `examples[]` — exactly 3 practical sentences with `japanese`, `reading`, `english`, `targetGrammar`
+  - `examples[]` — exactly 3 practical sentences with `japanese` (bracket-notation furigana e.g. `彼[かれ]は学生[がくせい]です`), `english`, `targetGrammar` (plain text, no brackets); `reading` field deprecated/optional for backward compat.
   - `highlight` fields use the same verbatim-substring contract as `targetGrammar` and drive bold + dotted-underline rendering in the mechanics cards.
+  - `examples` rendered in `concepts/[id]/page.tsx` via `furiganaHighlight` — position-maps plain-text `targetGrammar` into the bracket-notation `japanese` string, then renders each segment through `FuriganaText` with the matched segment wrapped in `<mark>`. Furigana show/hide respects the global `html[data-furigana]` toggle.
 - `backend/src/concepts/` module added: `ConceptsService` (generate / findById / findAll), `ConceptsController` (`POST /api/concepts/generate`, `GET /api/concepts`, `GET /api/concepts/:id`), `ConceptsModule` (imports `GeminiModule`).
 - `CONCEPTS_COLLECTION = 'concepts'` added to `firebase.module.ts`.
 - `GeminiService.generateConcept` added — mirrors `generateLesson` pattern (api-log start/complete, defensive JSON extraction) but uses `this.conceptModelName` sourced from `GEMINI_MODEL` env var, falling back to `this.modelName`. Logs startup line `Using Gemini concept model: …`.

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -30,7 +30,9 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
 
 3. 'examples': Provide exactly 3 practical, everyday example sentences covering the concept. No more, no less.
 
-4. 'targetGrammar': The specific Japanese substring in the example sentence that directly represents the concept. Must appear verbatim inside the 'japanese' string.
+4. 'japanese': Write the sentence with furigana in bracket notation — attach the reading in square brackets immediately after each kanji or kanji compound, e.g. 彼[かれ]は学生[がくせい]です。 Pure kana and punctuation need no brackets.
+
+5. 'targetGrammar': The specific Japanese substring that represents the grammar concept, written as plain Japanese text (no furigana brackets). It must appear verbatim in the plain text of 'japanese' after stripping all bracket annotations.
 
 **Constraints:**
 - ${USER_TARGET_LEVEL}
@@ -41,7 +43,7 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
 You MUST return a valid JSON object matching this schema exactly:
 {
   "type": "Concept",
-  "content": "<slug — lowercase, hyphens, e.g. relative-clauses>",
+  "content": "The topic being introduced.",
   "relatedUnits": [],
   "data": {
     "title": "<Human-readable title>",
@@ -68,10 +70,9 @@ You MUST return a valid JSON object matching this schema exactly:
     ],
     "examples": [
       {
-        "japanese": "<Full Japanese sentence>",
-        "reading": "<Full reading in hiragana/katakana, space-separated by word>",
+        "japanese": "<Full Japanese sentence with furigana in bracket notation, e.g. 彼[かれ]は学生[がくせい]ではありません。>",
         "english": "<Natural English translation>",
-        "targetGrammar": "<Specific substring that represents the concept — must appear verbatim in japanese>"
+        "targetGrammar": "<Plain-text substring representing the concept — must appear verbatim in japanese after stripping bracket annotations>"
       }
     ]
   }

--- a/backend/src/prompts/quiz.prompts.ts
+++ b/backend/src/prompts/quiz.prompts.ts
@@ -174,10 +174,11 @@ You MUST return ONLY a valid JSON object with the following schema:
 
 Rules:
 1. The answer MUST require the user to apply the provided Structural Rule.
-2. ${NO_ROMAJI}
-3. For 'applied-cloze', the blank must encapsulate the conjugated rule (e.g., if the rule is modifying a noun, the blank should ideally be the modifier clause).
-4. Use standard, N4/N5 level vocabulary for the surrounding sentence so the user focuses strictly on the grammar mechanic.
-5. ${JSON_ONLY_OUTPUT}`;
+2. The 'question' field MUST be written entirely in English. Any Japanese sentence being shown to the user (e.g. an error-correction sentence) must be embedded inline as a quoted string within the English question text — never write the instruction itself in Japanese.
+3. ${NO_ROMAJI}
+4. For 'applied-cloze', the blank must encapsulate the conjugated rule (e.g., if the rule is modifying a noun, the blank should ideally be the modifier clause).
+5. Use standard, N4/N5 level vocabulary for the surrounding sentence so the user focuses strictly on the grammar mechanic.
+6. ${JSON_ONLY_OUTPUT}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -4,6 +4,7 @@ import {
   FIRESTORE_CONNECTION,
   QUESTIONS_COLLECTION,
   QUESTION_STATES_SUBCOLLECTION,
+  CONCEPTS_COLLECTION,
   Timestamp,
   FieldValue,
 } from '../firebase/firebase.module';
@@ -158,6 +159,32 @@ export class QuestionsService {
     if (mechanicData) {
       return this.generateConceptQuestion(uid, mechanicData, kuId, facetId);
     }
+
+    if (kuId) {
+      // Check knowledge-units collection first
+      try {
+        const kuData = await this.knowledgeUnitsService.findOne(kuId);
+        if (kuData.type === 'Concept' && kuData.data.mechanics?.length > 0) {
+          const mechanic = kuData.data.mechanics[Math.floor(Math.random() * kuData.data.mechanics.length)];
+          this.logger.log(`Routing concept KU ${kuId} to concept question path (mechanic: "${mechanic.goalTitle}")`);
+          return this.generateConceptQuestion(uid, mechanic, kuId, facetId);
+        }
+      } catch {
+        // Not in knowledge-units — try the concepts collection
+      }
+
+      // Concept KUs live in their own collection
+      const conceptDoc = await this.db.collection(CONCEPTS_COLLECTION).doc(kuId).get();
+      if (conceptDoc.exists) {
+        const concept = conceptDoc.data() as ConceptKnowledgeUnit;
+        if (concept.data?.mechanics?.length > 0) {
+          const mechanic = concept.data.mechanics[Math.floor(Math.random() * concept.data.mechanics.length)];
+          this.logger.log(`Routing concepts/${kuId} to concept question path (mechanic: "${mechanic.goalTitle}")`);
+          return this.generateConceptQuestion(uid, mechanic, kuId, facetId);
+        }
+      }
+    }
+
     return this.generateVocabQuestion(uid, topic, kuId, facetId);
   }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -315,7 +315,7 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
     }>;
     examples: Array<{
       japanese: string;
-      reading: string;
+      reading?: string;
       english: string;
       targetGrammar: string;
     }>;

--- a/frontend/src/app/concepts/[id]/page.tsx
+++ b/frontend/src/app/concepts/[id]/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { apiFetch } from "@/lib/api-client";
 import { ConceptKnowledgeUnit } from "@/types";
+import { FuriganaText } from "@/components/FuriganaText";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -27,21 +28,39 @@ function highlightClause(text: string, target: string) {
   );
 }
 
-function highlightGrammar(text: string, target: string) {
-  const parts = text.split(target);
-  if (parts.length === 1) return <span>{text}</span>;
+function furiganaHighlight(text: string, target: string): React.ReactNode {
+  if (!target) return <FuriganaText text={text} />;
+
+  // Strip [reading] annotations to locate the plain-text target
+  const stripped = text.replace(/\[[^\]]+\]/g, '');
+  const idx = stripped.indexOf(target);
+  if (idx === -1) return <FuriganaText text={text} />;
+
+  // Build a map: stripped-text index → original-string index
+  const strippedToOrig: number[] = [];
+  let si = 0;
+  let inBracket = false;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '[') { inBracket = true; continue; }
+    if (text[i] === ']') { inBracket = false; continue; }
+    if (!inBracket) strippedToOrig[si++] = i;
+  }
+
+  const origStart = strippedToOrig[idx];
+  let origEnd = strippedToOrig[idx + target.length - 1] + 1;
+  // Include any [reading] bracket that immediately follows the last target character
+  if (origEnd < text.length && text[origEnd] === '[') {
+    const close = text.indexOf(']', origEnd);
+    if (close !== -1) origEnd = close + 1;
+  }
+
   return (
     <>
-      {parts.map((part, i) => (
-        <Fragment key={i}>
-          {part}
-          {i < parts.length - 1 && (
-            <mark className="bg-shodo-accent/15 text-shodo-accent rounded px-0.5 not-italic">
-              {target}
-            </mark>
-          )}
-        </Fragment>
-      ))}
+      <FuriganaText text={text.slice(0, origStart)} />
+      <mark className="bg-shodo-accent/15 text-shodo-accent rounded px-0.5 not-italic">
+        <FuriganaText text={text.slice(origStart, origEnd)} />
+      </mark>
+      <FuriganaText text={text.slice(origEnd)} />
     </>
   );
 }
@@ -194,9 +213,8 @@ export default function ConceptPage() {
           {data.examples.map((ex, i) => (
             <div key={i} className="border border-shodo-ink/10 rounded-xl px-6 py-5 space-y-2">
               <p className="text-2xl text-shodo-ink leading-snug">
-                {highlightGrammar(ex.japanese, ex.targetGrammar)}
+                {furiganaHighlight(ex.japanese, ex.targetGrammar)}
               </p>
-              <p className="text-sm text-shodo-ink/45 leading-snug">{ex.reading}</p>
               <p className="text-sm text-shodo-ink/65 border-t border-shodo-ink/8 pt-2 mt-2">{ex.english}</p>
             </div>
           ))}

--- a/frontend/src/components/AvatarMenu.tsx
+++ b/frontend/src/components/AvatarMenu.tsx
@@ -4,11 +4,18 @@ import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useAuth } from "@/providers/AuthProvider";
 import { UserAvatar } from "./UserAvatar";
+import { applyFurigana, loadFurigana } from "@/lib/furigana";
+import { apiFetch } from "@/lib/api-client";
 
 export function AvatarMenu() {
   const { user, signOut } = useAuth();
   const [open, setOpen] = useState(false);
+  const [showFurigana, setShowFurigana] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setShowFurigana(loadFurigana());
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -22,6 +29,17 @@ export function AvatarMenu() {
   }, [open]);
 
   if (!user?.email) return null;
+
+  const handleToggleFurigana = () => {
+    const next = !showFurigana;
+    setShowFurigana(next);
+    applyFurigana(next);
+    apiFetch("/api/users/me/preferences", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ showFurigana: next }),
+    }).catch(() => {});
+  };
 
   const handleSignOut = async () => {
     setOpen(false);
@@ -53,6 +71,20 @@ export function AvatarMenu() {
           >
             Profile &amp; Settings
           </Link>
+
+          <button
+            onClick={handleToggleFurigana}
+            className="flex w-full items-center justify-between px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors"
+          >
+            <span>Furigana</span>
+            <span
+              role="switch"
+              aria-checked={showFurigana}
+              className={`relative ml-3 w-8 h-4 rounded-full shrink-0 transition-colors duration-200 ${showFurigana ? "bg-shodo-ink" : "bg-shodo-ink/20"}`}
+            >
+              <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-shodo-paper shadow-sm transition-all duration-200 ${showFurigana ? "left-4" : "left-0.5"}`} />
+            </span>
+          </button>
 
           <div className="h-px bg-shodo-ink/10 my-1" />
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -350,7 +350,7 @@ export interface ConceptKnowledgeUnit extends KnowledgeUnitBase {
     }>;
     examples: Array<{
       japanese: string;
-      reading: string;
+      reading?: string;
       english: string;
       targetGrammar: string;
     }>;


### PR DESCRIPTION
PR Summary
                                                                                                                         
  Fix: Concept KU questions using wrong prompt
                                                                                                                         
  Concept KUs live in the concepts Firestore collection, not knowledge-units. QuestionsService.generateAndSave was       
  catching the not-found error from knowledgeUnitsService.findOne and silently falling through to generateVocabQuestion, 
  which then produced noun-particle or translation questions for grammar concepts.                                       
                                                            
  Fix: after the knowledge-units lookup fails, generateAndSave now imports CONCEPTS_COLLECTION and queries it directly.  
  If the document exists and has mechanics, a random mechanic is selected and generateConceptQuestion is called.
                                                                                                                         
  Fix: Concept questions rendered in Japanese                                                                            
  
  buildConceptQuestionPrompt now has an explicit rule: the question field must be written entirely in English, with      
  Japanese sentences quoted inline rather than as the instruction itself.
                                                                                                                         
  Feat: Concept examples use furigana                                                                                    
  
  Concept examples[].japanese now uses Kanji[Reading] bracket notation (matching the lesson format). The separate reading
   field is removed from the AI prompt schema and made optional in types for backward compatibility. On the frontend,
  highlightGrammar is replaced by furiganaHighlight — a position-mapping helper that strips brackets to locate the       
  plain-text targetGrammar, maps back to the bracket-notation string, and renders each segment through FuriganaText with
  the matched segment in a <mark>. The furigana visibility respects the user's global toggle.

  Feat: Furigana toggle in avatar menu                                                                                   
  
  The furigana on/off switch is now accessible from the avatar dropdown on every page. Clicking the pill switch calls    
  applyFurigana and persists the preference to the backend without closing the menu, so the effect is immediately
  visible. The profile page toggle remains as a secondary access point.  