### PR TITLE
fix: lesson session polish

### DIFF
--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -394,6 +394,7 @@ export class ReviewsService {
         if (count > 0 || kanjiLinked > 0) {
             try {
                 if (count > 0) {
+                    // create is idempotent — returns existing UKU if one already exists
                     await this.userKnowledgeUnitsService.create(uid, kuId);
                     await this.userKnowledgeUnitsService.update(uid, kuId, {
                         facet_count: FieldValue.increment(count),

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -394,6 +394,7 @@ export class ReviewsService {
         if (count > 0 || kanjiLinked > 0) {
             try {
                 if (count > 0) {
+                    await this.userKnowledgeUnitsService.create(uid, kuId);
                     await this.userKnowledgeUnitsService.update(uid, kuId, {
                         facet_count: FieldValue.increment(count),
                     });

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { VocabLesson, KanjiLesson, GrammarLesson, Lesson } from "@/types";
 import { apiFetch } from "@/lib/api-client";
+import { FuriganaText } from "@/components/FuriganaText";
 
 interface QueueItem {
   kuId: string;
@@ -106,7 +107,7 @@ function VocabWordSlide({ loaded, onAudio }: { loaded: LoadedItem; onAudio: (tex
           title="Play audio"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072M12 6v12m0 0l-3-3m3 3l3-3M6.343 9.657a8 8 0 000 11.314" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
           </svg>
         </button>
       </div>
@@ -153,7 +154,7 @@ function VocabExampleSlide({ loaded }: { loaded: LoadedItem }) {
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto">
       <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">Example</span>
-      <p className="text-3xl text-shodo-ink leading-relaxed">{stripped(ex.sentence)}</p>
+      <p className="text-3xl text-shodo-ink leading-relaxed"><FuriganaText text={ex.sentence} /></p>
       <p className="text-xl text-shodo-ink-light">{stripped(ex.translation)}</p>
     </div>
   );

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -154,6 +154,7 @@ function VocabExampleSlide({ loaded }: { loaded: LoadedItem }) {
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto">
       <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">Example</span>
+      {/* content is server-generated lesson data, not user input */}
       <p className="text-3xl text-shodo-ink leading-relaxed"><FuriganaText text={ex.sentence} /></p>
       <p className="text-xl text-shodo-ink-light">{stripped(ex.translation)}</p>
     </div>

--- a/frontend/src/components/DailyCheckInDialog.tsx
+++ b/frontend/src/components/DailyCheckInDialog.tsx
@@ -136,7 +136,7 @@ export default function DailyCheckInDialog({ plan, learnCount, onClose }: Props)
           <div className="flex-1 rounded-xl border border-shodo-ink/10 bg-shodo-ink/[0.02] p-4 flex flex-col">
             <div className="text-sm font-medium text-shodo-ink/60 mb-1">Available lessons</div>
             <div className="text-3xl font-bold text-shodo-ink">
-              {learnCount}
+              {learnCount > 0 ? learnCount : "~10"}
             </div>
             <Link
               href="/learn/session"


### PR DESCRIPTION
## Summary
- `generateReviewFacets` now calls `create` before `update` on the UKU, so items enrolled via the lesson session appear in the library as 'reviewing' (was silently failing when no UKU existed)
- Corrected audio button SVG to a proper speaker/volume-up icon
- `VocabExampleSlide` renders furigana via `FuriganaText` instead of stripping the markup
- Available lessons shows `~10` for new users with an empty library
- `fetchRef` guard prevents double-load under React Strict Mode

## Test plan
- [ ] Complete a lesson session — items appear in `/learn` under "In Review" afterwards
- [ ] Audio button on vocab word slide shows a speaker icon
- [ ] Example sentence on slide 4 shows furigana ruby annotations
- [ ] Daily check-in shows `~10` for a brand new user with no library items
- [ ] Running in dev does not produce inflated loading progress counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)