### PR TITLE
fix: remove AI-Generated-Question from kanji lesson facets

### DIFF
--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -222,7 +222,7 @@ export default function LearnItemPage() {
       ].filter(k => !existingFacetTypes.has(k));
     }
     if (lesson.type === "Kanji") {
-      return ["Kanji-Component-Meaning", "Kanji-Component-Reading", "AI-Generated-Question"]
+      return ["Kanji-Component-Meaning", "Kanji-Component-Reading"]
         .filter(k => !existingFacetTypes.has(k));
     }
     if (lesson.type === "Grammar") {
@@ -499,7 +499,7 @@ export default function LearnItemPage() {
       "AI-Generated-Question",
     ] as string[]).filter(k => !existingFacetTypes.has(k)) : [];
 
-    const newKanjiKeys = lesson?.type === "Kanji" ? (["Kanji-Component-Meaning", "Kanji-Component-Reading", "AI-Generated-Question"] as string[])
+    const newKanjiKeys = lesson?.type === "Kanji" ? (["Kanji-Component-Meaning", "Kanji-Component-Reading"] as string[])
       .filter(k => !existingFacetTypes.has(k)) : [];
 
     const anythingLeft = lesson?.type === "Vocab"
@@ -733,17 +733,6 @@ export default function LearnItemPage() {
                     onChange={() => handleCheckboxChange("Kanji-Component-Reading")}
                   />
                   <span className="ml-3 text-lg text-gray-900 dark:text-white">Reading (Kanji {"->"} On/Kun)</span>
-                </label>
-              )}
-              {!existingFacetTypes.has("AI-Generated-Question") && (
-                <label className="flex items-center p-4 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    className="h-5 w-5 rounded bg-gray-300 dark:bg-gray-900 border-gray-400 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
-                    checked={!!selectedFacets["AI-Generated-Question"]}
-                    onChange={() => handleCheckboxChange("AI-Generated-Question")}
-                  />
-                  <span className="ml-3 text-lg text-gray-900 dark:text-white">General usage patterns</span>
                 </label>
               )}
             </>


### PR DESCRIPTION
## Summary

- Removes `AI-Generated-Question` from the available facet keys for Kanji lessons in `getAvailableStandardFacetKeys` and from the `newKanjiKeys` list in `renderFacetChecklist`
- Removes the "General usage patterns" checkbox from the Kanji section of the facet checklist UI

## Why

Kanji KUs have exactly two knowledge dimensions: `Kanji-Component-Meaning` (kanji → meaning) and `Kanji-Component-Reading` (kanji → on/kun readings). `AI-Generated-Question` generates vocab-style usage-pattern questions that are not applicable to standalone kanji.

Removing it also resolves issue #171's pre-checked confusion: once both component facets exist (e.g. auto-created as component stubs when enrolling a vocab word), the kanji lesson page now correctly shows "All available facets are already configured." instead of still offering an AI question option. Previously this caused the Meaning/Reading checkboxes to appear pre-checked while a spurious "General usage patterns" option remained available.

## Scope

Frontend-only change. Any existing `AI-Generated-Question` facets already present on Kanji KUs in Firestore will continue to surface in reviews — this fix prevents new ones from being created.

## Test plan

- [ ] Visit a Kanji lesson with no existing facets — only "Meaning (Kanji → Meaning)" and "Reading (Kanji → On/Kun)" options appear; no "General usage patterns"
- [ ] Enroll both facets, revisit the lesson — page shows "All available facets are already configured."
- [ ] Visit a Kanji lesson whose component facets were already created via a vocab lesson — same "already configured" state, no dangling AI option
- [ ] Vocab and Grammar lesson facet checklists are unaffected

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)