### PR TITLE
strip periods from ai generated questions

### DIFF
--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -204,9 +204,10 @@ export class ReviewsService {
         questionId: string,
         kuId: string,
     ) {
-        // 1. Local Check
+        // 1. Local Check — strip trailing Japanese/ASCII punctuation before comparing
+        const normalize = (s: string) => s.toLowerCase().replace(/[。、！？,.!?\s]+$/u, '').trim();
         const isLocalMatch = expectedAnswers.some(
-            (ans) => ans.toLowerCase() === userAnswer.toLowerCase(),
+            (ans) => normalize(ans) === normalize(userAnswer),
         );
 
         if (isLocalMatch) {


### PR DESCRIPTION
The local match did a plain lowercase compare — no punctuation stripping. One-line fix in the backend