### PR TITLE
fix: single kanji vocab incorrectly flags itself as a kanji component lesson

### DIFF
--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -91,7 +91,7 @@ export default function LearnItemPage() {
 
         const statuses: Record<string, string> = {};
         data.forEach((ku) => {
-          if (kanjiChars.has(ku.content) && (ku as any).ukuStatus) {
+          if (ku.id !== kuId && kanjiChars.has(ku.content) && (ku as any).ukuStatus) {
             statuses[ku.content] = (ku as any).ukuStatus;
           }
         });


### PR DESCRIPTION
## Summary

- Single-kanji vocab (e.g. 蓋) was reporting its own UKU as an already-queued kanji component lesson, because the vocab content character matched the component kanji character
- Added a `ku.id !== kuId` guard when scanning the user's KUs for kanji component statuses, so the parent vocab KU is always skipped
- A genuine separate Kanji KU for the same character (if it exists) is still detected correctly

Fixes #167

## Test plan

- [ ] Open the lesson for a single-kanji vocab (e.g. 蓋)
- [ ] Verify the component kanji section no longer says "You already have a lesson queued for 蓋"
- [ ] Verify that multi-kanji vocab (e.g. 食べる with 食) still correctly shows kanji component status when the kanji is separately enrolled

🤖 Generated with [Claude Code](https://claude.com/claude-code)