### PR TITLE
feat: implemented userroot and some parts of tutorContext

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,8 +193,8 @@ Per-user data lives in **Firestore sub-collections** under `users/{uid}/<collect
 | `questions` | **No** | Global question corpus — no `userId` on new docs. `rank` and `rejectionCount` fields drive selection. |
 | `users/{uid}/question-states` | Yes — sub-collection path | Per-user `UserQuestionState`: `rejected`, `consecutiveFailures`, `kuId` |
 | `users/{uid}/scenarios` | Yes — sub-collection path | Roleplay scenario state. Admin (`user_default`) uses root `scenarios` collection. `sourceKuId` field links back to the vocabulary KU that triggered generation from a context example. Requires composite index on `(sourceKuId, createdAt)`. |
-| `user-stats` | Yes — doc ID is uid | Legacy stats; `USER_STATS_COLLECTION.doc(uid)` |
-| `users` | Yes — doc path `users/{uid}` | `UserRoot` document (stats, tutorContext, preferences) |
+| `user-stats` | Yes — doc ID is uid | **Abandoned.** Stats now live in `users/{uid}.stats.*`. Old documents are stale and ignored. |
+| `users` | Yes — doc path `users/{uid}` | `UserRoot` document — single source of truth for `stats`, `tutorContext`, and `preferences` |
 | `concepts` | **No** | Global grammar concept corpus — no `userId` on docs; `createdBy` field for audit only |
 | `api-logs` | **No** | Centralised logging; no user field |
 
@@ -202,10 +202,15 @@ Per-user data lives in **Firestore sub-collections** under `users/{uid}/<collect
 
 ### Key Types
 
-- **`UserRoot`** (`backend/src/types/index.ts` ~line 34) — stored at `users/{uid}`. Contains `stats`, `tutorContext`, and two `preferences` fields: `tutorContext.preferences` (feed tuning — `dailyMaxNew`, `dailyMaxTotal`) and a top-level `preferences` object (`showFurigana: boolean`). Top-level preferences are written via `PATCH /api/users/me/preferences` and read on the `/profile` page.
+- **`UserRoot`** (`backend/src/types/index.ts` ~line 34) — stored at `users/{uid}`. Three top-level groups:
+  - `stats` — review forecasts, streak, totals, levelProgress. Written exclusively by `StatsService` via dot-notation Firestore updates inside the SRS transaction.
+  - `tutorContext` — AI personalisation data. Mechanical fields written by `StatsService` helpers; AI-inferred fields not yet implemented. See **UserRoot Stats & AI Tutor Context** section.
+  - `preferences` — top-level user-facing prefs (`showFurigana`, `jlptLevel`, `preferredUserRole`). Written via `PATCH /api/users/me/preferences`.
+  - `tutorContext.preferences` — feed-engine tuning (`dailyMaxNew`, `dailyMaxTotal`). Separate from top-level `preferences`.
+- **`TutorVocabEntry`** — `{ content: string; facetTypes: FacetType[] }`. Used for `frontierVocab`, `leechVocab`, and `weakGrammarPoints` arrays so per-facet-type granularity is preserved (e.g. a word can be frontier for meaning but a leech for reading).
 - **`KnowledgeUnit`** (~line 205) — has `userId` field (marked `@deprecated` as part of future migration to a separate `user-kus` sub-collection). `data` bag holds `jlptLevel`, `wanikaniLevel`, `reading`, `meaning`.
-- **`UserKnowledgeUnit`** (~line 235) — intended future shape: user metadata (`status`, `personalNotes`, `facet_count`) pointing at a global KU via `kuId`. **Not yet used in queries.**
-- **`ReviewFacet`** (~line 261) — bridges to `KnowledgeUnit` via `kuId`; carries `srsStage` (0–8) and `nextReviewAt`.
+- **`UserKnowledgeUnit`** (~line 235) — user metadata (`status`, `personalNotes`, `facet_count`) pointing at a global KU via `kuId`.
+- **`ReviewFacet`** (~line 261) — bridges to `KnowledgeUnit` via `kuId`; carries `srsStage` (0–8), `nextReviewAt`, and `consecutiveFailures` (per-facet failure counter, written in the SRS transaction, used for leech detection — survives question rotation).
 - **`QuestionItem`** — global question document. `rank: number` (0–100, starts 50, suitable threshold 30); `rejectionCount: number` (observability only). Deprecated fields (`userId`, `status`, `lastUsed`, `previousAnswers`) may exist on legacy docs but are ignored.
 - **`UserQuestionState`** — stored at `users/{uid}/question-states/{questionId}`. `rejected: boolean` (user never sees this question again); `consecutiveFailures: number` (persists across sessions, resets on correct answer, triggers rotation at 3); `kuId` (denormalised for querying).
 
@@ -401,6 +406,63 @@ The gate threshold remains `minSrsStage >= 1` across all vocab KUs linked to the
 | Stage 0 (learning from scratch) | Requires one successful review to reach stage 1 before the gate is satisfied |
 
 A user who claims to know all linked vocab can proceed to roleplay immediately. A user learning from scratch must complete at least one review per KU first.
+
+---
+
+## UserRoot Stats & AI Tutor Context
+
+### Stats
+
+All user stats live in `users/{uid}.stats.*`. The `user-stats/{uid}` top-level collection is abandoned. `StatsService` is the only writer; all updates use Firestore dot-notation so sibling fields are never clobbered.
+
+| Field | Written by | Trigger |
+|---|---|---|
+| `stats.reviewForecast` / `stats.hourlyForecast` | `StatsService.updateReviewScheduleStats` | Inside SRS transaction on every review answer |
+| `stats.currentStreak` / `stats.lastReviewDate` | same | same |
+| `stats.totalReviews` / `stats.passedReviews` | same | same |
+| `stats.levelProgress.{n5\|n4\|...}.total` | `StatsService.recordKuEnrolled` | `UserKnowledgeUnitsService.create` (non-blocking) |
+| `stats.levelProgress.{n5\|n4\|...}.mastered` | `StatsService.recordKuMastered` | `LearningProgressService.recomputeAndCache` on mastered transition |
+
+`stats.lastReviewDate` is optional on the document — the default user doc omits it so the first-ever review correctly sets the streak to 1.
+
+---
+
+### AI Tutor Context
+
+`tutorContext` fields provide the AI with a real-time picture of where the user is in their learning. Five fields are mechanically derivable; the remaining fields (`communicationStyle`, `semanticWeaknesses`, `suggestedThemes`) require AI inference and are not yet implemented.
+
+#### Mechanical fields
+
+| Field | Type | Semantics |
+|---|---|---|
+| `frontierVocab` | `TutorVocabEntry[]` | KUs recently promoted to `reviewing` — words the AI should actively reinforce |
+| `leechVocab` | `TutorVocabEntry[]` | KUs with ≥ 3 consecutive facet failures — words needing repair |
+| `allowedGrammar` | `string[]` | Grammar KU content strings the user has enrolled in |
+| `weakGrammarPoints` | `TutorVocabEntry[]` | Grammar KUs with ≥ 3 consecutive facet failures |
+| `currentCurriculumNode` | `string` | JLPT level of the most recently enrolled KU |
+
+#### Hook points
+
+| Field | Hook | Trigger |
+|---|---|---|
+| `frontierVocab` | `LearningProgressService.recomputeAndCache` | Added on `learning→reviewing`; removed on `→mastered`. `AI-Generated-Question` excluded from `facetTypes` (it's a question format, not a knowledge dimension). |
+| `leechVocab` / `weakGrammarPoints` | `ReviewsService.updateFacetSrs` (post-transaction, non-blocking) | Added when `ReviewFacet.consecutiveFailures` crosses 3; removed when user passes after prior failures. |
+| `allowedGrammar` | `UserKnowledgeUnitsService.create` (non-blocking) | Added when a Grammar KU is enrolled. |
+| `currentCurriculumNode` | `UserKnowledgeUnitsService.create` (non-blocking) | Set to jlptLevel of the enrolled KU. |
+
+#### Storage design
+
+`frontierVocab`, `leechVocab`, and `weakGrammarPoints` use `TutorVocabEntry[]` (`{ content, facetTypes }`) rather than `string[]`. This allows the same KU to appear in both arrays with different facet-type sets — e.g. 入れる can be frontier for `Content-to-Definition` and a leech for `Reading-to-Content` simultaneously.
+
+`FieldValue.arrayUnion/arrayRemove` cannot merge nested objects, so all mutations use Firestore transaction-based read-modify-write helpers in `StatsService`: `mergeTutorVocabEntry` (add/merge) and `removeTutorVocabFacetType` (remove one facet type, drop entry if none remain).
+
+`allowedGrammar` stays as `string[]` — no per-facet granularity needed.
+
+#### Leech detection: why `updateFacetSrs` not `recordAnswer`
+
+`QuestionsService.recordAnswer` tracks `UserQuestionState.consecutiveFailures` per-question, which controls question rotation (swap out a question after 3 failures). After rotation, a fresh question is issued and the per-question counter resets to 0 — so the leech threshold is never reached from the question side.
+
+`ReviewsService.updateFacetSrs` fires once per review submission regardless of which question was shown. The `ReviewFacet.consecutiveFailures` counter written there is scoped to the facet, not the question, and survives rotation. This is the correct hook for any "how is this user performing on this facet type?" logic.
 
 ---
 
@@ -603,6 +665,18 @@ Library page (`/learn`): Kanji items now show `data.meaning` in the hint column 
 - **`POST /api/reviews/generate`** — body now accepts `selfCertifiedFacets?: string[]`.
 - **Lesson page UX inverted** (`/learn/[kuId]`): heading changed to "What do you already know?"; all standard facets always enrolled on submit — checked = self-certified (stage 6), unchecked = learn from scratch (stage 0). Kanji component stubs and context-example scenarios remain opt-in. `getAvailableStandardFacetKeys()` helper centralises available-facet computation used by both render and submit. Button: "Enroll in Review Queue".
 - **`AI-Generated-Question` display label** renamed to "General usage patterns" on the lesson page, concepts page, and grammar lesson view; "Usage patterns" on the review card header. Firestore `facetType` value `"AI-Generated-Question"` unchanged.
+
+---
+
+**UserRoot stats + tutorContext implementation (2026-05-02)**
+
+- `user-stats/{uid}` collection abandoned. All stats now live in `users/{uid}.stats.*` via dot-notation Firestore updates in `StatsService`.
+- Five mechanical `tutorContext` fields implemented: `frontierVocab`, `leechVocab`, `allowedGrammar`, `weakGrammarPoints`, `currentCurriculumNode`. See **UserRoot Stats & AI Tutor Context** section.
+- `TutorVocabEntry = { content: string; facetTypes: FacetType[] }` introduced in both type files. Allows per-facet-type granularity within the same KU entry.
+- Leech detection moved from `QuestionsService.recordAnswer` (per-question scope — broken for AI-Generated-Question facets due to question rotation) to `ReviewsService.updateFacetSrs` (per-facet scope). `ReviewFacet.consecutiveFailures` field added.
+- `AI-Generated-Question` filtered from `frontierVocab.facetTypes` — it is a question format, not a knowledge dimension.
+- `facetType` now sent with `POST /reviews/evaluate` from the frontend and threaded through to `recordAnswer` for future use.
+- Review page answer input focus bug fixed for AI-Generated-Question facets: imperative `answerInputRef.current?.focus()` via `useEffect` on `isFetchingDynamicQuestion`/`dynamicQuestion` replaces reliance on `autoFocus` alone.
 
 ---
 

--- a/backend/src/learning-progress/learning-progress.module.ts
+++ b/backend/src/learning-progress/learning-progress.module.ts
@@ -1,10 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 import { LearningProgressService } from './learning-progress.service';
 import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
+import { StatsModule } from '../stats/stats.module';
 
 @Global()
 @Module({
-    imports: [UserKnowledgeUnitsModule],
+    imports: [UserKnowledgeUnitsModule, StatsModule],
     providers: [LearningProgressService],
     exports: [LearningProgressService],
 })

--- a/backend/src/learning-progress/learning-progress.service.ts
+++ b/backend/src/learning-progress/learning-progress.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { CollectionReference, Firestore, Query } from 'firebase-admin/firestore';
-import { FIRESTORE_CONNECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
+import { FIRESTORE_CONNECTION, KNOWLEDGE_UNITS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
 import { ADMIN_USER_ID, MASTERED_STAGE } from '../lib/constants';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
+import { StatsService } from '../stats/stats.service';
 import { ReviewFacet } from '../types';
 
 @Injectable()
@@ -12,6 +13,7 @@ export class LearningProgressService {
     constructor(
         @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
         private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
+        private readonly statsService: StatsService,
     ) {}
 
     private facetsColRef(uid: string): CollectionReference {
@@ -43,7 +45,12 @@ export class LearningProgressService {
      *   - All facets >= MASTERED_STAGE → 'mastered'
      */
     async recomputeAndCache(uid: string, kuId: string): Promise<void> {
-        const facets = await this.getFacetsForKu(uid, kuId);
+        const [facets, currentUku] = await Promise.all([
+            this.getFacetsForKu(uid, kuId),
+            this.userKnowledgeUnitsService.findByKuId(uid, kuId),
+        ]);
+
+        const previousStatus = currentUku?.status;
 
         let status: 'learning' | 'reviewing' | 'mastered';
         if (facets.length === 0) {
@@ -57,6 +64,39 @@ export class LearningProgressService {
         try {
             await this.userKnowledgeUnitsService.update(uid, kuId, { status });
             this.logger.log(`UKU status=${status} for uid=${uid} kuId=${kuId}`);
+
+            const isNewlyReviewing = status === 'reviewing' && previousStatus === 'learning';
+            const isNewlyMastered = status === 'mastered' && previousStatus !== 'mastered';
+
+            if (isNewlyReviewing || isNewlyMastered) {
+                const kuDoc = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(kuId).get();
+                const kuData = kuDoc.data();
+                const jlptLevel = kuData?.data?.jlptLevel;
+                const kuContent = kuData?.content as string | undefined;
+
+                if (isNewlyReviewing && kuContent) {
+                    const facetTypes = facets
+                        .map(f => f.facetType)
+                        .filter(t => t !== 'AI-Generated-Question');
+                    if (facetTypes.length > 0) {
+                        void this.statsService.addToFrontierVocab(uid, kuContent, facetTypes).catch(e =>
+                            this.logger.error(`Failed to add frontierVocab uid=${uid} kuId=${kuId}`, e),
+                        );
+                    }
+                }
+
+                if (isNewlyMastered) {
+                    if (jlptLevel) {
+                        await this.statsService.recordKuMastered(uid, jlptLevel);
+                        this.logger.log(`Mastered KU uid=${uid} kuId=${kuId} jlptLevel=${jlptLevel}`);
+                    }
+                    if (kuContent) {
+                        void this.statsService.removeFromFrontierVocab(uid, kuContent).catch(e =>
+                            this.logger.error(`Failed to remove frontierVocab uid=${uid} kuId=${kuId}`, e),
+                        );
+                    }
+                }
+            }
         } catch (e) {
             this.logger.error(`Failed to recompute UKU status for uid=${uid} kuId=${kuId}`, e);
         }

--- a/backend/src/questions/questions.module.ts
+++ b/backend/src/questions/questions.module.ts
@@ -4,13 +4,12 @@ import { QuestionsController } from './questions.controller';
 import { GeminiModule } from '../gemini/gemini.module';
 import { ReviewsModule } from '../reviews/reviews.module';
 import { KnowledgeUnitsModule } from '../knowledge-units/knowledge-units.module';
-
-@Global() // Optional: Makes it available everywhere without importing
+@Global()
 @Module({
     providers: [QuestionsService],
     exports: [QuestionsService],
     controllers: [QuestionsController],
     imports: [KnowledgeUnitsModule, GeminiModule,
-        forwardRef(() => ReviewsModule)], // Needed for GeminiService
+        forwardRef(() => ReviewsModule)],
 })
 export class QuestionsModule { }

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -303,7 +303,7 @@ export class QuestionsService {
     return this.toResponse(newQuestion, true);
   }
 
-  async recordAnswer(uid: string, questionId: string, kuId: string, result: 'pass' | 'fail') {
+  async recordAnswer(uid: string, questionId: string, kuId: string, result: 'pass' | 'fail', facetType?: string) {
     const questionRef = this.db.collection(QUESTIONS_COLLECTION).doc(questionId);
     const stateRef = this.questionStatesRef(uid).doc(questionId);
 

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -11,8 +11,8 @@ export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) { }
 
   @Post('evaluate')
-  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId: string }) {
-    const { userAnswer, expectedAnswers, question, topic, questionId, kuId } = body;
+  async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId: string; facetType?: string }) {
+    const { userAnswer, expectedAnswers, question, topic, questionId, kuId, facetType } = body;
 
     this.logger.log(`body ${JSON.stringify(body)}`);
 
@@ -29,7 +29,7 @@ export class ReviewsController {
       throw new BadRequestException('kuId is required when questionId is provided');
     }
 
-    return this.reviewsService.evaluateAnswer(uid, userAnswer, expectedAnswers, question, topic, questionId, kuId);
+    return this.reviewsService.evaluateAnswer(uid, userAnswer, expectedAnswers, question, topic, questionId, kuId, facetType as any);
   }
 
   @Put('facets/:id')

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -14,7 +14,7 @@ import {
 import { ADMIN_USER_ID, MASTERED_STAGE, SELF_CERTIFIED_STAGE } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { QuestionsService } from '../questions/questions.service';
-import { ReviewFacet } from '@/types';
+import { FacetType, ReviewFacet } from '@/types';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { StatsService } from '../stats/stats.service';
@@ -110,6 +110,10 @@ export class ReviewsService {
                 transaction
             );
 
+            // Track consecutive failures on the facet for leech detection
+            const prevConsecutiveFailures = facetData.consecutiveFailures ?? 0;
+            const newConsecutiveFailures = result === 'pass' ? 0 : prevConsecutiveFailures + 1;
+
             // WRITE (Facet)
             this.logger.log(`Updating facet ${facetId} to stage ${nextSrsStage} (${result.toUpperCase()})`);
 
@@ -117,6 +121,7 @@ export class ReviewsService {
                 srsStage: nextSrsStage,
                 nextReviewAt: nextReviewDate,
                 lastReviewAt: now,
+                consecutiveFailures: newConsecutiveFailures,
                 history: FieldValue.arrayUnion({
                     stage: nextSrsStage,
                     timestamp: now,
@@ -134,6 +139,9 @@ export class ReviewsService {
                 newStage: nextSrsStage,
                 nextReview: nextReviewDate,
                 kuId: facetData.kuId,
+                facetType: facetData.facetType,
+                prevConsecutiveFailures,
+                newConsecutiveFailures,
             };
         });
 
@@ -152,6 +160,27 @@ export class ReviewsService {
             } catch (e) {
                 this.logger.error(`Failed to check vocabReady for uid=${uid} kuId=${txResult.kuId}`, e);
             }
+        }
+
+        // Post-transaction: update tutorContext leech/weak-grammar tracking
+        if (txResult.kuId && txResult.facetType) {
+            const { kuId, facetType, prevConsecutiveFailures, newConsecutiveFailures } = txResult;
+            const LEECH_THRESHOLD = 3;
+            void (async () => {
+                try {
+                    const ku = await this.knowledgeUnitsService.findOne(kuId);
+                    const isGrammar = ku.type === 'Grammar';
+                    if (newConsecutiveFailures >= LEECH_THRESHOLD) {
+                        await this.statsService.addToLeechVocab(uid, ku.content, facetType);
+                        if (isGrammar) await this.statsService.addToWeakGrammarPoints(uid, ku.content, facetType);
+                    } else if (result === 'pass' && prevConsecutiveFailures > 0) {
+                        await this.statsService.removeFromLeechVocab(uid, ku.content, facetType);
+                        if (isGrammar) await this.statsService.removeFromWeakGrammarPoints(uid, ku.content, facetType);
+                    }
+                } catch (e) {
+                    this.logger.error(`Failed to update tutorContext leech for uid=${uid} facetId=${facetId}`, e);
+                }
+            })();
         }
 
         return { success: txResult.success, facetId: txResult.facetId, newStage: txResult.newStage, nextReview: txResult.nextReview };
@@ -203,6 +232,7 @@ export class ReviewsService {
         topic: string,
         questionId: string,
         kuId: string,
+        facetType?: FacetType,
     ) {
         // 1. Local Check — strip trailing Japanese/ASCII punctuation before comparing
         const normalize = (s: string) => s.toLowerCase().replace(/[。、！？,.!?\s]+$/u, '').trim();
@@ -213,7 +243,7 @@ export class ReviewsService {
         if (isLocalMatch) {
             this.logger.log(`Local match passed for topic: ${topic}`);
             if (questionId) {
-                await this.questionsService.recordAnswer(uid, questionId, kuId, 'pass');
+                await this.questionsService.recordAnswer(uid, questionId, kuId, 'pass', facetType);
             }
             return { result: 'pass', explanation: 'Correct!' };
         }
@@ -231,7 +261,7 @@ export class ReviewsService {
         ) as { result: 'pass' | 'fail'; explanation: string };
 
         if (questionId) {
-            await this.questionsService.recordAnswer(uid, questionId, kuId, evalResult.result);
+            await this.questionsService.recordAnswer(uid, questionId, kuId, evalResult.result, facetType);
         }
 
         return evalResult;

--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
-import { Firestore, Timestamp, Transaction } from 'firebase-admin/firestore';
+import { FieldValue, Firestore, Timestamp, Transaction } from 'firebase-admin/firestore';
+import { FacetType, TutorVocabEntry } from '../types';
 import {
     FIRESTORE_CONNECTION,
     REVIEW_FACETS_COLLECTION,
-    USER_STATS_COLLECTION,
     USER_KUS_SUBCOLLECTION,
     SCENARIOS_COLLECTION,
 } from '../firebase/firebase.module';
@@ -38,8 +38,7 @@ export class StatsService {
             .count()
             .get();
 
-        // New: Fetch User Stats Document
-        const userStatsQuery = this.db.collection(USER_STATS_COLLECTION).doc(uid).get();
+        const userStatsQuery = this.db.collection('users').doc(uid).get();
 
         const scenariosCol = uid === ADMIN_USER_ID
             ? this.db.collection(SCENARIOS_COLLECTION)
@@ -60,8 +59,7 @@ export class StatsService {
         const reviewsDueCount = reviewsSnapshot.data().count;
         this.logger.log(`Reviews due for user ${uid}: ${reviewsDueCount}`);
 
-        const userStatsDocData = userStatsDoc.data();
-        const userStats = userStatsDocData ? userStatsDocData : {};
+        const userStats = userStatsDoc.data()?.stats ?? {};
 
         const rawReviewForecast = userStats.reviewForecast || {};
         const rawHourlyForecast = userStats.hourlyForecast || {};
@@ -152,9 +150,9 @@ export class StatsService {
         result: 'pass' | 'fail',
         transaction: Transaction
     ) {
-        const statsRef = this.db.collection(USER_STATS_COLLECTION).doc(userId);
-        const statsDoc = await transaction.get(statsRef);
-        const statsData = statsDoc.data() || {};
+        const userRef = this.db.collection('users').doc(userId);
+        const statsDoc = await transaction.get(userRef);
+        const statsData = statsDoc.data()?.stats || {};
 
         const currentStats = {
             reviewForecast: statsData.reviewForecast || {},
@@ -210,16 +208,124 @@ export class StatsService {
         const newTotal = currentStats.totalReviews + 1;
         const newPassed = currentStats.passedReviews + (result === 'pass' ? 1 : 0);
 
-        // 4. Write to DB
-        transaction.set(statsRef, {
-            userId, // Ensure userId is set
-            reviewForecast: currentStats.reviewForecast,
-            hourlyForecast: currentStats.hourlyForecast,
-            currentStreak: newStreak,
-            lastReviewDate: now, // Firestore will convert Date to Timestamp
-            totalReviews: newTotal,
-            passedReviews: newPassed,
-        }, { merge: true });
+        // 4. Write to users/{uid} using dot-notation to avoid clobbering other UserRoot fields
+        transaction.update(userRef, {
+            'stats.reviewForecast': currentStats.reviewForecast,
+            'stats.hourlyForecast': currentStats.hourlyForecast,
+            'stats.currentStreak': newStreak,
+            'stats.lastReviewDate': now,
+            'stats.totalReviews': newTotal,
+            'stats.passedReviews': newPassed,
+        });
+    }
+
+    /** Normalize "N5" / "JLPT-N5" / "JLPT N5" → "n5" for levelProgress map key. */
+    private jlptKey(level: string): string | null {
+        const m = level.match(/n(\d)/i);
+        return m ? `n${m[1]}` : null;
+    }
+
+    async recordKuEnrolled(uid: string, jlptLevel: string): Promise<void> {
+        const key = this.jlptKey(jlptLevel);
+        if (!key) return;
+        await this.db.collection('users').doc(uid).update({
+            [`stats.levelProgress.${key}.total`]: FieldValue.increment(1),
+        });
+    }
+
+    async recordKuMastered(uid: string, jlptLevel: string): Promise<void> {
+        const key = this.jlptKey(jlptLevel);
+        if (!key) return;
+        await this.db.collection('users').doc(uid).update({
+            [`stats.levelProgress.${key}.mastered`]: FieldValue.increment(1),
+        });
+    }
+
+    /** Merge facetTypes into an existing entry (by content) or add a new entry. */
+    private async mergeTutorVocabEntry(
+        uid: string,
+        field: 'frontierVocab' | 'leechVocab' | 'weakGrammarPoints',
+        content: string,
+        facetTypes: FacetType[],
+    ): Promise<void> {
+        const userRef = this.db.collection('users').doc(uid);
+        await this.db.runTransaction(async (transaction) => {
+            const doc = await transaction.get(userRef);
+            const entries: TutorVocabEntry[] = doc.data()?.tutorContext?.[field] ?? [];
+            const idx = entries.findIndex(e => e.content === content);
+            if (idx >= 0) {
+                const merged = Array.from(new Set([...entries[idx].facetTypes, ...facetTypes]));
+                entries[idx] = { content, facetTypes: merged };
+            } else {
+                entries.push({ content, facetTypes });
+            }
+            transaction.update(userRef, { [`tutorContext.${field}`]: entries });
+        });
+    }
+
+    /** Remove a specific facetType from an entry; drop the entry entirely if no facetTypes remain.
+     *  Pass facetType=undefined to remove the whole entry regardless. */
+    private async removeTutorVocabFacetType(
+        uid: string,
+        field: 'frontierVocab' | 'leechVocab' | 'weakGrammarPoints',
+        content: string,
+        facetType?: FacetType,
+    ): Promise<void> {
+        const userRef = this.db.collection('users').doc(uid);
+        await this.db.runTransaction(async (transaction) => {
+            const doc = await transaction.get(userRef);
+            let entries: TutorVocabEntry[] = doc.data()?.tutorContext?.[field] ?? [];
+            if (facetType === undefined) {
+                entries = entries.filter(e => e.content !== content);
+            } else {
+                const idx = entries.findIndex(e => e.content === content);
+                if (idx >= 0) {
+                    const remaining = entries[idx].facetTypes.filter(t => t !== facetType);
+                    if (remaining.length === 0) {
+                        entries.splice(idx, 1);
+                    } else {
+                        entries[idx] = { content, facetTypes: remaining };
+                    }
+                }
+            }
+            transaction.update(userRef, { [`tutorContext.${field}`]: entries });
+        });
+    }
+
+    async addToFrontierVocab(uid: string, content: string, facetTypes: FacetType[]): Promise<void> {
+        await this.mergeTutorVocabEntry(uid, 'frontierVocab', content, facetTypes);
+    }
+
+    async removeFromFrontierVocab(uid: string, content: string): Promise<void> {
+        await this.removeTutorVocabFacetType(uid, 'frontierVocab', content);
+    }
+
+    async addToLeechVocab(uid: string, content: string, facetType: FacetType): Promise<void> {
+        await this.mergeTutorVocabEntry(uid, 'leechVocab', content, [facetType]);
+    }
+
+    async removeFromLeechVocab(uid: string, content: string, facetType: FacetType): Promise<void> {
+        await this.removeTutorVocabFacetType(uid, 'leechVocab', content, facetType);
+    }
+
+    async addToAllowedGrammar(uid: string, pattern: string): Promise<void> {
+        await this.db.collection('users').doc(uid).update({
+            'tutorContext.allowedGrammar': FieldValue.arrayUnion(pattern),
+        });
+    }
+
+    async addToWeakGrammarPoints(uid: string, pattern: string, facetType: FacetType): Promise<void> {
+        await this.mergeTutorVocabEntry(uid, 'weakGrammarPoints', pattern, [facetType]);
+    }
+
+    async removeFromWeakGrammarPoints(uid: string, pattern: string, facetType: FacetType): Promise<void> {
+        await this.removeTutorVocabFacetType(uid, 'weakGrammarPoints', pattern, facetType);
+    }
+
+    async updateCurriculumNode(uid: string, jlptLevel: string): Promise<void> {
+        await this.db.collection('users').doc(uid).update({
+            'tutorContext.currentCurriculumNode': jlptLevel,
+        });
     }
 
     // Helper to generate bucket keys

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -31,6 +31,12 @@ export interface ApiLog {
   };
 }
 
+/** A KU entry in a tutor context array, with per-facet-type granularity. */
+export interface TutorVocabEntry {
+  content: string;
+  facetTypes: FacetType[];
+}
+
 /**
  * Represents the root document for a user in the strict multi-tenant architecture.
  * Document path: users/{uid}
@@ -51,7 +57,7 @@ export interface UserRoot {
 
     // Engagement
     currentStreak: number;
-    lastReviewDate: Timestamp; // ISO Date
+    lastReviewDate?: Timestamp;
 
     // Performance
     totalReviews: number;
@@ -73,10 +79,10 @@ export interface UserRoot {
    */
   tutorContext: {
     /** Words learned recently that the AI should actively try to reinforce in scenarios/examples. */
-    frontierVocab: string[];
+    frontierVocab: TutorVocabEntry[];
 
     /** Words the user has failed often that need repair/re-evaluation through the AI tutor. */
-    leechVocab: string[];
+    leechVocab: TutorVocabEntry[];
 
     /** The current topic or structural node the user is tackling in their overall curriculum. */
     currentCurriculumNode: string;
@@ -85,7 +91,7 @@ export interface UserRoot {
     allowedGrammar: string[];
 
     /** Specific grammar points the user struggles with; AI should emphasize diagnosing and practicing these. */
-    weakGrammarPoints: string[];
+    weakGrammarPoints: TutorVocabEntry[];
 
     /** The user's identified conversational tendency, signaling how the AI should prompt for polite vs. casual context. */
     communicationStyle: 'too_formal' | 'too_casual' | 'balanced' | 'hesitant';
@@ -411,6 +417,8 @@ export interface ReviewFacet {
     stage: number;
   }>;
   currentQuestionId?: string;
+  /** Consecutive failures on this facet (resets on pass). Used for leech detection. */
+  consecutiveFailures?: number;
   /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
   data?: any;

--- a/backend/src/user-knowledge-units/user-knowledge-units.module.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.module.ts
@@ -1,8 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { UserKnowledgeUnitsService } from './user-knowledge-units.service';
+import { StatsModule } from '../stats/stats.module';
 
 @Global()
 @Module({
+  imports: [StatsModule],
   providers: [UserKnowledgeUnitsService],
   exports: [UserKnowledgeUnitsService],
 })

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -2,12 +2,16 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Firestore, Timestamp } from 'firebase-admin/firestore';
 import { FIRESTORE_CONNECTION, KNOWLEDGE_UNITS_COLLECTION, USER_KUS_SUBCOLLECTION } from '../firebase/firebase.module';
 import { KnowledgeUnit, UserKnowledgeUnit } from '../types';
+import { StatsService } from '../stats/stats.service';
 
 @Injectable()
 export class UserKnowledgeUnitsService {
   private readonly logger = new Logger(UserKnowledgeUnitsService.name);
 
-  constructor(@Inject(FIRESTORE_CONNECTION) private readonly db: Firestore) {}
+  constructor(
+    @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+    private readonly statsService: StatsService,
+  ) {}
 
   private userKusRef(uid: string) {
     return this.db.collection('users').doc(uid).collection(USER_KUS_SUBCOLLECTION);
@@ -108,6 +112,25 @@ export class UserKnowledgeUnitsService {
 
     const ref = await this.userKusRef(uid).add(payload);
     this.logger.log(`Created UKU id=${ref.id} for uid=${uid} kuId=${kuId} source=${source?.type ?? 'none'}`);
+
+    // Non-blocking: update stats and tutorContext on enrollment
+    void (async () => {
+      try {
+        const kuDoc = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(kuId).get();
+        const kuData = kuDoc.data();
+        const jlptLevel = kuData?.data?.jlptLevel;
+        if (jlptLevel) {
+          await this.statsService.recordKuEnrolled(uid, jlptLevel);
+          await this.statsService.updateCurriculumNode(uid, jlptLevel);
+        }
+        if (kuData?.type === 'Grammar' && kuData?.content) {
+          await this.statsService.addToAllowedGrammar(uid, kuData.content);
+        }
+      } catch (e) {
+        this.logger.error(`Failed to record KU enrolled stats uid=${uid} kuId=${kuId}`, e);
+      }
+    })();
+
     return { id: ref.id, ...payload };
   }
 }

--- a/backend/src/users/user.service.ts
+++ b/backend/src/users/user.service.ts
@@ -20,7 +20,6 @@ export class UserService {
         reviewForecast: {},
         hourlyForecast: {},
         currentStreak: 0,
-        lastReviewDate: Timestamp.now(),
         totalReviews: 0,
         passedReviews: 0,
         levelProgress: {

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -102,6 +102,7 @@ export default function ReviewPage() {
 
   const lastFetchedIndex = useRef<number | null>(null);
   const nextButtonRef = useRef<HTMLButtonElement>(null);
+  const answerInputRef = useRef<HTMLInputElement>(null);
 
   // --- Focus Next Button Effect ---
   const FOCUS_TIMEOUT_MS = 50;
@@ -122,6 +123,17 @@ export default function ReviewPage() {
       }
     };
   }, [answerState]);
+
+  // Focus the answer input after AI-Generated question finishes loading
+  useEffect(() => {
+    if (
+      currentItem?.facet.facetType === "AI-Generated-Question" &&
+      !isFetchingDynamicQuestion &&
+      dynamicQuestion
+    ) {
+      answerInputRef.current?.focus();
+    }
+  }, [isFetchingDynamicQuestion, dynamicQuestion, currentItem]);
 
   // --- Fetch Dynamic Question Logic ---
   const fetchDynamicQuestion = async (
@@ -376,6 +388,7 @@ export default function ReviewPage() {
           questionType,
           questionId,
           kuId: currentItem.facet.kuId,
+          facetType: currentItem.facet.facetType,
         }),
       });
 
@@ -815,6 +828,7 @@ export default function ReviewPage() {
         {/* Answer Form */}
         <form onSubmit={handleEvaluateAnswer} className="relative">
           <input
+            ref={answerInputRef}
             key={currentItem.facet.id} // Force re-render (and autoFocus) on new item
             type="text"
             value={userAnswer}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,12 @@ export interface ApiLog {
   };
 }
 
+/** A KU entry in a tutor context array, with per-facet-type granularity. */
+export interface TutorVocabEntry {
+  content: string;
+  facetTypes: FacetType[];
+}
+
 /**
  * Represents the root document for a user in the strict multi-tenant architecture.
  * Document path: users/{uid}
@@ -45,7 +51,7 @@ export interface UserRoot {
 
     // Engagement
     currentStreak: number;
-    lastReviewDate: Timestamp; // ISO Date
+    lastReviewDate?: Timestamp;
 
     // Performance
     totalReviews: number;
@@ -67,10 +73,10 @@ export interface UserRoot {
    */
   tutorContext: {
     /** Words learned recently that the AI should actively try to reinforce in scenarios/examples. */
-    frontierVocab: string[];
+    frontierVocab: TutorVocabEntry[];
 
     /** Words the user has failed often that need repair/re-evaluation through the AI tutor. */
-    leechVocab: string[];
+    leechVocab: TutorVocabEntry[];
 
     /** The current topic or structural node the user is tackling in their overall curriculum. */
     currentCurriculumNode: string;


### PR DESCRIPTION
Summary                                                   
                                                                                                                         
  - Migrates all user stats writes from the orphaned user-stats/{uid} collection to users/{uid}.stats.* using            
  dot-notation Firestore updates
  - Implements five mechanically-derivable tutorContext fields: frontierVocab, leechVocab, allowedGrammar,               
  weakGrammarPoints, currentCurriculumNode                                                                               
  - Introduces TutorVocabEntry shape ({ content, facetTypes }) so a single KU can appear in both arrays with different
  facet-type granularity                                                                                                 
  - Fixes answer input focus regression for AI-Generated-Question (Usage Patterns) facets
                                                                                                                         
  Stats changes                                                                                                          
                                                                                                                         
  - stats.currentStreak, lastReviewDate, totalReviews, passedReviews, reviewForecast, hourlyForecast — written by        
  StatsService.updateReviewScheduleStats inside the same Firestore transaction as the facet SRS update
  - stats.levelProgress.{n5|n4|...}.total — incremented by recordKuEnrolled on UKU creation                              
  - stats.levelProgress.{n5|n4|...}.mastered — incremented by recordKuMastered on mastered transition in
  LearningProgressService                                                                                                
  - lastReviewDate made optional; removed from buildDefaultUserRoot so first-ever review correctly initialises the streak
                                                                                                                         
  tutorContext changes                                      
                                                                                                                         
  ┌───────────────────────┬───────────────────────────┬──────────────────┬───────────────────────────────────────────┐   
  │         Field         │       Trigger (add)       │ Trigger (remove) │                   Hook                    │
  ├───────────────────────┼───────────────────────────┼──────────────────┼───────────────────────────────────────────┤   
  │ frontierVocab         │ learning → reviewing      │ → mastered       │ LearningProgressService.recomputeAndCache │
  ├───────────────────────┼───────────────────────────┼──────────────────┼───────────────────────────────────────────┤
  │ leechVocab            │ facet consecutiveFailures │ pass after prior │ ReviewsService.updateFacetSrs             │   
  │                       │  >= 3                     │  failure         │                                           │   
  ├───────────────────────┼───────────────────────────┼──────────────────┼───────────────────────────────────────────┤   
  │ allowedGrammar        │ Grammar UKU created       │ —                │ UserKnowledgeUnitsService.create          │   
  ├───────────────────────┼───────────────────────────┼──────────────────┼───────────────────────────────────────────┤   
  │ weakGrammarPoints     │ same as leech, Grammar    │ same as leech    │ ReviewsService.updateFacetSrs             │
  │                       │ KUs only                  │                  │                                           │   
  ├───────────────────────┼───────────────────────────┼──────────────────┼───────────────────────────────────────────┤
  │ currentCurriculumNode │ any UKU created           │ —                │ UserKnowledgeUnitsService.create          │   
  └───────────────────────┴───────────────────────────┴──────────────────┴───────────────────────────────────────────┘   
  
  Bug fixes                                                                                                              
                                                            
  - Leech detection hook moved to updateFacetSrs — AI-Generated-Question facets rotate to a new question after 3         
  per-question failures, which reset the old per-question counter before the leech threshold was reached. The new
  per-facet consecutiveFailures field (written in the SRS transaction) survives question rotation.                       
  - AI-Generated-Question filtered from frontierVocab.facetTypes — it's a question format, not a knowledge dimension. It
  is retained in leechVocab.facetTypes where it correctly signals "user struggles with usage-pattern questions for this  
  word."
  - Answer input focus — imperative answerInputRef.current?.focus() via useEffect on                                     
  isFetchingDynamicQuestion/dynamicQuestion fixes the case where autoFocus fires during loading and is lost by the time  
  the question renders.
                                                                                                                         
  Storage note                                              

  frontierVocab, leechVocab, and weakGrammarPoints are now TutorVocabEntry[] instead of string[]. All mutations use      
  Firestore transaction-based read-modify-write (mergeTutorVocabEntry / removeTutorVocabFacetType in StatsService) —
  FieldValue.arrayUnion/arrayRemove cannot merge nested objects. Existing documents with the old string[] format will be 
  overwritten on first write.      