### PR TITLE
fix: disambiguate review labels and short-circuit kana reading matches

### DIFF
--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -357,8 +357,26 @@ export default function ReviewPage() {
     setError(null);
     setAiExplanation("");
 
-    const expectedAnswers = getExpectedAnswer(currentItem); // Now using array
+    const expectedAnswers = getExpectedAnswer(currentItem);
     const question = getQuestion(currentItem);
+
+    // Short-circuit for reading facets: normalize both sides to hiragana and
+    // compare locally so an exact kana match never requires an AI round-trip.
+    const isReadingFacet =
+      currentItem.facet.facetType === "Kanji-Component-Reading" ||
+      currentItem.facet.facetType === "Content-to-Reading";
+    if (isReadingFacet && expectedAnswers.length > 0) {
+      const normalizedAnswer = wanakana.toHiragana(userAnswer.trim());
+      const matched = expectedAnswers.some(
+        (a) => wanakana.toHiragana(a) === normalizedAnswer,
+      );
+      if (matched) {
+        await handleUpdateSrs("pass");
+        setAiExplanation("");
+        setAnswerState("correct");
+        return;
+      }
+    }
     const topic = currentItem.facet.data?.content || '';
     const questionType = getQuestionType(currentItem); // Get the question type
     // Use dynamicQuestionId if available (for AI questions), otherwise fallback to facet's currentQuestionId (though that might be stale)
@@ -584,8 +602,13 @@ export default function ReviewPage() {
       case "Kanji-Component-Reading":
         return "Kanji Component Reading";
       case "Definition-to-Content":
+        return (item.facet.data?.definitions?.length ?? 0) > 0 || item.facet.data?.reading
+          ? "Vocab Word"
+          : "Kanji Character";
       case "Reading-to-Content":
-        return "Vocab/Kanji";
+        return item.facet.data?.reading
+          ? "Vocab Word"
+          : "Kanji Character";
       case "audio":
         return "Audio Comprehension";
       default:
@@ -600,6 +623,8 @@ export default function ReviewPage() {
     return (
       type === "Content-to-Reading" ||
       type === "Kanji-Component-Reading" ||
+      type === "Definition-to-Content" ||
+      type === "Reading-to-Content" ||
       type === "AI-Generated-Question"
     );
   };


### PR DESCRIPTION
## Summary

- **Label disambiguation**: `getQuestionType` now inspects `facet.data` for `Definition-to-Content` and `Reading-to-Content` to return either `"Vocab Word"` or `"Kanji Character"` instead of the old `"Vocab/Kanji"`. This label flows to the evaluate endpoint, giving the AI a precise signal about what strictness to apply.

- **Japanese input**: `isJapaneseInput` now includes `Definition-to-Content` and `Reading-to-Content` — the expected answer for both is `data.content` (Japanese), so wanakana conversion and the `回答を入力して...` placeholder apply correctly instead of the generic "Type your answer...".

- **Kana short-circuit**: `handleEvaluateAnswer` now checks `Kanji-Component-Reading` and `Content-to-Reading` answers locally before hitting the AI. Both the user's input and the expected answers are normalized to hiragana via `wanakana.toHiragana()`, so typing `りょく` correctly matches the stored onyomi `リョク` with no API round-trip.

## Why the kana mismatch happened

Onyomi readings are stored as katakana (e.g. `["リョク", "リキ"]`). Wanakana converts romaji input to hiragana (`りょく`). A simple string comparison always fails, forcing every reading answer through the AI backend — which would accept the match but at unnecessary cost and latency.

## Test plan

- [ ] Review a `Kanji-Component-Reading` facet — type the onyomi in romaji (e.g. `ryoku`) and confirm it resolves as correct without an AI round-trip (no "Evaluating..." flash)
- [ ] Review a `Content-to-Reading` vocab facet — same check
- [ ] Wrong reading still goes to AI and gets marked incorrect
- [ ] `Definition-to-Content` review shows label "Vocab Word" (if vocab facet data present) or "Kanji Character"
- [ ] `Definition-to-Content` input field shows Japanese placeholder and wanakana converts romaji

🤖 Generated with [Claude Code](https://claude.com/claude-code)