### PR TITLE
feat: add import scenarios and search for manage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -506,6 +506,27 @@ Library page (`/learn`): Kanji items now show `data.meaning` in the hint column 
 
 ---
 
+**Manage page — Search & Enroll + Import Scenario (2026-04-30)**
+
+- **KU Search endpoint**: `GET /api/knowledge-units/search?q=` — Firestore prefix range query (`.where('content', '>=', q).where('content', '<=', q + '').limit(15)`). Guard on `data.createdAt` before calling `.toDate()` — WaniKani bulk-imported docs have no `createdAt` field.
+- **KU create find-or-create**: `KnowledgeUnitsController.create` now calls `findByContent` first; if found, links the user's UKU to the existing global KU and returns `{ id, isNew: false }`. No duplicate global KUs created.
+- **Manage page Search & Enroll section** (`frontend/src/app/manage/page.tsx`): debounced (300ms) search input, result list with per-item "Add"/"In queue" state, dedup against enrolled KUs.
+- **Import Scenario**: `POST /api/scenarios/import` — `ImportScenarioDto`: `conversationText`, `userRole`, `aiRoles?: string[]` (or legacy `aiRole?: string`), `difficulty?`, `sceneNotes?`. AI preserves Japanese verbatim, maps speaker labels to role names, extracts vocab + grammar. Stored with `sourceType: 'custom'`. New page at `/manage/scenarios`.
+- **`buildImportPrompt`** in `backend/src/prompts/scenario.prompts.ts` — instructs AI to preserve Japanese verbatim, map speaker labels to role names, infer setting, return same JSON schema as `buildArchitectPrompt`. Multi-role aware.
+
+**Three-role scenario support (2026-04-30)**
+
+- `Scenario.roles.ai: string | string[]` in both type files — existing single-string docs work without change.
+- `ChatMessage.roleName?: string` — set from `speaker` in Gemini's JSON response. Frontend chat bubble shows the actual character name instead of "ai". Falls back to `scenario.roles?.ai` (first element if array) for old messages.
+- `buildChatSystemPrompt` accepts `aiRoles: string | string[]`. Tells the AI which characters it plays; for multiple roles adds instruction to respond as ONE character per turn and always set `speaker` to the exact role name.
+- `buildImportPrompt` accepts `aiRoles: string[]`. Generates correct `participants` list and `roles.ai` as string (single) or array (multiple) in the output JSON.
+- `getInitialChatHistory` — fixed to prefer `scenario.roles` over `determineRoles` fallback; checks first dialogue speaker against all AI roles (array).
+- `generateEvaluation` — normalises `roles.ai` to string (`join(', ')`) for the evaluation context passed to Gemini.
+- Import form — "Other Role" input is now a dynamic list; "Add another role" link appends a new row; `×` removes. Sends `aiRoles: string[]`.
+- Gemini chat response schema already had `speaker: STRING` — now used to populate `ChatMessage.roleName`.
+
+---
+
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.
   2. Authentication → Sign-in method → **Email link (passwordless sign-in)** enabled (sub-toggle under Email/Password).

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -35,6 +35,12 @@ export class KnowledgeUnitsController {
         return this.knowledgeUnitsService.update(id, body);
     }
 
+    @Get('search')
+    async search(@Query('q') q: string) {
+        if (!q || q.trim().length === 0) return [];
+        return this.knowledgeUnitsService.search(q.trim());
+    }
+
     @Get(':id')
     async findOne(@UserId() uid: string, @Param('id') id: string) {
         const ku = await this.knowledgeUnitsService.findOneById(id);
@@ -68,11 +74,29 @@ export class KnowledgeUnitsController {
     }
 
     @Post()
-    async create(@Body() body: any) {
+    async create(@UserId() uid: string, @Body() body: any) {
         if (!body.content || !body.type) {
             throw new BadRequestException('Content and Type are required');
         }
-        return this.knowledgeUnitsService.create(body);
+
+        // Find-or-create the global KU
+        const existing = await this.knowledgeUnitsService.findByContent(body.content, body.type);
+        let kuId: string;
+        let isNewKu: boolean;
+
+        if (existing) {
+            kuId = existing.id;
+            isNewKu = false;
+        } else {
+            const created = await this.knowledgeUnitsService.create(body);
+            kuId = created.id;
+            isNewKu = true;
+        }
+
+        // Link the KU to the user (idempotent)
+        await this.userKnowledgeUnitsService.create(uid, kuId);
+
+        return { id: kuId, isNew: isNewKu };
     }
 
 }

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -77,6 +77,27 @@ export class KnowledgeUnitsService {
         } as unknown as KnowledgeUnit;
     }
 
+    async search(query: string): Promise<KnowledgeUnit[]> {
+        const snapshot = await this.db
+            .collection(KNOWLEDGE_UNITS_COLLECTION)
+            .where('content', '>=', query)
+            .where('content', '<=', query + '\uf8ff')
+            .orderBy('content')
+            .limit(15)
+            .get();
+
+        if (snapshot.empty) return [];
+
+        return snapshot.docs.map(doc => {
+            const data = doc.data();
+            return {
+                id: doc.id,
+                ...data,
+                createdAt: data.createdAt ? (data.createdAt as Timestamp).toDate().toISOString() : null,
+            } as unknown as KnowledgeUnit;
+        });
+    }
+
     async findByKanjiComponent(kanjiChar: string): Promise<KnowledgeUnit[]> {
         const snapshot = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
             .where('type', '==', 'Vocab')

--- a/backend/src/prompts/scenario.prompts.ts
+++ b/backend/src/prompts/scenario.prompts.ts
@@ -3,7 +3,7 @@
  * Source: backend/src/scenarios/scenarios.service.ts
  */
 
-import { GenerateScenarioDto, Scenario } from '../types/scenario';
+import { GenerateScenarioDto, ImportScenarioDto, Scenario } from '../types/scenario';
 import { FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
 
 // ---------------------------------------------------------------------------
@@ -135,17 +135,21 @@ ${dto.userRole && dto.aiRole
  */
 export function buildChatSystemPrompt(
   scenario: Scenario,
-  aiRole: string,
+  aiRoles: string | string[],
   userRole: string,
   referenceScript: string,
   historyLines: string,
 ): string {
+  const rolesArray = Array.isArray(aiRoles) ? aiRoles : [aiRoles];
+  const multiRole = rolesArray.length > 1;
+  const roleLabel = multiRole ? rolesArray.join(', ') : rolesArray[0];
+
   return `
       You are a roleplay partner in a Japanese immersion scenario.
       **Scenario Context:**
       - Title: ${scenario.title}
       - Setting: ${scenario.setting.location}
-      - Your Role: ${aiRole}
+      - Your Role(s): ${roleLabel}
       - User Role: ${userRole}
       - Goal: ${scenario.setting.goal}
       - Difficulty: ${scenario.difficultyLevel}
@@ -157,9 +161,9 @@ export function buildChatSystemPrompt(
       ${historyLines}
 
       **INSTRUCTIONS:**
-      1. You are acting out the role of ${aiRole}.
+      1. You are acting out the role(s) of ${roleLabel}.${multiRole ? `\n      1a. Each response should come from ONE character. Pick the most appropriate character to respond based on context and the reference script.` : ''}
       2. Use the 'REFERENCE SCRIPT' as your guide for the conversation flow.
-      3. You must ensure key events/questions from the script occur (e.g., if the script has the shopkeeper ask for a passport, YOU must ask for the passport).
+      3. You must ensure key events/questions from the script occur.
       4. Speak ONLY in Japanese appropriate for the setting and your role.
       5. Engage the user to help them achieve the goal.
       6. Do NOT repeat greetings if they have already been said (check 'PREVIOUS CHAT HISTORY').
@@ -168,5 +172,87 @@ export function buildChatSystemPrompt(
       9. If the user makes a mistake (grammar/vocab), reply naturally but include a short "correction" in the JSON.
       10. Keep responses concise (1-2 sentences).
       11. CHECK GOAL: If the user has explicitly and successfully achieved the goal ("${scenario.setting.goal}") during this turn, set 'sceneFinished' to true in your JSON response. Otherwise false.
+      12. Set 'speaker' in your JSON response to the exact role name of the character speaking (one of: ${rolesArray.join(', ')}).
     `;
+}
+
+// ---------------------------------------------------------------------------
+// Manual conversation import prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the prompt for structuring a user-provided conversation into a scenario.
+ * Preserves the original Japanese verbatim — no corrections or rewrites.
+ */
+export function buildImportPrompt(dto: ImportScenarioDto): string {
+  const aiRoles = dto.aiRoles ?? (dto.aiRole ? [dto.aiRole] : []);
+  const aiRoleList = aiRoles.join(', ');
+  const participantList = [dto.userRole, ...aiRoles].map(r => `"${r}"`).join(', ');
+  const aiRolesJson = aiRoles.length === 1 ? `"${aiRoles[0]}"` : JSON.stringify(aiRoles);
+
+  return `You are a Japanese language curriculum assistant.
+A learner has provided a conversation they want to practice. Structure it as a learning scenario.
+
+**Provided Conversation:**
+${dto.conversationText}
+
+**Parameters:**
+- Learner's Role: ${dto.userRole}
+- Partner Role(s): ${aiRoleList}
+- Target Level: ${dto.difficulty ?? 'N4'}${dto.sceneNotes ? `\n- Scene Context: ${dto.sceneNotes}` : ''}
+
+**Instructions:**
+1. **Dialogue:** Parse the conversation into structured lines.
+   - PRESERVE the original Japanese text VERBATIM — do NOT change, correct, or rewrite any Japanese.
+   - Identify which lines belong to "${dto.userRole}" and which to the partner role(s) (${aiRoleList}). Use these exact names as the speaker field.
+   - If there are multiple partner roles, assign each line to the most appropriate one based on the conversation context.
+   - If the conversation uses labels (A/B, names, numbers), map them to the correct role.
+   - Add an accurate English translation for each line.
+2. **Setting:** Infer location, participants, goal, timeOfDay, and visualPrompt from the conversation.${dto.sceneNotes ? ' Use the provided scene context as your primary guide.' : ''}
+3. **Vocabulary:** Extract 3-8 key vocabulary items the learner needs to participate in this conversation.
+4. **Grammar Notes:** Identify 1-3 grammar patterns used in the conversation and explain them Genki-style.
+5. **Title & Description:** Write a short English title and description for this scenario.
+
+**Data Formatting Rules:**
+- \`title\`, \`description\`, and all \`setting\` fields in English.
+- NO ROMAJI anywhere.
+- Extracted KUs: \`content\` = Japanese only, \`reading\` = kana only, \`meaning\` = English definition, \`jlptLevel\` = one of N5/N4/N3/N2/N1.
+- Grammar note fragments: ${FRAGMENT_CONTRACT}
+- ${ACCEPTED_ALTERNATIVES_DEF}
+
+**Output Schema (Return ONLY raw JSON):**
+{
+  "title": "Scenario Title",
+  "description": "Brief English context",
+  "setting": {
+    "location": "Specific location",
+    "participants": [${participantList}],
+    "goal": "What the learner needs to achieve",
+    "timeOfDay": "Morning/Afternoon/Evening/etc",
+    "visualPrompt": "Detailed visual description of the scene"
+  },
+  "roles": {
+    "user": "${dto.userRole}",
+    "ai": ${aiRolesJson}
+  },
+  "dialogue": [
+    { "speaker": "EXACT_ROLE_NAME", "text": "Japanese text verbatim", "translation": "English translation" }
+  ],
+  "extractedKUs": [
+    { "content": "本屋", "reading": "ほんや", "meaning": "Bookstore", "type": "vocab", "jlptLevel": "N4" }
+  ],
+  "grammarNotes": [
+    {
+      "pattern": "～をお願いします",
+      "title": "Grammar Point Name",
+      "explanation": "Clear explanation",
+      "exampleInContext": {
+        "japanese": "Example sentence from the conversation",
+        "english": "English translation",
+        "fragments": ["minimal", "chunks"],
+        "accepted_alternatives": []
+      }
+    }
+  ]
+}`;
 }

--- a/backend/src/scenarios/scenarios.controller.ts
+++ b/backend/src/scenarios/scenarios.controller.ts
@@ -12,7 +12,7 @@ import {
   UseGuards
 } from '@nestjs/common';
 import { ScenariosService } from './scenarios.service';
-import { GenerateScenarioDto, ChatTurnDto, ResetSessionDto } from '../types/scenario';
+import { GenerateScenarioDto, ImportScenarioDto, ChatTurnDto, ResetSessionDto } from '../types/scenario';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
 import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES } from '../prompts/scenario.prompts';
@@ -35,8 +35,16 @@ export class ScenariosController {
   @Post('generate')
   async generateScenario(@UserId() uid: string, @Body() dto: GenerateScenarioDto) {
     const id = await this.scenariosService.generateScenario(uid, dto);
+    return { id };
+  }
 
-    // FIX: Must return an object, not a raw string, so the frontend can parse it as JSON
+  @Post('import')
+  async importScenario(@UserId() uid: string, @Body() dto: ImportScenarioDto) {
+    const hasAiRole = dto.aiRole || (dto.aiRoles && dto.aiRoles.length > 0);
+    if (!dto.conversationText || !dto.userRole || !hasAiRole) {
+      throw new BadRequestException('conversationText, userRole, and at least one aiRole are required');
+    }
+    const id = await this.scenariosService.importScenario(uid, dto);
     return { id };
   }
 

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException
 } from '@nestjs/common';
 import { Firestore, CollectionReference, Timestamp, FieldValue } from 'firebase-admin/firestore';
-import { Scenario, GenerateScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt, ProgressStatus, LevelProgress, Attempt } from '../types/scenario';
+import { Scenario, GenerateScenarioDto, ImportScenarioDto, ScenarioState, ExtractedKU, ChatMessage, ScenarioEvaluation, ScenarioAttempt, ProgressStatus, LevelProgress, Attempt } from '../types/scenario';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { LessonsService } from '../lessons/lessons.service';
@@ -14,7 +14,7 @@ import { UserService } from '../users/user.service';
 import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
-import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildChatSystemPrompt } from '../prompts/scenario.prompts';
+import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildImportPrompt, buildChatSystemPrompt } from '../prompts/scenario.prompts';
 
 import { ScenarioTemplate, SCENARIO_TEMPLATES } from './templates';
 
@@ -150,6 +150,74 @@ export class ScenariosService {
     } catch (error) {
       this.logger.error('Scenario Generation Failed:', error);
       throw new InternalServerErrorException('Failed to generate scenario from AI', error);
+    }
+  }
+
+  async importScenario(uid: string, dto: ImportScenarioDto): Promise<string> {
+    const resolvedAiRoles = dto.aiRoles?.length ? dto.aiRoles : (dto.aiRole ? [dto.aiRole] : []);
+    if (!dto.conversationText?.trim() || !dto.userRole?.trim() || resolvedAiRoles.length === 0) {
+      throw new InternalServerErrorException('conversationText, userRole, and at least one aiRole are required');
+    }
+
+    const prompt = buildImportPrompt({
+      ...dto,
+      aiRoles: resolvedAiRoles,
+      difficulty: dto.difficulty ?? 'N4',
+    });
+
+    try {
+      const jsonString = await this.geminiService.generateScenario(prompt);
+      const data = JSON.parse(jsonString);
+
+      const docRef = this.scenariosColRef(uid).doc();
+      const id = docRef.id;
+
+      const cleanContent = (str: string) => str ? str.replace(/\(.*\)/g, '').replace(/（.*）/g, '').trim() : '';
+      const cleanMeaning = (str: string) => str ? str.replace(/^-/, '').trim() : '';
+
+      const newScenario: Scenario = {
+        id,
+        userId: uid,
+        title: data.title,
+        description: data.description,
+        difficultyLevel: dto.difficulty ?? 'N4',
+        setting: {
+          location: data.setting.location,
+          participants: data.setting.participants,
+          goal: data.setting.goal,
+          timeOfDay: data.setting.timeOfDay,
+          visualPrompt: data.setting.visualPrompt,
+        },
+        roles: data.roles,
+        dialogue: data.dialogue,
+        extractedKUs: data.extractedKUs.map((ku: any) => ({
+          content: cleanContent(ku.content),
+          reading: cleanContent(ku.reading),
+          meaning: cleanMeaning(ku.meaning),
+          type: 'vocab',
+          status: 'new',
+          jlptLevel: ku.jlptLevel ?? null,
+        })),
+        grammarNotes: data.grammarNotes,
+        state: 'encounter',
+        createdAt: Timestamp.now(),
+        chatHistory: [],
+        isObjectiveMet: false,
+        isActive: true,
+        sourceType: 'custom',
+      };
+
+      const cleanData = Object.fromEntries(
+        Object.entries(newScenario).filter(([_, value]) => value !== undefined)
+      );
+
+      await docRef.set(cleanData);
+      this.logger.log(`Imported scenario ${id} for uid=${uid}`);
+      return id;
+
+    } catch (error) {
+      this.logger.error('Scenario Import Failed:', error);
+      throw new InternalServerErrorException('Failed to import scenario', error);
     }
   }
 
@@ -324,16 +392,16 @@ export class ScenariosService {
     }
 
     let userRole = scenario.roles?.user;
-    let aiRole = scenario.roles?.ai;
+    let aiRoles: string | string[] | undefined = scenario.roles?.ai;
 
-    if (!userRole || !aiRole) {
+    if (!userRole || !aiRoles) {
       // Fallback for older scenarios that lack the 'roles' field
       const roles = this.determineRoles(scenario.setting.participants);
       userRole = roles.userRole;
-      aiRole = roles.aiRole;
+      aiRoles = roles.aiRole;
     }
 
-    const systemPrompt = buildChatSystemPrompt(scenario, aiRole, userRole, referenceScript, historyLines);
+    const systemPrompt = buildChatSystemPrompt(scenario, aiRoles, userRole, referenceScript, historyLines);
 
     // 3. Get AI Response
     const aiResponse = await this.geminiService.generateChatResponse(
@@ -353,6 +421,7 @@ export class ScenariosService {
       timestamp: Date.now(),
       correction: aiResponse.correction,
       sceneFinished: aiResponse.sceneFinished,
+      roleName: aiResponse.speaker || undefined,
     };
 
     // 5. Persist to Firestore (Atomic Update)
@@ -379,24 +448,38 @@ export class ScenariosService {
     if (!scenario.dialogue || scenario.dialogue.length === 0) return [];
 
     const firstLine = scenario.dialogue[0];
-    const { aiRole, userRole } = this.determineRoles(scenario.setting.participants);
 
+    let userRole: string;
+    let aiRolesRaw: string | string[];
+
+    if (scenario.roles?.user && scenario.roles?.ai) {
+      userRole = scenario.roles.user;
+      aiRolesRaw = scenario.roles.ai;
+    } else {
+      const roles = this.determineRoles(scenario.setting.participants);
+      userRole = roles.userRole;
+      aiRolesRaw = roles.aiRole;
+    }
+
+    const aiRoles = Array.isArray(aiRolesRaw) ? aiRolesRaw : [aiRolesRaw];
     const speaker = firstLine.speaker.toLowerCase();
-    const ai = aiRole.toLowerCase();
     const user = userRole.toLowerCase();
 
-    // Safety: If speaker matches User, definitely DO NOT seed.
     if (user.includes(speaker) || speaker.includes(user)) {
       return [];
     }
 
-    // If the first speaker IS the AI, seed the chat
-    // Fuzzy match: if "Teacher" is in "Teacher (Sensei)" or vice versa
-    if (ai.includes(speaker) || speaker.includes(ai)) {
+    const matchedAiRole = aiRoles.find(r => {
+      const ai = r.toLowerCase();
+      return ai.includes(speaker) || speaker.includes(ai);
+    });
+
+    if (matchedAiRole) {
       return [{
         speaker: 'ai',
         text: firstLine.text,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        roleName: matchedAiRole,
       }];
     }
 
@@ -416,13 +499,14 @@ export class ScenariosService {
     }
 
     // 2. Prepare Context for Gemini Service
+    const aiRoleStr = Array.isArray(aiRole) ? aiRole.join(', ') : aiRole;
     const context = {
       title: scenario.title,
       goal: scenario.setting.goal,
       difficulty: scenario.difficultyLevel,
       isObjectiveMet: scenario.isObjectiveMet ?? false,
       userRole,
-      aiRole
+      aiRole: aiRoleStr,
     };
 
     // 3. Prepare History (Map ChatMessage[] to simpler structure if needed, though interfaces align)

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -10,6 +10,7 @@ export interface ChatMessage {
     timestamp: number;
     correction?: string;
     sceneFinished?: boolean;
+    roleName?: string;
 }
 
 export interface ScenarioDialogueLine {
@@ -112,7 +113,7 @@ export interface Scenario {
 
     roles?: {
         user: string;
-        ai: string;
+        ai: string | string[];
     };
 
     sourceType?: 'library' | 'custom' | 'context-example';
@@ -145,7 +146,7 @@ export interface ScenarioTemplate {
     grammarNotes: GrammarNote[];
     roles?: {
         user: string;
-        ai: string;
+        ai: string | string[];
     };
 }
 
@@ -172,6 +173,15 @@ export class GenerateScenarioDto {
     sourceKuId?: string;
     userRole?: string;
     aiRole?: string;
+}
+
+export class ImportScenarioDto {
+    conversationText!: string;
+    userRole!: string;
+    aiRole?: string;
+    aiRoles?: string[];
+    difficulty?: ScenarioDifficulty;
+    sceneNotes?: string;
 }
 
 // FIX: DTOs must be Classes for NestJS reflection/validation to work

--- a/frontend/src/app/manage/page.tsx
+++ b/frontend/src/app/manage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, FormEvent } from "react";
+import React, { useState, useEffect, useRef, FormEvent } from "react";
 import { KnowledgeUnit, ReviewFacet } from "@/types";
 import Link from "next/link";
 import EditKnowledgeUnitModal from "@/components/EditKnowledgeUnitModal";
@@ -36,6 +36,13 @@ export default function KnowledgeManagementPage() {
   // --- Edit Modal State ---
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editingKu, setEditingKu] = useState<KnowledgeUnit | null>(null);
+
+  // --- Search & Enroll State ---
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<KnowledgeUnit[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [enrollingId, setEnrollingId] = useState<string | null>(null);
+  const searchDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // --- VALIDATION ---
   // Derived state to determine if the form is valid.
@@ -171,6 +178,40 @@ export default function KnowledgeManagementPage() {
     }
   };
 
+  // --- Search & Enroll Handlers ---
+  const handleSearchChange = (q: string) => {
+    setSearchQuery(q);
+    if (searchDebounce.current) clearTimeout(searchDebounce.current);
+    if (!q.trim()) { setSearchResults([]); return; }
+    searchDebounce.current = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const res = await apiFetch(`/api/knowledge-units/search?q=${encodeURIComponent(q.trim())}`);
+        if (res.ok) setSearchResults(await res.json());
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+  };
+
+  const handleEnroll = async (ku: KnowledgeUnit) => {
+    setEnrollingId(ku.id);
+    try {
+      const res = await apiFetch("/api/knowledge-units", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: ku.type, content: ku.content }),
+      });
+      if (!res.ok) throw new Error();
+      await fetchData();
+      window.dispatchEvent(new CustomEvent("refreshStats"));
+    } catch {
+      setError("Failed to add unit — please try again.");
+    } finally {
+      setEnrollingId(null);
+    }
+  };
+
   // --- Render Logic ---
   const renderKuList = () => {
     if (isLoading) {
@@ -272,9 +313,17 @@ export default function KnowledgeManagementPage() {
 
   return (
     <main className="container mx-auto max-w-4xl p-8">
-      <header className="mb-8">
-        <h1 className="text-4xl font-bold text-white mb-2">Manage Knowledge</h1>
-        <p className="text-xl text-gray-400">Your personal knowledge graph.</p>
+      <header className="mb-8 flex items-start justify-between">
+        <div>
+          <h1 className="text-4xl font-bold text-white mb-2">Manage Knowledge</h1>
+          <p className="text-xl text-gray-400">Your personal knowledge graph.</p>
+        </div>
+        <Link
+          href="/manage/scenarios"
+          className="shrink-0 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Import Conversation →
+        </Link>
       </header>
 
       {/* Show form-level error messages here */}
@@ -463,6 +512,61 @@ export default function KnowledgeManagementPage() {
             Add Unit
           </button>
         </form>
+      </div>
+
+      {/* Search & Enroll */}
+      <div className="bg-gray-800 p-6 rounded-lg shadow-lg mb-8">
+        <h2 className="text-2xl font-semibold mb-4 text-white">Search Existing Vocab</h2>
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          placeholder="Type Japanese or kana to search the corpus…"
+          className="w-full p-3 bg-gray-700 border-gray-600 text-white rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 mb-3"
+        />
+
+        {searchLoading && (
+          <p className="text-sm text-gray-400 animate-pulse">Searching…</p>
+        )}
+
+        {!searchLoading && searchResults.length > 0 && (
+          <ul className="space-y-2">
+            {searchResults.map((result) => {
+              const alreadyEnrolled = kus.some((k) => k.id === result.id);
+              const isEnrolling = enrollingId === result.id;
+              const hint = result.type === "Vocab"
+                ? [result.data.reading, result.data.definition].filter(Boolean).join(" · ")
+                : result.type === "Kanji"
+                  ? result.data.meaning
+                  : (result.data as any).title ?? "";
+
+              return (
+                <li key={result.id} className="flex items-center justify-between gap-4 bg-gray-700 rounded-lg px-4 py-3">
+                  <div className="min-w-0">
+                    <span className="text-white font-semibold mr-2">{result.content}</span>
+                    <span className="text-xs font-mono bg-gray-600 text-gray-300 px-1.5 py-0.5 rounded mr-2">{result.type}</span>
+                    {hint && <span className="text-sm text-gray-400 truncate">{hint}</span>}
+                  </div>
+                  {alreadyEnrolled ? (
+                    <span className="text-xs text-green-400 shrink-0">In queue</span>
+                  ) : (
+                    <button
+                      onClick={() => handleEnroll(result)}
+                      disabled={isEnrolling}
+                      className="shrink-0 text-sm px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-500 text-white rounded transition-colors"
+                    >
+                      {isEnrolling ? "Adding…" : "Add"}
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {!searchLoading && searchQuery.trim() && searchResults.length === 0 && (
+          <p className="text-sm text-gray-500 italic">No results — use the form above to add a new unit.</p>
+        )}
       </div>
 
       {/* "Explore & Connect" (Journey 1.3) list */}

--- a/frontend/src/app/manage/scenarios/page.tsx
+++ b/frontend/src/app/manage/scenarios/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api-client";
+
+type Difficulty = "N5" | "N4" | "N3" | "N2" | "N1";
+
+export default function ImportScenarioPage() {
+  const router = useRouter();
+
+  const [conversationText, setConversationText] = useState("");
+  const [userRole, setUserRole] = useState("");
+  const [aiRoles, setAiRoles] = useState<string[]>([""]);
+  const [difficulty, setDifficulty] = useState<Difficulty>("N4");
+  const [sceneNotes, setSceneNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filledAiRoles = aiRoles.filter((r) => r.trim());
+  const isValid = conversationText.trim() && userRole.trim() && filledAiRoles.length > 0;
+
+  const updateRole = (idx: number, value: string) => {
+    setAiRoles((prev) => prev.map((r, i) => (i === idx ? value : r)));
+  };
+
+  const addRole = () => setAiRoles((prev) => [...prev, ""]);
+
+  const removeRole = (idx: number) => {
+    setAiRoles((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValid) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await apiFetch("/api/scenarios/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationText: conversationText.trim(),
+          userRole: userRole.trim(),
+          aiRoles: filledAiRoles.map((r) => r.trim()),
+          difficulty,
+          sceneNotes: sceneNotes.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || "Import failed");
+      router.push(`/scenarios/${data.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed — please try again");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="container mx-auto max-w-2xl px-6 py-12 space-y-8">
+      <header>
+        <Link href="/manage" className="text-sm text-shodo-ink/40 hover:text-shodo-ink/70 transition-colors mb-4 inline-block">
+          ← Manage
+        </Link>
+        <h1 className="text-3xl font-bold text-shodo-ink">Import Conversation</h1>
+        <p className="text-shodo-ink/50 mt-1">
+          Paste a conversation from a textbook or real life. The AI will structure it into a practice scenario.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+
+        {/* Conversation text */}
+        <div>
+          <label htmlFor="conversation" className="block text-sm font-medium text-shodo-ink mb-1.5">
+            Conversation
+          </label>
+          <textarea
+            id="conversation"
+            value={conversationText}
+            onChange={(e) => setConversationText(e.target.value)}
+            rows={10}
+            placeholder={"A: すみません、このシャツはいくらですか？\nB: 3000円です。\nA: 少し高いですね。もう少し安くなりますか？\nB: では、2500円にしましょう。\nA: ありがとうございます。"}
+            className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-3 text-shodo-ink placeholder:text-shodo-ink/25 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors resize-y font-mono text-sm leading-relaxed"
+            required
+          />
+          <p className="text-xs text-shodo-ink/40 mt-1">
+            Use any speaker labels — A/B, names, numbers, or none. The AI will figure out who is who.
+          </p>
+        </div>
+
+        {/* Roles */}
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="userRole" className="block text-sm font-medium text-shodo-ink mb-1.5">
+              Your Role
+            </label>
+            <input
+              type="text"
+              id="userRole"
+              value={userRole}
+              onChange={(e) => setUserRole(e.target.value)}
+              placeholder="e.g. Customer, Student, Tourist"
+              className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors text-sm"
+              required
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="block text-sm font-medium text-shodo-ink">
+                Other Role{aiRoles.length > 1 ? "s" : ""}
+              </label>
+              <button
+                type="button"
+                onClick={addRole}
+                className="text-xs text-shodo-accent hover:text-shodo-accent/70 transition-colors"
+              >
+                + Add another role
+              </button>
+            </div>
+            <div className="space-y-2">
+              {aiRoles.map((role, idx) => (
+                <div key={idx} className="flex gap-2">
+                  <input
+                    type="text"
+                    value={role}
+                    onChange={(e) => updateRole(idx, e.target.value)}
+                    placeholder="e.g. Shop staff, Teacher, Friend"
+                    className="flex-1 rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors text-sm"
+                  />
+                  {aiRoles.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeRole(idx)}
+                      className="px-3 py-2.5 text-shodo-ink/30 hover:text-shodo-accent transition-colors text-sm"
+                      aria-label="Remove role"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Difficulty */}
+        <div>
+          <label htmlFor="difficulty" className="block text-sm font-medium text-shodo-ink mb-1.5">
+            JLPT Level
+          </label>
+          <select
+            id="difficulty"
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value as Difficulty)}
+            className="rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors text-sm"
+          >
+            {(["N5", "N4", "N3", "N2", "N1"] as Difficulty[]).map((l) => (
+              <option key={l} value={l}>{l}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Scene notes */}
+        <div>
+          <label htmlFor="sceneNotes" className="block text-sm font-medium text-shodo-ink mb-1.5">
+            Scene Notes{" "}
+            <span className="text-shodo-ink/40 font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="sceneNotes"
+            value={sceneNotes}
+            onChange={(e) => setSceneNotes(e.target.value)}
+            rows={2}
+            placeholder="e.g. 'Chapter 5 of Genki I — buying clothes at a department store'"
+            className="w-full rounded-lg border border-shodo-ink/20 bg-shodo-paper px-4 py-2.5 text-shodo-ink placeholder:text-shodo-ink/30 focus:outline-none focus:ring-2 focus:ring-shodo-accent/50 focus:border-shodo-accent transition-colors resize-y text-sm"
+          />
+        </div>
+
+        {error && (
+          <p className="text-sm text-shodo-accent">{error}</p>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={!isValid || isSubmitting}
+            className={`px-6 py-2.5 rounded-lg text-sm font-medium text-shodo-paper transition-colors ${
+              !isValid || isSubmitting
+                ? "bg-shodo-ink/40 cursor-not-allowed"
+                : "bg-shodo-ink hover:bg-shodo-ink/80"
+            }`}
+          >
+            {isSubmitting ? "Structuring conversation…" : "Import Scenario"}
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/frontend/src/app/scenarios/[id]/page.tsx
+++ b/frontend/src/app/scenarios/[id]/page.tsx
@@ -391,7 +391,7 @@ export default function ScenarioPage({
                       }`}
                     >
                       <div className="font-bold text-xs opacity-70 mb-1">
-                        {msg.speaker}
+                        {msg.speaker === "user" ? (scenario.roles?.user ?? "You") : (msg.roleName ?? (Array.isArray(scenario.roles?.ai) ? scenario.roles.ai[0] : scenario.roles?.ai) ?? "AI")}
                       </div>
                       {msg.text}
                     </div>
@@ -686,7 +686,7 @@ export default function ScenarioPage({
                   }`}
                 >
                   <div className="text-xs opacity-70 mb-1 flex items-center gap-2">
-                    <span>{msg.speaker}</span>
+                    <span>{msg.speaker === "user" ? (scenario.roles?.user ?? "You") : (msg.roleName ?? (Array.isArray(scenario.roles?.ai) ? scenario.roles.ai[0] : scenario.roles?.ai) ?? "AI")}</span>
                     {msg.speaker !== "user" && (
                       <button
                         onClick={() => playTts(msg.text)}

--- a/frontend/src/types/scenario.ts
+++ b/frontend/src/types/scenario.ts
@@ -13,6 +13,7 @@ export interface ChatMessage {
   timestamp: number;
   correction?: string;
   sceneFinished?: boolean;
+  roleName?: string;
 }
 
 export interface ScenarioDialogueLine {
@@ -96,7 +97,7 @@ export interface Scenario {
 
   roles?: {
     user: string;
-    ai: string;
+    ai: string | string[];
   };
 
   sourceType?: 'library' | 'custom' | 'context-example';
@@ -127,7 +128,7 @@ export interface ScenarioTemplate {
   grammarNotes: GrammarNote[];
   roles?: {
     user: string;
-    ai: string;
+    ai: string | string[];
   };
 }
 


### PR DESCRIPTION
- **Fix KU search crash** — WaniKani bulk-imported documents have no `createdAt` field; guarded `(data.createdAt as
  Timestamp).toDate()` with a null check in `KnowledgeUnitsService.search`. Also explains why `二人` wasn't returning    
  results.                                                                                                           
 - **Manage: Search & Enroll** — `GET /api/knowledge-units/search?q=` (Firestore prefix range query, limit 15). `POST   
  /api/knowledge-units` now does find-or-create: looks up existing global KU by content before writing, then links a  
  `UserKnowledgeUnit` for the requesting user. Manage page gains a debounced search input with per-result Add/In-queue   
  state.                                                                                                              
 - **Import Scenario** — `POST /api/scenarios/import` accepts a pasted conversation + role names and uses Gemini to     
  structure it into a full scenario (verbatim Japanese preserved, speaker labels mapped to roles, vocab/grammar     
  extracted). New page at `/manage/scenarios`.                                                                           
 - **Multi-role scenario support** — `Scenario.roles.ai` widened to `string | string[]`; `ChatMessage.roleName` added;
  import form supports a dynamic list of other-party roles. AI is instructed to play multiple characters and tag each    
  response with the speaking character's name. Backward-compatible: all existing single-role scenarios work unchanged.   
                                                                                                                      
  ## Test plan                                                                                                           
                                                            
  - [ ] Search for a WaniKani-imported KU (e.g. `二人`) — should return results without crashing the backend
  - [ ] Add a KU via search that already exists globally — should enroll without creating a duplicate, `isNew: false`    
  - [ ] Import a two-party conversation — verify dialogue is verbatim, vocab/grammar extracted, redirects to scenario
  page                                                                                                                   
  - [ ] Import a three-party conversation (e.g. customer + shopkeeper + manager) — verify all three roles appear in the  
  dialogue and the AI plays both non-user roles during simulate                                                          
  - [ ] Existing single-role scenario — chat bubble should show the role name instead of "ai"; no regressions   