### PR TITLE
feat: invert review selection process

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -337,6 +337,73 @@ Intended use: dashboard queries such as `where('state','==','drill').where('voca
 
 ---
 
+## Learning Progress & Mastery
+
+### Design Principle
+
+Learning state for a KU is not a field to be manually managed — it is derived from evidence. `LearningProgressService` is the single service that owns the rules for interpreting that evidence and is the **only** place that may write `UKU.status`. The SRS is the single arbiter of whether a user actually knows something; the service interprets SRS data into a coherent status.
+
+The current `UKU.status` field is a hodge-podge of manually-set values that can drift out of sync with actual facet SRS data. Under this design it becomes a **materialized view** — computed by `LearningProgressService` and cached on the UKU document, never set directly by other services.
+
+---
+
+### LearningProgressService
+
+A dedicated service, separate from `ReviewsService`. `ReviewsService` owns the mechanics (facet CRUD, SRS scheduling, due reviews). `LearningProgressService` owns the *interpretation* of those mechanics.
+
+Responsibilities:
+- **Define what each UKU status level means** in terms of facet SRS data
+- **Compute and cache `UKU.status`** after every facet creation or SRS update
+- **Own the facet creation rules** applied when a user submits the lesson page
+
+Nothing else computes or sets `UKU.status` directly. All status transitions flow through this service.
+
+---
+
+### Lesson Page — "What Do You Already Know?"
+
+The lesson page UX is inverted from the original design. Instead of asking the user what they *want* to learn, it asks what they *already know*.
+
+For each possible review facet, the user makes a binary choice:
+
+| Selection | Meaning | Facet created at |
+|---|---|---|
+| **Checked** | "I already know this" | Stage N-1 (one below mastered) |
+| **Unchecked** | "I need to learn this" | Stage 0 |
+
+Every visible facet gets created — the only difference is the starting stage. A user who checks nothing gets all facets at stage 0 and works through them normally. A user who checks everything self-certifies and the SRS verifies that claim on their next review.
+
+The SRS is the single arbiter. If the user was right, they'll burn through high-stage facets quickly. If they were wrong, they'll fail reviews and fall back into active learning.
+
+**Note:** Kanji component facets follow user selection on the lesson page, but Kanji mastery is not a tracked learning goal and is never gated on. Users may choose to learn Kanji via SRS but it is outside the scope of `LearningProgressService`.
+
+---
+
+### UKU Status Rules
+
+Computed by `LearningProgressService` from facet data. `MASTERED_STAGE` is a named constant (currently 7).
+
+| Status | Condition |
+|---|---|
+| `learning` | UKU exists; no review facets — appears in learning queue |
+| `reviewing` | Has facets; at least one facet below `MASTERED_STAGE` |
+| `mastered` | Has facets; all facets at or above `MASTERED_STAGE` |
+
+---
+
+### Scenario vocabReady Gate
+
+The gate threshold remains `minSrsStage >= 1` across all vocab KUs linked to the scenario.
+
+| Facet starting stage | Gate behaviour |
+|---|---|
+| Stage N-1 (self-certified) | Satisfies gate immediately on creation — scenario unlocks without requiring a review |
+| Stage 0 (learning from scratch) | Requires one successful review to reach stage 1 before the gate is satisfied |
+
+A user who claims to know all linked vocab can proceed to roleplay immediately. A user learning from scratch must complete at least one review per KU first.
+
+---
+
 ## Migration History
 
 **Note**: This section is very much outdated but should be used to summarize the history of the project. 
@@ -524,6 +591,18 @@ Library page (`/learn`): Kanji items now show `data.meaning` in the hint column 
 - `generateEvaluation` — normalises `roles.ai` to string (`join(', ')`) for the evaluation context passed to Gemini.
 - Import form — "Other Role" input is now a dynamic list; "Add another role" link appends a new row; `×` removes. Sends `aiRoles: string[]`.
 - Gemini chat response schema already had `speaker: STRING` — now used to populate `ChatMessage.roleName`.
+
+---
+
+**LearningProgressService + lesson page UX overhaul (2026-05-01)**
+
+- **`MASTERED_STAGE = 7`, `SELF_CERTIFIED_STAGE = 6`** added to `backend/src/lib/constants.ts`.
+- **`LearningProgressService`** (`backend/src/learning-progress/`) — new `@Global()` service and module registered in `AppModule`. Single owner of `UKU.status`; `recomputeAndCache(uid, kuId)` derives status from facet SRS data and writes to UKU. `ReviewsService` is the only caller — invoked after every facet creation and every SRS update. No other service may write `UKU.status` directly.
+- **`ReviewsService.generateReviewFacets`** — now accepts `selfCertifiedFacets: string[]`. Self-certified facets created at stage 6 with `nextReviewAt = now + 730 h` and `selfCertified: true` flag on the Firestore doc. Unchecked facets created at stage 0 as before. Direct `status: 'reviewing'` write removed; replaced with `recomputeAndCache`.
+- **`ReviewsService.updateFacetSrs`** — direct `status: 'mastered'` write removed; replaced with `recomputeAndCache`.
+- **`POST /api/reviews/generate`** — body now accepts `selfCertifiedFacets?: string[]`.
+- **Lesson page UX inverted** (`/learn/[kuId]`): heading changed to "What do you already know?"; all standard facets always enrolled on submit — checked = self-certified (stage 6), unchecked = learn from scratch (stage 0). Kanji component stubs and context-example scenarios remain opt-in. `getAvailableStandardFacetKeys()` helper centralises available-facet computation used by both render and submit. Button: "Enroll in Review Queue".
+- **`AI-Generated-Question` display label** renamed to "General usage patterns" on the lesson page, concepts page, and grammar lesson view; "Usage patterns" on the review card header. Firestore `facetType` value `"AI-Generated-Question"` unchanged.
 
 ---
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,9 +18,10 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './users/user.module';
 import { UserKnowledgeUnitsModule } from './user-knowledge-units/user-knowledge-units.module';
 import { ConceptsModule } from './concepts/concepts.module';
+import { LearningProgressModule } from './learning-progress/learning-progress.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule],
+  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, LearningProgressModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -35,7 +35,9 @@ export const FieldValue = admin.firestore.FieldValue;
           });
         }
         const firestoreDbName = configService.get<string>('FIRESTORE_DB') || '(default)';
-        return getFirestore(admin.app(), firestoreDbName);
+        const db = getFirestore(admin.app(), firestoreDbName);
+        db.settings({ ignoreUndefinedProperties: true });
+        return db;
       },
     },
   ],

--- a/backend/src/learning-progress/learning-progress.module.ts
+++ b/backend/src/learning-progress/learning-progress.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { LearningProgressService } from './learning-progress.service';
+import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
+
+@Global()
+@Module({
+    imports: [UserKnowledgeUnitsModule],
+    providers: [LearningProgressService],
+    exports: [LearningProgressService],
+})
+export class LearningProgressModule {}

--- a/backend/src/learning-progress/learning-progress.service.ts
+++ b/backend/src/learning-progress/learning-progress.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { CollectionReference, Firestore, Query } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
+import { ADMIN_USER_ID, MASTERED_STAGE } from '../lib/constants';
+import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
+import { ReviewFacet } from '../types';
+
+@Injectable()
+export class LearningProgressService {
+    private readonly logger = new Logger(LearningProgressService.name);
+
+    constructor(
+        @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+        private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
+    ) {}
+
+    private facetsColRef(uid: string): CollectionReference {
+        if (uid === ADMIN_USER_ID) {
+            return this.db.collection(REVIEW_FACETS_COLLECTION);
+        }
+        return this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+    }
+
+    private facetsBaseQuery(uid: string): Query {
+        const col = this.facetsColRef(uid);
+        return uid === ADMIN_USER_ID ? col.where('userId', '==', uid) : col;
+    }
+
+    private async getFacetsForKu(uid: string, kuId: string): Promise<ReviewFacet[]> {
+        const snapshot = await this.facetsBaseQuery(uid)
+            .where('kuId', '==', kuId)
+            .get();
+        return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as ReviewFacet));
+    }
+
+    /**
+     * Derives UKU status from facet SRS data and writes it back to the UKU document.
+     * This is the single place that determines and caches UKU status.
+     *
+     * Rules:
+     *   - No facets          → 'learning'  (appears in learning queue)
+     *   - Any facet < MASTERED_STAGE → 'reviewing'
+     *   - All facets >= MASTERED_STAGE → 'mastered'
+     */
+    async recomputeAndCache(uid: string, kuId: string): Promise<void> {
+        const facets = await this.getFacetsForKu(uid, kuId);
+
+        let status: 'learning' | 'reviewing' | 'mastered';
+        if (facets.length === 0) {
+            status = 'learning';
+        } else if (facets.every(f => (f.srsStage ?? 0) >= MASTERED_STAGE)) {
+            status = 'mastered';
+        } else {
+            status = 'reviewing';
+        }
+
+        try {
+            await this.userKnowledgeUnitsService.update(uid, kuId, { status });
+            this.logger.log(`UKU status=${status} for uid=${uid} kuId=${kuId}`);
+        } catch (e) {
+            this.logger.error(`Failed to recompute UKU status for uid=${uid} kuId=${kuId}`, e);
+        }
+    }
+}

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -3,3 +3,10 @@
 //   - backend/src/auth/firebase-auth.guard.ts (dev-mode fallback)
 // Those references should eventually be replaced with this constant.
 export const ADMIN_USER_ID = 'user_default';
+
+// SRS stage at which a facet is considered mastered.
+export const MASTERED_STAGE = 7;
+
+// Starting SRS stage for self-certified facets (one below mastered).
+// A self-certified facet is due for review in ~1 month; one failure drops it back into active review.
+export const SELF_CERTIFIED_STAGE = 6;

--- a/backend/src/prompts/scenario.prompts.ts
+++ b/backend/src/prompts/scenario.prompts.ts
@@ -58,7 +58,7 @@ ${dto.userRole && dto.aiRole
     }
 6. **Data Formatting (CRITICAL):**
    - \`title\`, \`description\` and all \`setting\` object fields should be in English
-   - **NO ROMAJI**. Never include Romaji in any field.
+   - **NO ROMAJI**. Never include Romaji in any field — including grammar explanations. Write Japanese words in Japanese script (e.g. です, の) not romanised text (e.g. 'desu', 'no').
    - **Extracted KUs:**
      - \`content\`: Japanese text ONLY (e.g., "本屋"). No readings or definitions in this field.
      - \`reading\`: Kana reading ONLY (e.g., "ほんや"). No Romaji.
@@ -209,13 +209,13 @@ ${dto.conversationText}
    - If the conversation uses labels (A/B, names, numbers), map them to the correct role.
    - Add an accurate English translation for each line.
 2. **Setting:** Infer location, participants, goal, timeOfDay, and visualPrompt from the conversation.${dto.sceneNotes ? ' Use the provided scene context as your primary guide.' : ''}
-3. **Vocabulary:** Extract 3-8 key vocabulary items the learner needs to participate in this conversation.
+3. **Vocabulary:** Extract 3-5 key vocabulary items the learner needs to participate in this conversation.
 4. **Grammar Notes:** Identify 1-3 grammar patterns used in the conversation and explain them Genki-style.
 5. **Title & Description:** Write a short English title and description for this scenario.
 
 **Data Formatting Rules:**
 - \`title\`, \`description\`, and all \`setting\` fields in English.
-- NO ROMAJI anywhere.
+- **NO ROMAJI**. Never include Romaji in any field — including grammar explanations. Write Japanese words in Japanese script (e.g. です, の) not romanised text (e.g. 'desu', 'no').
 - Extracted KUs: \`content\` = Japanese only, \`reading\` = kana only, \`meaning\` = English definition, \`jlptLevel\` = one of N5/N4/N3/N2/N1.
 - Grammar note fragments: ${FRAGMENT_CONTRACT}
 - ${ACCEPTED_ALTERNATIVES_DEF}

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -48,14 +48,13 @@ export class ReviewsController {
   @Post('generate')
   async generateReviewFacets(
     @UserId() uid: string,
-    @Body() body: { kuId: string, facetsToCreate: { key: string; data?: any }[] }
+    @Body() body: { kuId: string; facetsToCreate: { key: string; data?: any }[]; selfCertifiedFacets?: string[] }
   ) {
     if (!body.kuId || !body.facetsToCreate || body.facetsToCreate.length === 0) {
       throw new BadRequestException('Missing kuId or facetsToCreate');
     }
 
-    console.log(`Generating review facets for KU ${body.kuId}`);
-    return this.reviewsService.generateReviewFacets(uid, body.kuId, body.facetsToCreate);
+    return this.reviewsService.generateReviewFacets(uid, body.kuId, body.facetsToCreate, body.selfCertifiedFacets ?? []);
   }
 
   @Get('facets')

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -8,6 +8,7 @@ import { KnowledgeUnitsModule } from 'src/knowledge-units/knowledge-units.module
 import { StatsModule } from '../stats/stats.module';
 import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
 import { ScenariosModule } from '../scenarios/scenarios.module';
+import { LearningProgressModule } from '../learning-progress/learning-progress.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { ScenariosModule } from '../scenarios/scenarios.module';
     StatsModule,
     UserKnowledgeUnitsModule,
     ScenariosModule,
+    LearningProgressModule,
   ],
   controllers: [ReviewsController],
   providers: [ReviewsService],

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -11,7 +11,7 @@ import {
     REVIEW_FACETS_COLLECTION,
     USER_STATS_COLLECTION,
 } from '../firebase/firebase.module';
-import { ADMIN_USER_ID } from '../lib/constants';
+import { ADMIN_USER_ID, MASTERED_STAGE, SELF_CERTIFIED_STAGE } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
 import { ReviewFacet } from '@/types';
@@ -19,6 +19,7 @@ import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.servic
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { StatsService } from '../stats/stats.service';
 import { ScenariosService } from '../scenarios/scenarios.service';
+import { LearningProgressService } from '../learning-progress/learning-progress.service';
 import { buildAnswerEvaluatorPrompt } from '../prompts/evaluation.prompts';
 
 @Injectable()
@@ -47,6 +48,7 @@ export class ReviewsService {
         private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
         private readonly statsService: StatsService,
         private readonly scenariosService: ScenariosService,
+        private readonly learningProgressService: LearningProgressService,
     ) { }
 
     private facetsColRef(uid: string): CollectionReference {
@@ -132,18 +134,12 @@ export class ReviewsService {
                 newStage: nextSrsStage,
                 nextReview: nextReviewDate,
                 kuId: facetData.kuId,
-                reachedMastered: nextSrsStage === 8,
             };
         });
 
-        // Post-transaction: propagate mastered status to UKU (outside transaction — queries not allowed inside)
-        if (txResult.reachedMastered && txResult.kuId) {
-            try {
-                await this.userKnowledgeUnitsService.update(uid, txResult.kuId, { status: 'mastered' });
-                this.logger.log(`Marked UKU mastered for uid=${uid} kuId=${txResult.kuId}`);
-            } catch (e) {
-                this.logger.error(`Failed to mark UKU mastered for uid=${uid} kuId=${txResult.kuId}`, e);
-            }
+        // Post-transaction: recompute and cache UKU status from facet SRS data
+        if (txResult.kuId) {
+            await this.learningProgressService.recomputeAndCache(uid, txResult.kuId);
         }
 
         // Post-transaction: check if a linked scenario's vocab is now all drill-ready
@@ -244,6 +240,7 @@ export class ReviewsService {
         uid: string,
         kuId: string,
         facetsToCreate: { key: string; data?: any }[],
+        selfCertifiedFacets: string[] = [],
     ) {
         // Pre-fetch existing facets for the parent KU to prevent duplicates on re-submission
         const existingParentFacets = await this.getFacetsByKuId(uid, kuId);
@@ -254,6 +251,9 @@ export class ReviewsService {
         let kanjiLinked = 0;                  // Kanji component stubs linked
         const kanjiLinkedKuIds: { kuId: string; newFacetCount: number }[] = [];
         const now = Timestamp.now();
+        const selfCertifiedNextReview = Timestamp.fromMillis(
+            Date.now() + this.INTERVALS[SELF_CERTIFIED_STAGE] * 60 * 60 * 1000,
+        );
 
         for (const facet of facetsToCreate) {
             const { key, data } = facet;
@@ -327,15 +327,20 @@ export class ReviewsService {
             }
 
             // --- Create the Facet (Batch) ---
+            const isSelfCertified = selfCertifiedFacets.includes(key);
+            const startStage = isSelfCertified ? SELF_CERTIFIED_STAGE : 0;
+            const nextReviewAt = isSelfCertified ? selfCertifiedNextReview : now;
+
             const newFacetRef = this.facetsColRef(uid).doc();
             batch.set(newFacetRef, {
                 kuId: targetKuId,
                 facetType: key,
-                srsStage: 0,
-                nextReviewAt: now,
+                srsStage: startStage,
+                nextReviewAt,
                 createdAt: now,
                 history: [],
                 source: { type: 'lesson', id: kuId },
+                ...(isSelfCertified ? { selfCertified: true } : {}),
                 ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
                 ...(modifiedData ? { data: modifiedData } : {}),
             });
@@ -345,27 +350,29 @@ export class ReviewsService {
 
         await batch.commit();
 
-        // Update parent UKU (vocab/grammar) if any facets or kanji components were selected
+        // Update facet_count on parent UKU and recompute derived status
         if (count > 0 || kanjiLinked > 0) {
             try {
-                await this.userKnowledgeUnitsService.update(uid, kuId, {
-                    status: 'reviewing',
-                    ...(count > 0 ? { facet_count: FieldValue.increment(count) } : {}),
-                });
-                this.logger.log(`Updated UKU for uid=${uid} kuId=${kuId}: status=reviewing${count > 0 ? `, facet_count+=${count}` : ''}`);
+                if (count > 0) {
+                    await this.userKnowledgeUnitsService.update(uid, kuId, {
+                        facet_count: FieldValue.increment(count),
+                    });
+                }
+                await this.learningProgressService.recomputeAndCache(uid, kuId);
             } catch (e) {
                 this.logger.error(`Failed to update UKU for uid=${uid} kuId=${kuId}`, e);
             }
         }
 
-        // Update each Kanji UKU to reviewing in parallel
+        // Update each Kanji UKU in parallel
         await Promise.all(kanjiLinkedKuIds.map(async ({ kuId: kanjiKuId, newFacetCount }) => {
             try {
-                await this.userKnowledgeUnitsService.update(uid, kanjiKuId, {
-                    status: 'reviewing',
-                    ...(newFacetCount > 0 ? { facet_count: FieldValue.increment(newFacetCount) } : {}),
-                });
-                this.logger.log(`Updated Kanji UKU for uid=${uid} kuId=${kanjiKuId}: status=reviewing${newFacetCount > 0 ? `, facet_count+=${newFacetCount}` : ''}`);
+                if (newFacetCount > 0) {
+                    await this.userKnowledgeUnitsService.update(uid, kanjiKuId, {
+                        facet_count: FieldValue.increment(newFacetCount),
+                    });
+                }
+                await this.learningProgressService.recomputeAndCache(uid, kanjiKuId);
             } catch (e) {
                 this.logger.error(`Failed to update Kanji UKU for uid=${uid} kuId=${kanjiKuId}`, e);
             }

--- a/frontend/src/app/concepts/[id]/page.tsx
+++ b/frontend/src/app/concepts/[id]/page.tsx
@@ -251,7 +251,7 @@ export default function ConceptPage() {
 
           <div className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-widest text-shodo-ink/40">
-              AI-Generated Questions
+              General Usage Patterns
             </h3>
             <label className="flex items-start gap-3 p-4 border border-shodo-ink/10 rounded-lg hover:bg-shodo-ink/[0.02] cursor-pointer transition-colors">
               <input
@@ -261,8 +261,8 @@ export default function ConceptPage() {
                 onChange={() => setIncludeAiQuestion(prev => !prev)}
               />
               <div className="min-w-0">
-                <p className="text-sm font-medium text-shodo-ink">AI-Generated Questions</p>
-                <p className="text-sm text-shodo-ink/50 mt-0.5">Practice applying this concept through AI-generated quiz questions</p>
+                <p className="text-sm font-medium text-shodo-ink">General usage patterns</p>
+                <p className="text-sm text-shodo-ink/50 mt-0.5">Practice applying this concept through varied usage questions</p>
               </div>
             </label>
           </div>

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -203,27 +203,55 @@ export default function LearnItemPage() {
     }));
   };
 
+  // All standard (non-context-example, non-kanji-component-stub) facet keys available for this lesson.
+  // Used to enroll every facet on submit; checked ones are self-certified, unchecked start at stage 0.
+  const getAvailableStandardFacetKeys = (existingFacetTypes: Set<string>): string[] => {
+    if (!lesson || !ku) return [];
+    if (lesson.type === "Vocab") {
+      const hasReadingFacet = ku.type === "Vocab" && (ku as any).data?.reading !== ku?.content;
+      const hasAudio = ((lesson as VocabLesson).context_examples?.length ?? 0) > 0;
+      return [
+        "Definition-to-Content",
+        "Content-to-Definition",
+        ...(hasReadingFacet ? ["Content-to-Reading"] : []),
+        ...(hasAudio ? ["audio"] : []),
+        "AI-Generated-Question",
+      ].filter(k => !existingFacetTypes.has(k));
+    }
+    if (lesson.type === "Kanji") {
+      return ["Kanji-Component-Meaning", "Kanji-Component-Reading", "AI-Generated-Question"]
+        .filter(k => !existingFacetTypes.has(k));
+    }
+    if (lesson.type === "Grammar") {
+      return ["sentence-assembly", "AI-Generated-Question", "Content-to-Definition"]
+        .filter(k => !existingFacetTypes.has(k));
+    }
+    return [];
+  };
+
   const handleSubmitFacets = async () => {
     if (!ku || !lesson) return;
     setIsSubmitting(true);
     setError(null);
 
-    const selectedFacetKeys = Object.keys(selectedFacets).filter(
-      (key) => selectedFacets[key],
+    const existingFacetTypes = new Set<string>((existingFacets ?? []).map((f: any) => f.facetType));
+    const allStandardKeys = getAvailableStandardFacetKeys(existingFacetTypes);
+    const selfCertifiedKeys = allStandardKeys.filter(key => selectedFacets[key]);
+
+    // Optional items still require explicit selection
+    const selectedOptionalKeys = Object.keys(selectedFacets).filter(key => selectedFacets[key]);
+    const contextExampleKeys = selectedOptionalKeys.filter(key => key.startsWith("Context-Example-"));
+    const kanjiComponentKeys = selectedOptionalKeys.filter(key =>
+      key.startsWith("Kanji-Component-") &&
+      key !== "Kanji-Component-Meaning" &&
+      key !== "Kanji-Component-Reading"
     );
 
-    if (selectedFacetKeys.length === 0) {
-      setError("Please select at least one facet to learn.");
-      setIsSubmitting(false);
-      return;
-    }
-
-    const contextExampleKeys = selectedFacetKeys.filter((key) =>
-      key.startsWith("Context-Example-"),
-    );
-    const reviewFacetKeys = selectedFacetKeys.filter(
-      (key) => !key.startsWith("Context-Example-"),
-    );
+    // Combine standard + kanji component stubs for the review facets payload
+    const reviewFacetKeys = [
+      ...allStandardKeys,
+      ...kanjiComponentKeys,
+    ];
 
     const promises: Promise<any>[] = [];
 
@@ -257,12 +285,12 @@ export default function LearnItemPage() {
       });
     }
 
-    // 2a. Grammar facets (handled separately — may emit multiple sentence-assembly facets)
-    if (ku?.type === "Grammar" && lesson?.type === "Grammar") {
+    // 2a. Grammar facets — always enroll all; checked ones are self-certified
+    if (ku?.type === "Grammar" && lesson?.type === "Grammar" && allStandardKeys.length > 0) {
       const grammarLesson = lesson as GrammarLesson;
       const grammarFacets: { key: string; data: Record<string, any> }[] = [];
 
-      if (selectedFacets["sentence-assembly"]) {
+      if (allStandardKeys.includes("sentence-assembly")) {
         grammarLesson.examples.forEach((ex) => {
           grammarFacets.push({
             key: "sentence-assembly",
@@ -278,7 +306,7 @@ export default function LearnItemPage() {
           });
         });
       }
-      if (selectedFacets["AI-Generated-Question"]) {
+      if (allStandardKeys.includes("AI-Generated-Question")) {
         grammarFacets.push({
           key: "AI-Generated-Question",
           data: {
@@ -289,7 +317,7 @@ export default function LearnItemPage() {
           },
         });
       }
-      if (selectedFacets["Content-to-Definition"]) {
+      if (allStandardKeys.includes("Content-to-Definition")) {
         grammarFacets.push({
           key: "Content-to-Definition",
           data: {
@@ -306,7 +334,11 @@ export default function LearnItemPage() {
           apiFetch("/api/reviews/generate", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ kuId: ku.id, facetsToCreate: grammarFacets }),
+            body: JSON.stringify({
+              kuId: ku.id,
+              facetsToCreate: grammarFacets,
+              selfCertifiedFacets: selfCertifiedKeys,
+            }),
           }).then(async (res) => {
             if (!res.ok) {
               const err = await res.json();
@@ -317,7 +349,7 @@ export default function LearnItemPage() {
       }
     }
 
-    // 2. Process Standard Review Facets (skip Grammar — all grammar facets handled in 2a above)
+    // 2. Process Standard Review Facets (skip Grammar — handled in 2a above)
     if (reviewFacetKeys.length > 0 && ku?.type !== "Grammar") {
       const facetsToCreatePayload = reviewFacetKeys.map((key) => {
         // Component kanji stub creation (Kanji-Component-食 etc.) — no facet created, just KU stub
@@ -387,6 +419,7 @@ export default function LearnItemPage() {
         body: JSON.stringify({
           kuId: ku.id,
           facetsToCreate: facetsToCreatePayload,
+          selfCertifiedFacets: selfCertifiedKeys,
         }),
       }).then(async (res) => {
         if (!res.ok) {
@@ -397,8 +430,7 @@ export default function LearnItemPage() {
       promises.push(reviewPromise);
     }
 
-    // Count review items being added (exclude Context-Example scenario generations only)
-    const learningItemCount = reviewFacetKeys.length;
+    const learningItemCount = allStandardKeys.length;
 
     try {
       await Promise.all(promises);
@@ -473,8 +505,6 @@ export default function LearnItemPage() {
         ? newKanjiKeys.length > 0
         : !existingFacetTypes.has("AI-Generated-Question");
 
-    const noneSelected = Object.values(selectedFacets).every(v => !v);
-
     const FACET_LABELS: Record<string, string> = {
       "Definition-to-Content": "Content",
       "Content-to-Definition": "Meaning",
@@ -482,15 +512,23 @@ export default function LearnItemPage() {
       "audio": "Audio Comprehension",
       "Kanji-Component-Meaning": "Meaning (Kanji → Meaning)",
       "Kanji-Component-Reading": "Reading (Kanji → On/Kun)",
-      "AI-Generated-Question": "AI-Generated Questions",
+      "AI-Generated-Question": "General usage patterns",
       "sentence-assembly": "Sentence Assembly",
     };
 
+    const availableStandardKeys = getAvailableStandardFacetKeys(existingFacetTypes);
+    const noneSelected = availableStandardKeys.length === 0 && Object.values(selectedFacets).every(v => !v);
+
     return (
       <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow-lg">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-white">
-          {isAddMore ? "Select Additional Items to Review" : "Choose What to Learn"}
+        <h2 className="text-2xl font-semibold mb-2 text-gray-900 dark:text-white">
+          {isAddMore ? "Add More Review Items" : "What do you already know?"}
         </h2>
+        {!isAddMore && availableStandardKeys.length > 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Check the items you already know. Everything gets added to your review queue — checked items start near mastered and the SRS will verify your claim.
+          </p>
+        )}
 
         {existingFacets && existingFacets.length > 0 && (
           <div className="mb-6">
@@ -686,7 +724,7 @@ export default function LearnItemPage() {
                 checked={!!selectedFacets["AI-Generated-Question"]}
                 onChange={() => handleCheckboxChange("AI-Generated-Question")}
               />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">AI-Generated Questions</span>
+              <span className="ml-3 text-lg text-gray-900 dark:text-white">General usage patterns</span>
             </label>
           )}
         </div>
@@ -698,7 +736,7 @@ export default function LearnItemPage() {
             disabled={isSubmitting || !lesson || noneSelected}
             className="mt-6 w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700 disabled:bg-gray-500 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? "Saving..." : isAddMore ? "Add Selected Facets" : "Start Learning Selected Items"}
+            {isSubmitting ? "Saving..." : isAddMore ? "Add Selected Items" : "Enroll in Review Queue"}
           </button>
         )}
       </div>
@@ -788,7 +826,7 @@ export default function LearnItemPage() {
                 disabled={isSubmitting || !lesson}
                 className="w-full py-4 text-lg bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? "Saving..." : existingFacets && existingFacets.length > 0 ? "Add Selected Facets" : "Start Learning Selected Items"}
+                {isSubmitting ? "Saving..." : existingFacets && existingFacets.length > 0 ? "Add Selected Items" : "Enroll in Review Queue"}
               </button>
             </div>
           );

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -559,7 +559,7 @@ export default function ReviewPage() {
   const getQuestionType = (item: ReviewItem): string => {
     switch (item.facet.facetType) {
       case "AI-Generated-Question":
-        return `AI Quiz`;
+        return "Usage patterns";
       case "Content-to-Definition":
         return (item.facet.data?.kuType === "Grammar" || !item.facet.data?.reading)
           ? "Grammar Pattern → Meaning"

--- a/frontend/src/components/lessons/GrammarLessonView.tsx
+++ b/frontend/src/components/lessons/GrammarLessonView.tsx
@@ -24,7 +24,7 @@ export default function GrammarLessonView({
 
   const facetOptions = [
     { key: "sentence-assembly", label: "Sentence Assembly", description: "Reassemble example sentences" },
-    { key: "AI-Generated-Question", label: "AI Question", description: "Answer a dynamic question about this pattern" },
+    { key: "AI-Generated-Question", label: "General usage patterns", description: "Answer varied questions about how this pattern is used in context" },
     { key: "Content-to-Definition", label: "Pattern → Meaning", description: "See the pattern, recall its meaning" },
   ];
 


### PR DESCRIPTION
Design                                                    
                                                                                                                         
  Identified that UKU.status was a hodge-podge of manually-set values across multiple services with no single source of  
  truth, and that the lesson page framing ("what do you want to learn?") assumed the user knew nothing — providing no
  path for experienced learners to bypass busy-work.                                                                     
                                                            
  Core decisions:
  - UKU.status becomes a materialised view, derived from facet SRS data, never set directly
  - Lesson page inverted: "What do you already know?" — all standard facets always enrolled; user marks what they already
   know                                                                                                                  
  - Checked facets start at stage 6 (one below mastered, ~1 month until first review); unchecked at stage 0              
  - Scenario vocabReady gate unchanged at minSrsStage >= 1; self-certified facets satisfy it immediately on creation
                                                                                                                         
  Backend                                                                                                                
                                                                                                                         
  New: LearningProgressService (backend/src/learning-progress/)                                                          
  - @Global() module registered in AppModule                                                                             
  - recomputeAndCache(uid, kuId) — reads all facets for a KU, derives status (learning / reviewing / mastered), writes to
   UKU                                                                                                                   
  - Single owner of UKU.status; no other service may set it                                                              
                                                            
  backend/src/lib/constants.ts                                                                                           
  - Added MASTERED_STAGE = 7                                
  - Added SELF_CERTIFIED_STAGE = 6                                                                                       
                                                            
  ReviewsService.generateReviewFacets                                                                                    
  - New parameter: selfCertifiedFacets: string[]
  - Self-certified facets written at stage 6, nextReviewAt = now + 730h, selfCertified: true flag on doc                 
  - Direct status: 'reviewing' write replaced with recomputeAndCache                                    
                                                                                                                         
  ReviewsService.updateFacetSrs                             
  - Direct status: 'mastered' write replaced with recomputeAndCache                                                      
                                                            
  POST /api/reviews/generate                                                                                             
  - Body now accepts optional selfCertifiedFacets?: string[]
                                                                                                                         
  Frontend
                                                                                                                         
  /learn/[kuId]/page.tsx                                    
  - Heading: "What do you already know?" with explanatory subtext
  - getAvailableStandardFacetKeys() — helper computing all enrollable facet keys; used by both render and submit         
  - Submit always enrolls all standard facets; selfCertifiedFacets carries the checked subset                   
  - Kanji component stubs and context-example scenarios remain opt-in                                                    
  - Button: "Enroll in Review Queue"                                                                                     
                                                                                                                         
  Label rename: AI-Generated-Question → "General usage patterns"                                                         
  - frontend/src/app/learn/[kuId]/page.tsx — FACET_LABELS map + checkbox span                                            
  - frontend/src/components/lessons/GrammarLessonView.tsx — facet option label + description                             
  - frontend/src/app/concepts/[id]/page.tsx — section header + checkbox label                                            
  - frontend/src/app/review/page.tsx — getQuestionType return value → "Usage patterns"                                   
  - Firestore facetType value "AI-Generated-Question" unchanged throughout   