### PR TITLE
feat: expand dashboard KU widget to show pending/reviewing/mastered buckets

### DIFF
--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -29,6 +29,12 @@ export class StatsService {
             .count()
             .get();
 
+        const masteredQuery = this.db.collection('users').doc(uid)
+            .collection(USER_KUS_SUBCOLLECTION)
+            .where("status", "==", "mastered")
+            .count()
+            .get();
+
         const facetsCol = uid === ADMIN_USER_ID
             ? this.db.collection(REVIEW_FACETS_COLLECTION).where('userId', '==', uid)
             : this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
@@ -48,9 +54,10 @@ export class StatsService {
             .count()
             .get();
 
-        const [ukuLearnSnapshot, reviewingSnapshot, reviewsSnapshot, userStatsDoc, simulateScenariosSnapshot] = await Promise.all([
+        const [ukuLearnSnapshot, reviewingSnapshot, masteredSnapshot, reviewsSnapshot, userStatsDoc, simulateScenariosSnapshot] = await Promise.all([
             ukuLearnQuery,
             reviewQuery,
+            masteredQuery,
             reviewsDueQuery,
             userStatsQuery,
             simulateScenariosQuery,
@@ -130,6 +137,8 @@ export class StatsService {
 
         return {
             learnCount: ukuLearnSnapshot.data().count,
+            reviewingCount: reviewingSnapshot.data().count,
+            masteredCount: masteredSnapshot.data().count,
             reviewCount: totalActive,
             reviewsDue: reviewsDueCount,
             simulateCount: simulateScenariosSnapshot.data().count,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,8 @@ import { apiFetch } from "@/lib/api-client";
 
 interface DashboardStats {
   learnCount: number;
+  reviewingCount: number;
+  masteredCount: number;
   next24HoursCount: number;
   reviewCount: number;
   reviewsDue: number;
@@ -26,6 +28,8 @@ interface DashboardStats {
 export default function DashboardPage() {
   const [stats, setStats] = useState<DashboardStats>({
     learnCount: 0,
+    reviewingCount: 0,
+    masteredCount: 0,
     next24HoursCount: 0,
     reviewCount: 0,
     reviewsDue: 0,
@@ -87,7 +91,11 @@ export default function DashboardPage() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
         <div className="h-full">
-          <Lessons lessonCount={stats.learnCount} />
+          <Lessons
+            learningCount={stats.learnCount}
+            reviewingCount={stats.reviewingCount}
+            masteredCount={stats.masteredCount}
+          />
         </div>
         <div className="h-full">
           <Reviews reviewsDue={stats.reviewsDue} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { applyFurigana, loadFurigana } from "@/lib/furigana";
  */
 export default function Header() {
   const { user } = useAuth();
-  const [stats, setStats] = useState({ learnCount: 0, reviewsDue: 0, simulateCount: 0 });
+  const [stats, setStats] = useState({ learnCount: 0, reviewingCount: 0, reviewsDue: 0, simulateCount: 0 });
 
   const fetchStats = useCallback(async () => {
     try {
@@ -90,7 +90,7 @@ export default function Header() {
             href="/learn"
             className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
           >
-            Learn ({stats.learnCount})
+            Learn ({stats.learnCount}/{stats.reviewingCount})
           </Link>
           <Link
             href="/review"

--- a/frontend/src/components/Lessons.tsx
+++ b/frontend/src/components/Lessons.tsx
@@ -1,80 +1,79 @@
 import React from "react";
-import { Check } from "lucide-react";
 import Link from "next/link";
 
 interface LessonsProps {
-  lessonCount?: number;
+  learningCount?: number;
+  reviewingCount?: number;
+  masteredCount?: number;
 }
 
-export default function Lessons({ lessonCount = 0 }: LessonsProps) {
-  const hasLessons = lessonCount > 0;
+interface BucketProps {
+  label: string;
+  count: number;
+  color: string;
+}
 
+function Bucket({ label, count, color }: BucketProps) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <span className={`text-3xl font-bold leading-none ${color}`}>
+        {count.toLocaleString()}
+      </span>
+      <span className="text-xs font-medium uppercase tracking-wide text-[#6b7079]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function Lessons({
+  learningCount = 0,
+  reviewingCount = 0,
+  masteredCount = 0,
+}: LessonsProps) {
   return (
     <div className="flex items-center justify-center p-4 font-sans h-full">
       <div className="w-full max-w-lg">
-        <div className="flex justify-center">
-          <Link
-            href="/learn"
-            className="group relative flex w-full max-w-[480px] cursor-pointer flex-col overflow-hidden rounded-2xl border border-[#cad0d6] bg-[#e8ecf0] p-4 transition-all duration-200 hover:border-[#9ea5ac] hover:shadow-md active:scale-[0.99] active:border-[#cad0d6] active:shadow-sm"
-          >
-            <div className="flex flex-wrap items-center justify-center gap-4 sm:flex-nowrap">
-              {/* Image Container */}
-              <div className="flex shrink-0 basis-[140px] items-center justify-center">
-                <div className="relative flex w-full max-w-[140px] items-center justify-center">
-                  <img
-                    src="/shodo.png"
-                    alt="Completed Crabigator"
-                    className="aspect-square w-full object-contain transition-transform duration-300 group-hover:scale-105"
-                  />
-                </div>
+        <Link
+          href="/learn"
+          className="group relative flex w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-[#cad0d6] bg-[#e8ecf0] p-6 transition-all duration-200 hover:border-[#9ea5ac] hover:shadow-md active:scale-[0.99] active:border-[#cad0d6] active:shadow-sm"
+        >
+          <div className="flex flex-wrap items-center gap-4 sm:flex-nowrap">
+            <div className="flex shrink-0 basis-[100px] items-center justify-center">
+              <img
+                src="/shodo.png"
+                alt="Lessons"
+                className="aspect-square w-full max-w-[100px] object-contain transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+
+            <div className="flex grow flex-col gap-4">
+              <div className="text-[20px] font-bold leading-none text-[#333333]">
+                Knowledge Units
               </div>
 
-              {/* Content Container */}
-              <div className="flex grow flex-col gap-2 text-center sm:text-left">
-                <div>
-                  <div className="text-base leading-[1.4] text-[#333333]">
-                    Today's
-                  </div>
-                  <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 sm:justify-start">
-                    <div className="text-[24px] font-bold leading-none text-[#333333]">
-                      Lessons
-                    </div>
-                    <div>
-                      {!hasLessons ? (
-                        <span className="inline-flex h-6 min-w-[2rem] items-center justify-center rounded-full border border-[#cad0d6] bg-[#f4f4f4] px-2.5 text-xs font-semibold text-[#6b7079] transition-colors group-hover:bg-white group-hover:text-[#333333]">
-                          <span className="flex items-center gap-1">
-                            Done!
-                            <Check className="h-3 w-3" strokeWidth={3} />
-                          </span>
-                        </span>
-                      ) : (
-                        <span className="inline-flex h-6 min-w-[2rem] items-center justify-center rounded-full border border-[#cad0d6] bg-[#f4f4f4] px-2.5 text-xs font-semibold text-[#6b7079] transition-colors group-hover:bg-white group-hover:text-[#333333]">
-                          {lessonCount}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                <div className="text-sm leading-[1.6] text-[#6b7079]">
-                  <p className="m-0">
-                    {!hasLessons ? (
-                      <>
-                        All done. Do your{" "}
-                        <span className="font-medium text-[#333333] decoration-dotted hover:underline">
-                          Reviews
-                        </span>{" "}
-                        to advance your learning.
-                      </>
-                    ) : (
-                      <>You have {lessonCount} new lessons available.</>
-                    )}
-                  </p>
-                </div>
+              <div className="flex justify-around gap-4">
+                <Bucket
+                  label="Pending"
+                  count={learningCount}
+                  color="text-blue-500"
+                />
+                <div className="w-px self-stretch bg-[#cad0d6]" />
+                <Bucket
+                  label="Review"
+                  count={reviewingCount}
+                  color="text-amber-500"
+                />
+                <div className="w-px self-stretch bg-[#cad0d6]" />
+                <Bucket
+                  label="Mastered"
+                  count={masteredCount}
+                  color="text-green-600"
+                />
               </div>
             </div>
-          </Link>
-        </div>
+          </div>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Backend**: `getDashboardStats` now returns `reviewingCount` and `masteredCount` alongside the existing `learnCount`, each queried from the `user_kus` subcollection by status
- **`Lessons.tsx`**: Replaced the single lesson count card with a three-bucket layout — **Pending** (blue) / **Review** (amber) / **Mastered** (green) — under a "Knowledge Units" heading, giving an at-a-glance picture of where items sit in the pipeline
- **`Header.tsx`**: Learn link now shows `Learn (pending/reviewing)` e.g. `Learn (12/84)` — pending is the prominent signal, reviewing provides context on the active queue size

## Test plan

- [ ] Dashboard widget shows three buckets with correct counts
- [ ] Enrolling a new KU increments Pending
- [ ] Completing reviews that graduate a KU moves it from Pending → Review → Mastered as expected
- [ ] Header Learn count updates on the `refreshStats` event
- [ ] Zero counts display as `0` (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)