### PR TITLE
fix: Updated lesson page layout

### DIFF
--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -156,6 +156,10 @@ export class LessonsService {
         updates['data.definition'] = vocabLesson.definition;
       }
 
+      if (vocabLesson.conjugationType) {
+        updates['data.conjugationType'] = vocabLesson.conjugationType;
+      }
+
       if (Object.keys(updates).length > 0) {
         try {
           this.logger.log(`Updating KU ${kuId} with lesson data: ${JSON.stringify(updates)}`);

--- a/backend/src/prompts/vocab.prompts.ts
+++ b/backend/src/prompts/vocab.prompts.ts
@@ -15,7 +15,7 @@ The lesson should be in English. Where you want to use Japanese text for example
 * Provide the standard **Kana Reading**.
 * Provide a list of **Concise Definitions** (suitable for valid acceptable answers in a quiz).
 * Identify the **Part of Speech**.
-* Identify the **Conjugation Type** (if applicable).
+* Identify the **Conjugation Type** for verbs only (null for all non-verbs).
 
 **Task 2: Lesson Generation**
 * Generate detailed explanations for meaning and reading.
@@ -28,8 +28,9 @@ The lesson should be in English. Where you want to use Japanese text for example
 For the \`partOfSpeech\` property, select one of:
 * noun, proper-noun, noun-suru, i-adjective, na-adjective, transitive-verb, intransitive-verb, adverb, counter, prefix, suffix, conjunction, particle
 
-For the \`conjugation_type\` property, select one of (or null):
-* godan, ichidan, irregular, suru, i-adjective, na-adjective, null
+For the \`conjugationType\` property (verbs only):
+* MUST be one of: godan, ichidan, irregular
+* MUST be null for all non-verbs (nouns, adjectives, adverbs, etc.)
 
 Do not explain the terms "kun'yomi" or "on'yomi", never use the term "sino-japanese"
 
@@ -41,7 +42,7 @@ You MUST return a valid JSON object matching this schema:
   "reading": "The canonical kana reading (e.g. ぜったい)",
   "definitions": ["definition 1", "definition 2"],
   "partOfSpeech": "The selected part of speech string",
-  "conjugation_type": "The selected conjugation type or null",
+  "conjugationType": "godan | ichidan | irregular | null — null for all non-verbs",
 
   "meaning_explanation": "A detailed explanation of the word's meaning and nuance.",
   "reading_explanation": "An explanation of the reading (e.g., nuance, rendaku).",
@@ -73,7 +74,7 @@ Output:
   "reading": "せんせい",
   "definitions": ["teacher", "instructor", "master", "doctor"],
   "partOfSpeech": "noun",
-  "conjugation_type": null,
+  "conjugationType": null,
   "meaning_explanation": "A term used to address or refer to teachers, doctors, lawyers, politicians, and other authority figures or experts. It literally means 'one born before'.",
   "reading_explanation": "Note that 'sei' (せい) is prolonged, so it sounds like 'sensee'. This is a common pronunciation change in Japanese.",
   "context_examples": [
@@ -106,7 +107,7 @@ Output:
   "reading": "たべる",
   "definitions": ["to eat"],
   "partOfSpeech": "transitive-verb",
-  "conjugation_type": "ichidan",
+  "conjugationType": "ichidan",
   "meaning_explanation": "The standard verb for 'to eat'. It is a transitive verb, so it takes an object marked by 'o' (を).",
   "reading_explanation": "The reading 'ta' comes from the kanji 食 and 'beru' is okurigana.",
   "context_examples": [
@@ -132,7 +133,7 @@ Output:
   "reading": "ゆうめい",
   "definitions": ["famous", "fame"],
   "partOfSpeech": "na-adjective",
-  "conjugation_type": "na-adjective",
+  "conjugationType": null,
   "meaning_explanation": "Describes something or someone that has a name widely known. It is a Na-adjective, so you use 'na' to modify nouns (e.g. 有名のな人 - famous person).",
   "reading_explanation": "Standard on'yomi readings. 'Yuu' (有) + 'Mei' (名).",
   "context_examples": [
@@ -165,7 +166,7 @@ Output:
   "reading": "べんきょうする",
   "definitions": ["to study", "to work hard"],
   "partOfSpeech": "noun-suru",
-  "conjugation_type": "suru",
+  "conjugationType": "irregular",
   "meaning_explanation": "The primary verb for 'to study'. It is composed of the noun 'Benkyou' (study) and the auxiliary verb 'suru' (to do).",
   "reading_explanation": "Ben (勉) + Kyou (強) + Suru. Note that 'strong' (強) is usually read 'kyo' as a standalone on'yomi, but here it is 'kyou'.",
   "context_examples": [
@@ -198,7 +199,7 @@ Output:
   "reading": "にほん",
   "definitions": ["Japan"],
   "partOfSpeech": "proper-noun",
-  "conjugation_type": null,
+  "conjugationType": null,
   "meaning_explanation": "The country of Japan. Literally 'sun origin' (Land of the Rising Sun).",
   "reading_explanation": "Usually read 'Nihon', but sometimes 'Nippon' (more formal or emphatic).",
   "context_examples": [

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -123,6 +123,7 @@ export interface VocabLesson {
   definitions: string[];
   definition?: string; // Deprecated, kept for backward compatibility
   partOfSpeech: PartOfSpeech;
+  conjugationType?: 'godan' | 'ichidan' | 'irregular';
   meaning_explanation: string;
   reading_explanation: string;
   context_examples?: { sentence: string; translation: string }[];
@@ -260,6 +261,7 @@ export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
   data: {
     reading?: string;
     definition?: string;
+    conjugationType?: 'godan' | 'ichidan' | 'irregular';
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
     [key: string]: any;

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -2,10 +2,13 @@
 
 import React, { useState, useEffect, useRef } from "react"; // <-- Import useRef
 import { useRouter, useParams, useSearchParams } from "next/navigation";
-import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson, UserGrammarLesson } from "@/types";
+import { KnowledgeUnit, Lesson, VocabLesson, VocabKnowledgeUnit, KanjiLesson, GrammarLesson, UserGrammarLesson } from "@/types";
 import VocabLessonView from "@/components/lessons/VocabLessonView";
 import KanjiLessonView from "@/components/lessons/KanjiLessonView";
 import GrammarLessonView from "@/components/lessons/GrammarLessonView";
+import KuMetaTags from "@/components/lessons/KuMetaTags";
+import { FuriganaText } from "@/components/FuriganaText";
+import { buildFuriganaMarkup } from "@/lib/furigana";
 import { apiFetch } from "@/lib/api-client";
 
 const stripFurigana = (s: string) => s.replace(/\[[^\]]*\]/g, '').trim();
@@ -605,85 +608,104 @@ export default function LearnItemPage() {
                   <span className="ml-3 text-lg text-gray-900 dark:text-white">Audio Comprehension</span>
                 </label>
               )}
+              {!existingFacetTypes.has("AI-Generated-Question") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["AI-Generated-Question"]}
+                    onChange={() => handleCheckboxChange("AI-Generated-Question")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">General usage patterns</span>
+                </label>
+              )}
 
-              {(lesson as VocabLesson).component_kanji?.map((kanji, index) => {
-                const status = kanjiStatuses[kanji.kanji];
-                return (
-                  <div key={`${kanji.kanji}-${index}`} className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
-                    <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Component Kanji</h3>
-                    <p className="text-gray-600 dark:text-gray-400 mb-3">
-                      The kanji is <span className="font-bold text-lg">{kanji.kanji}</span>, which generally means "{kanji.meaning}".
-                    </p>
-                    {status ? (
-                      <div className="p-2 bg-gray-400 dark:bg-gray-700 rounded-md">
-                        <p className="text-lg text-gray-800 dark:text-gray-200">
-                          {status === "learning"
-                            ? `You already have a lesson queued for ${kanji.kanji}.`
-                            : `You are already learning ${kanji.kanji}.`}
-                        </p>
-                      </div>
-                    ) : (
-                      <>
+              {(availableKanjiComponents.length > 0 || hasContextExamples) && (
+                <div className="pt-5 mt-2 border-t border-gray-300 dark:border-gray-600 space-y-4">
+                  <h3 className="text-base font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                    Choose additional learning items and activities
+                  </h3>
+
+                  {(lesson as VocabLesson).component_kanji?.map((kanji, index) => {
+                    const status = kanjiStatuses[kanji.kanji];
+                    return (
+                      <div key={`${kanji.kanji}-${index}`} className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
+                        <h4 className="text-base font-semibold text-gray-700 dark:text-gray-300 mb-2">Component Kanji</h4>
                         <p className="text-gray-600 dark:text-gray-400 mb-3">
-                          In this word, it uses the reading <span className="font-bold text-lg">{kanji.reading}</span>.
+                          The kanji <span className="font-bold text-lg">{kanji.kanji}</span> generally means "{kanji.meaning}".
                         </p>
-                        <label className="flex items-center p-2 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            className="h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                            checked={!!selectedFacets[`Kanji-Component-${kanji.kanji}`]}
-                            onChange={() => handleCheckboxChange(`Kanji-Component-${kanji.kanji}`)}
-                          />
-                          <span className="ml-3 text-lg text-gray-900 dark:text-white">Add {kanji.kanji}</span>
-                        </label>
-                      </>
-                    )}
-                  </div>
-                );
-              })}
-
-              {hasContextExamples && (
-                <div className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
-                  <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Context Example Scenarios</h3>
-                  <p className="text-gray-600 dark:text-gray-400 mb-3 block">
-                    Select examples to instantly architect roleplay scenarios where you must use the word <strong>{ku?.content}</strong> in context.
-                  </p>
-                  <div className="space-y-3">
-                    {(lesson as VocabLesson).context_examples?.map((ex, index) => {
-                      const existing = kuScenarios[ex.sentence];
-                      if (existing) {
-                        return (
-                          <div key={index} className="flex items-start p-3 rounded-md bg-gray-400 dark:bg-gray-700">
-                            <span className="mt-1 h-5 w-5 flex items-center justify-center text-green-600 dark:text-green-400 font-bold text-sm flex-shrink-0">✓</span>
-                            <div className="ml-3 flex flex-col">
-                              <span className="text-lg text-gray-900 dark:text-white">{stripFurigana(ex.sentence)}</span>
-                              <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
-                              <a
-                                href={`/scenarios/${existing.id}`}
-                                className="mt-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                              >
-                                → View scenario
-                              </a>
-                            </div>
+                        {status ? (
+                          <div className="p-2 bg-gray-400 dark:bg-gray-700 rounded-md">
+                            <p className="text-lg text-gray-800 dark:text-gray-200">
+                              {status === "learning"
+                                ? `You already have a lesson queued for ${kanji.kanji}.`
+                                : `You are already learning ${kanji.kanji}.`}
+                            </p>
                           </div>
-                        );
-                      }
-                      return (
-                        <label key={index} className="flex items-start p-3 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            className="mt-1 h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                            checked={!!selectedFacets[`Context-Example-${index}`]}
-                            onChange={() => handleCheckboxChange(`Context-Example-${index}`)}
-                          />
-                          <span className="ml-3 text-lg text-gray-900 dark:text-white flex flex-col">
-                            <span>{stripFurigana(ex.sentence)}</span>
-                            <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
+                        ) : (
+                          <>
+                            <p className="text-gray-600 dark:text-gray-400 mb-3">
+                              In this word it uses the reading <span className="font-bold text-lg">{kanji.reading}</span>.
+                            </p>
+                            <label className="flex items-center p-2 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                className="h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                                checked={!!selectedFacets[`Kanji-Component-${kanji.kanji}`]}
+                                onChange={() => handleCheckboxChange(`Kanji-Component-${kanji.kanji}`)}
+                              />
+                              <span className="ml-3 text-lg text-gray-900 dark:text-white">Add {kanji.kanji}</span>
+                            </label>
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+
+                  {hasContextExamples && (
+                    <div className="p-4 bg-gray-300 dark:bg-gray-800 rounded-md">
+                      <h4 className="text-base font-semibold text-gray-700 dark:text-gray-300 mb-2">Context Example Scenarios</h4>
+                      <p className="text-gray-600 dark:text-gray-400 mb-3 block">
+                        Select examples to instantly architect roleplay scenarios where you must use the word <strong>{ku?.content}</strong> in context.
+                      </p>
+                      <div className="space-y-3">
+                        {(lesson as VocabLesson).context_examples?.map((ex, index) => {
+                          const existing = kuScenarios[ex.sentence];
+                          if (existing) {
+                            return (
+                              <div key={index} className="flex items-start p-3 rounded-md bg-gray-400 dark:bg-gray-700">
+                                <span className="mt-1 h-5 w-5 flex items-center justify-center text-green-600 dark:text-green-400 font-bold text-sm flex-shrink-0">✓</span>
+                                <div className="ml-3 flex flex-col">
+                                  <span className="text-lg text-gray-900 dark:text-white">{stripFurigana(ex.sentence)}</span>
+                                  <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
+                                  <a
+                                    href={`/scenarios/${existing.id}`}
+                                    className="mt-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                                  >
+                                    → View scenario
+                                  </a>
+                                </div>
+                              </div>
+                            );
+                          }
+                          return (
+                            <label key={index} className="flex items-start p-3 rounded-md hover:bg-gray-400 dark:hover:bg-gray-700 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                className="mt-1 h-5 w-5 rounded bg-gray-400 dark:bg-gray-900 border-gray-500 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                                checked={!!selectedFacets[`Context-Example-${index}`]}
+                                onChange={() => handleCheckboxChange(`Context-Example-${index}`)}
+                              />
+                              <span className="ml-3 text-lg text-gray-900 dark:text-white flex flex-col">
+                                <span>{stripFurigana(ex.sentence)}</span>
+                                <span className="text-sm text-gray-600 dark:text-gray-400">{stripFurigana(ex.translation)}</span>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
             </>
@@ -713,19 +735,18 @@ export default function LearnItemPage() {
                   <span className="ml-3 text-lg text-gray-900 dark:text-white">Reading (Kanji {"->"} On/Kun)</span>
                 </label>
               )}
+              {!existingFacetTypes.has("AI-Generated-Question") && (
+                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                    checked={!!selectedFacets["AI-Generated-Question"]}
+                    onChange={() => handleCheckboxChange("AI-Generated-Question")}
+                  />
+                  <span className="ml-3 text-lg text-gray-900 dark:text-white">General usage patterns</span>
+                </label>
+              )}
             </>
-          )}
-
-          {!existingFacetTypes.has("AI-Generated-Question") && (
-            <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-              <input
-                type="checkbox"
-                className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                checked={!!selectedFacets["AI-Generated-Question"]}
-                onChange={() => handleCheckboxChange("AI-Generated-Question")}
-              />
-              <span className="ml-3 text-lg text-gray-900 dark:text-white">General usage patterns</span>
-            </label>
           )}
         </div>
         )}
@@ -760,20 +781,24 @@ export default function LearnItemPage() {
           <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-2 break-all">
             {isLoading
               ? "..."
-              : lesson?.type === "Kanji" && (lesson as KanjiLesson).kanji
-                ? (lesson as KanjiLesson).kanji
-                : lesson?.type === "Grammar"
-                  ? (lesson as GrammarLesson).pattern
-                  : ku?.content || "..."}
+              : lesson?.type === "Vocab"
+                ? <FuriganaText text={buildFuriganaMarkup(
+                    ku?.content ?? "",
+                    (lesson as VocabLesson).component_kanji ?? [],
+                  )} />
+                : lesson?.type === "Kanji" && (lesson as KanjiLesson).kanji
+                  ? (lesson as KanjiLesson).kanji
+                  : lesson?.type === "Grammar"
+                    ? (lesson as GrammarLesson).pattern
+                    : ku?.content || "..."}
           </h1>
           {lesson && lesson?.type === "Vocab" && (
-            <p className="text-2xl text-gray-500 dark:text-gray-400 capitalize">
-              {lesson?.partOfSpeech
-                ? lesson.partOfSpeech
-                : ku
-                  ? ku.type
-                  : "..."}{" "}
-            </p>
+            <KuMetaTags
+              partOfSpeech={(lesson as VocabLesson).partOfSpeech}
+              conjugationType={(lesson as VocabLesson).conjugationType}
+              jlptLevel={ku?.type === "Vocab" ? (ku as VocabKnowledgeUnit).data.jlptLevel : null}
+              wanikaniLevel={ku?.type === "Vocab" ? (ku as VocabKnowledgeUnit).data.wanikaniLevel : null}
+            />
           )}
           {lesson && lesson?.type === "Grammar" && (
             <p className="text-2xl text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/lessons/KuMetaTags.tsx
+++ b/frontend/src/components/lessons/KuMetaTags.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { PartOfSpeech } from "@/types";
+
+interface KuMetaTagsProps {
+  partOfSpeech?: PartOfSpeech;
+  conjugationType?: "godan" | "ichidan" | "irregular";
+  jlptLevel?: string | null;
+  wanikaniLevel?: number | null;
+}
+
+// ── Label maps ────────────────────────────────────────────────────────────────
+
+const POS_LABELS: Partial<Record<PartOfSpeech, string>> = {
+  "transitive-verb":   "Transitive Verb",
+  "intransitive-verb": "Intransitive Verb",
+  "auxiliary-verb":    "Auxiliary Verb",
+  "i-adjective":       "い-adjective",
+  "na-adjective":      "な-adjective",
+  "noun":              "Noun",
+  "noun-prenominal":   "Prenominal",
+  "proper-noun":       "Proper Noun",
+  "noun-suru":         "Suru Noun",
+  "counter":           "Counter",
+  "adverb":            "Adverb",
+  "prefix":            "Prefix",
+  "suffix":            "Suffix",
+  "conjunction":       "Conjunction",
+};
+
+const CONJUGATION_LABELS: Record<string, string> = {
+  godan:     "Godan (う-verb)",
+  ichidan:   "Ichidan (る-verb)",
+  irregular: "Irregular",
+};
+
+// ── Tag styling by category (static strings for Tailwind JIT) ────────────────
+
+type TagVariant = "verb" | "adjective" | "noun" | "conjugation" | "jlpt" | "wanikani" | "default";
+
+const TAG_CLASSES: Record<TagVariant, string> = {
+  verb:        "bg-red-50 text-red-700 border border-red-200",
+  adjective:   "bg-emerald-50 text-emerald-700 border border-emerald-200",
+  noun:        "bg-sky-50 text-sky-800 border border-sky-200",
+  conjugation: "bg-orange-50 text-orange-700 border border-orange-200",
+  jlpt:        "bg-amber-50 text-amber-700 border border-amber-200",
+  wanikani:    "bg-purple-50 text-purple-700 border border-purple-200",
+  default:     "bg-stone-100 text-stone-600 border border-stone-200",
+};
+
+function posVariant(pos: PartOfSpeech): TagVariant {
+  if (pos.includes("verb"))      return "verb";
+  if (pos.includes("adjective")) return "adjective";
+  if (pos.includes("noun") || pos === "counter") return "noun";
+  return "default";
+}
+
+function normaliseJlpt(raw: string): string {
+  const upper = raw.toUpperCase();
+  return upper.startsWith("JLPT") ? upper : `JLPT ${upper}`;
+}
+
+// ── Tag primitive ─────────────────────────────────────────────────────────────
+
+function Tag({ label, variant }: { label: string; variant: TagVariant }) {
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-semibold tracking-wide ${TAG_CLASSES[variant]}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Public component ──────────────────────────────────────────────────────────
+
+export default function KuMetaTags({
+  partOfSpeech,
+  conjugationType,
+  jlptLevel,
+  wanikaniLevel,
+}: KuMetaTagsProps) {
+  const tags: React.ReactNode[] = [];
+
+  if (partOfSpeech) {
+    tags.push(
+      <Tag
+        key="pos"
+        label={POS_LABELS[partOfSpeech] ?? partOfSpeech}
+        variant={posVariant(partOfSpeech)}
+      />
+    );
+  }
+
+  if (conjugationType) {
+    tags.push(
+      <Tag
+        key="conj"
+        label={CONJUGATION_LABELS[conjugationType] ?? conjugationType}
+        variant="conjugation"
+      />
+    );
+  }
+
+  if (jlptLevel) {
+    tags.push(
+      <Tag key="jlpt" label={normaliseJlpt(jlptLevel)} variant="jlpt" />
+    );
+  }
+
+  if (wanikaniLevel != null) {
+    tags.push(
+      <Tag key="wk" label={`WK ${wanikaniLevel}`} variant="wanikani" />
+    );
+  }
+
+  if (tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {tags}
+    </div>
+  );
+}

--- a/frontend/src/lib/furigana.ts
+++ b/frontend/src/lib/furigana.ts
@@ -14,3 +14,29 @@ export function loadFurigana(): boolean {
   if (typeof localStorage === 'undefined') return false;
   return localStorage.getItem('furiganaVisible') === 'true';
 }
+
+/**
+ * Builds a FuriganaText-compatible markup string from a Japanese word and its
+ * per-kanji component data.
+ *
+ * e.g. content="食べる", componentKanji=[{kanji:"食", reading:"た"}]
+ *      → "食[た]べる"
+ *
+ * Pure-kana words or words with no component_kanji return unchanged — FuriganaText
+ * renders them as plain text, which is correct (kana needs no furigana).
+ */
+export function buildFuriganaMarkup(
+  content: string,
+  componentKanji: { kanji: string; reading: string }[],
+): string {
+  if (!componentKanji.length) return content;
+
+  const kanjiMap = new Map(componentKanji.map(k => [k.kanji, k.reading]));
+
+  let result = "";
+  for (const char of content) {
+    const reading = kanjiMap.get(char);
+    result += reading ? `${char}[${reading}]` : char;
+  }
+  return result;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -104,6 +104,7 @@ export interface VocabLesson {
   definitions: string[];
   definition?: string; // Deprecated, kept for backward compatibility
   partOfSpeech: PartOfSpeech;
+  conjugationType?: 'godan' | 'ichidan' | 'irregular';
   meaning_explanation: string;
   reading_explanation: string;
   context_examples?: { sentence: string; translation: string }[];
@@ -168,6 +169,7 @@ export interface GlobalVocabLesson {
   definitions: string[];
   definition?: string;
   partOfSpeech: PartOfSpeech;
+  conjugationType?: 'godan' | 'ichidan' | 'irregular';
   meaning_explanation: string;
   reading_explanation: string;
   context_examples?: { sentence: string; translation: string }[];
@@ -295,6 +297,7 @@ export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
   data: {
     reading?: string;
     definition?: string;
+    conjugationType?: 'godan' | 'ichidan' | 'irregular';
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
     [key: string]: any;
@@ -375,7 +378,7 @@ export type PartOfSpeech =
   | "transitive-verb"
   | "intransitive-verb"
   | "i-adjective"
-  | "na-  "
+  | "na-adjective"
   | "noun"
   | "noun-prenominal"
   | "proper-noun"
@@ -387,7 +390,7 @@ export type PartOfSpeech =
   | "suffix"
   | "conjunction"
   | "grammar"
-  | "expresssion";
+  | "expression";
 
 export interface GlobalKnowledgeUnit {
   id: string;


### PR DESCRIPTION
Summary                                                   
                                                                                                                         
  - conjugationType for verb KUs — Added conjugationType?: 'godan' | 'ichidan' | 'irregular' to VocabLesson and          
  VocabKnowledgeUnit.data in both type files. Prompt updated to use camelCase and restrict to verb-only values (dropped
  suru, i-adjective, na-adjective). Persisted to KU document after lesson generation alongside reading and definition.   
  - Metadata tag strip — New KuMetaTags component renders part-of-speech, conjugation type, JLPT level, and WaniKani
  level as colour-coded pill tags below the word heading on the lesson page. Verbs → red, adjectives → emerald, nouns →  
  sky, conjugation type → orange, JLPT → amber, WaniKani → purple.
  - Furigana in the lesson heading — buildFuriganaMarkup(content, componentKanji) utility (in lib/furigana.ts) builds    
  漢字[よみ] markup by walking the word character-by-character and looking up each kanji in the per-word component_kanji 
  readings already present in every vocab lesson. No AI changes or extra API calls needed. Applied to the via the
  existing FuriganaText component.                                                                                       
  - Facet checklist restructure — "General usage patterns" (AI-Generated-Question) moved up alongside Content / Meaning /
   Reading / Audio as a standard self-certifiable facet. Component Kanji and Context Example Scenarios moved into a      
  visually separated subsection "Choose additional learning items and activities".
  - Bug fix — Frontend PartOfSpeech type had two pre-existing typos: "na-  " → "na-adjective" and "expresssion" →        
  "expression".                                                                                                          
   
  Test plan                                                                                                              
                                                            
  - Open a verb lesson (e.g. 食べる) — confirm furigana appears above the kanji in the heading and tags show Transitive  
  Verb + Ichidan (る-verb) + JLPT/WK levels if present
  - Open a noun/adjective lesson — confirm conjugationType tag is absent                                                 
  - Open a lesson with no component_kanji — confirm heading renders plain text, no crash                                 
  - Enroll a new lesson — confirm "General usage patterns" appears in the main facet list, not below the divider         
  - Confirm Component Kanji and Context Example Scenarios appear under the "Choose additional learning items and         
  activities" heading                                                                                                    
  - Kanji lesson — confirm all three facets (Meaning, Reading, General usage patterns) appear in a single group  