### PR TITLE
feat: change generate question to use tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -680,6 +680,28 @@ Library page (`/learn`): Kanji items now show `data.meaning` in the hint column 
 
 ---
 
+**Lesson session (`/learn/session`) + component kanji (2026-05-04)**
+
+- `frontend/src/app/learn/session/page.tsx` — new WaniKani-style lesson slideshow page. Fetches up to 10 items from `GET /api/lessons/queue`, generates lessons in parallel, then walks through slides (word → kanji building blocks → meaning → definitions → examples for Vocab; character → mnemonic → readings → vocab for Kanji; pattern → meaning → examples → notes for Grammar). Enrolls review facets on completion via `POST /api/reviews/generate`.
+- **Component kanji (Option B):** When a Vocab lesson has `component_kanji`, a "Building Blocks" slide is inserted after the word slide showing each kanji character, its meaning, and its reading within the word. Corresponding `Kanji-Component-{char}` facets are auto-enrolled alongside the standard vocab facets. `renderSlide()` uses dynamic index arithmetic (`s--` pattern) so the slide sequence is correct whether or not kanji are present.
+- **React Strict Mode guard:** `fetchRef.current` guard in the load `useEffect` prevents the double-invocation that was showing "16/10" or "20/10" in the progress bar.
+- `DailyCheckInDialog.tsx` — "Start Learning" button changed from `<button>` to `<Link href="/learn/session">`. Available lessons count shows actual `learnCount` or "~10" fallback.
+
+**Lesson queue contamination fix (2026-05-04)**
+
+- `LessonsService.getQueue(uid)` now fetches both `review-facets` AND `user-kus` sub-collections in parallel. Any KU that already has a `UserKnowledgeUnit` record for the user is excluded from the lesson queue — scenario-extracted words land in `user-kus` before they are formally taught, so this prevents them from appearing in the curated lesson stream regardless of how their `jlptLevel` was tagged.
+- `backend/scripts/cleanup-legacy-kus.mjs` — one-off admin script to identify legacy Vocab KUs (created before the WaniKani import), delete dupes whose content matches a WaniKani KU, and classify remaining unleveled KUs via Gemini. Uses the named Firestore database (`FIRESTORE_DB` env var, defaults to `aisrs-japanese-dev`).
+
+**Question generation with curriculum-aware function calling (2026-05-05)**
+
+- `backend/src/prompts/curriculum.ts` (new) — defines `JLPT_LEVEL_ORDER`, `getCumulativeGrammar(upToLevel)` (returns an array where each entry explicitly states it includes all previous levels), and `GET_USER_LEVEL_DECLARATION` (Gemini `FunctionDeclaration`).
+- `GeminiService.generateWithTools<T>(userMessage, systemPrompt, toolDeclarations, toolHandlers, responseSchema)` — general-purpose multi-turn tool-calling loop. Sends with function declarations, dispatches handler results back into the conversation, then makes a final structured-output call (no tools, with `responseSchema`) to get the typed result. Logs each tool call and result to stdout and captures a `toolCalls[]` array in the Firestore log `responseData`.
+- `QuestionsService` — `generateVocabQuestion` and `generateConceptQuestion` now call `generateWithTools` instead of `generateQuestionAI`. A `buildLevelToolHandler(uid)` private method queries `users/{uid}.preferences.jlptLevel` and returns `{ jlptLevel, cumulativeGrammar }`. `capturedLevel` side-channel captures the returned level so it can be written to `QuestionItem.data.difficulty` instead of the previous hardcoded `'JLPT-N5'`/`'JLPT-N4'`.
+- All three question prompts (`buildVocabQuestionPrompt`, `buildNounParticleQuestionPrompt`, `buildConceptQuestionPrompt`) updated: lead with "FIRST: Call get_user_level", hardcoded level references removed, "LEVEL CONSTRAINT (critical)" rule instructs the model to use only grammar from the returned cumulative schema for surrounding sentences while allowing the target item itself to be more advanced.
+- `ApiLog.responseData` extended with `toolCalls?: Array<{ fn, args, response }>` (both type files).
+
+---
+
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.
   2. Authentication → Sign-in method → **Email link (passwordless sign-in)** enabled (sub-toggle under Email/Password).

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -5,7 +5,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, FunctionDeclaration, FunctionCallingConfigMode, createPartFromFunctionResponse, Content } from '@google/genai';
 import { ApiLog, Lesson, ScenarioEvaluation } from '@/types';
 import { Timestamp } from 'firebase-admin/firestore';
 import { ApilogService } from '../apilog/apilog.service';
@@ -768,6 +768,124 @@ export class GeminiService implements OnModuleInit {
           console.error('Failed to update cloze log', err)
         );
       }
+    }
+  }
+
+  /**
+   * Generates a structured response via a tool-calling loop.
+   *
+   * Flow:
+   *  1. Send the user message with the provided function declarations.
+   *  2. While the model returns function calls: dispatch to handlers, feed responses back.
+   *  3. Final turn: drop tools, enforce responseSchema, return parsed result.
+   *
+   * Tool handlers receive the function args and return a plain object that is
+   * sent back to the model as the function response.
+   */
+  async generateWithTools<T>(
+    userMessage: string,
+    systemPrompt: string,
+    toolDeclarations: FunctionDeclaration[],
+    toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>>,
+    responseSchema: Record<string, unknown>,
+    logContext?: Record<string, any>,
+  ): Promise<T> {
+    const startTime = performance.now();
+    let errorOccurred = false;
+    let capturedError: any;
+    let result: T | undefined;
+
+    const logRef = await this.apilogService.startLog({
+      timestamp: Timestamp.now(),
+      route: logContext?.route ?? '/questions/generate',
+      status: 'pending',
+      modelUsed: this.modelName,
+      requestData: { userMessage, systemPrompt, ...logContext },
+    });
+
+    const toolCallLog: Array<{ fn: string; args: Record<string, unknown>; response: Record<string, unknown> }> = [];
+
+    try {
+      const contents: Content[] = [
+        { role: 'user', parts: [{ text: userMessage }] },
+      ];
+
+      this.logger.log(`[generateWithTools] topic="${logContext?.topic ?? userMessage.slice(0, 40)}" tools=[${toolDeclarations.map(t => t.name).join(', ')}]`);
+
+      // Tool-calling loop (safety cap: 5 iterations)
+      for (let i = 0; i < 5; i++) {
+        const response = await this.client.models.generateContent({
+          model: this.modelName,
+          contents,
+          config: {
+            systemInstruction: { parts: [{ text: systemPrompt }] },
+            tools: [{ functionDeclarations: toolDeclarations }],
+            toolConfig: { functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO } },
+          },
+        });
+
+        const calls = response.functionCalls;
+        if (!calls || calls.length === 0) {
+          this.logger.log(`[generateWithTools] No function calls on turn ${i + 1} — proceeding to final turn`);
+          break;
+        }
+
+        this.logger.log(`[generateWithTools] Turn ${i + 1}: model called [${calls.map(c => c.name).join(', ')}]`);
+
+        // Append model turn
+        contents.push({ role: 'model', parts: response.candidates![0].content!.parts! });
+
+        // Dispatch each call and collect responses
+        const responseParts = await Promise.all(
+          calls.map(async (fc) => {
+            const handler = toolHandlers[fc.name!];
+            const args = (fc.args as Record<string, unknown>) ?? {};
+            const handlerResult = handler
+              ? await handler(args)
+              : { error: `Unknown function: ${fc.name}` };
+
+            this.logger.log(`[generateWithTools] ${fc.name}() → ${JSON.stringify(handlerResult).slice(0, 200)}`);
+            toolCallLog.push({ fn: fc.name!, args, response: handlerResult });
+
+            return createPartFromFunctionResponse(fc.id ?? fc.name!, fc.name!, handlerResult);
+          }),
+        );
+
+        contents.push({ role: 'user', parts: responseParts });
+      }
+
+      // Final turn: structured output, no tools
+      const finalResponse = await this.client.models.generateContent({
+        model: this.modelName,
+        contents,
+        config: {
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          responseMimeType: 'application/json',
+          responseSchema: responseSchema as any,
+        },
+      });
+
+      if (!finalResponse.text) throw new Error('Empty response from Gemini on final turn');
+      result = JSON.parse(finalResponse.text) as T;
+      this.logger.log(`[generateWithTools] result: ${JSON.stringify(result)}`);
+      return result;
+
+    } catch (error) {
+      errorOccurred = true;
+      capturedError = error;
+      this.logger.error('generateWithTools error:', error);
+      throw new InternalServerErrorException('Failed to generate with tools');
+    } finally {
+      const durationMs = performance.now() - startTime;
+      const updateData: Partial<ApiLog> = { durationMs };
+      if (errorOccurred) {
+        updateData.status = 'error';
+        updateData.errorData = { message: capturedError instanceof Error ? capturedError.message : String(capturedError) };
+      } else {
+        updateData.status = 'success';
+        updateData.responseData = { toolCalls: toolCallLog, parsedJson: result };
+      }
+      await this.apilogService.completeLog(logRef, updateData).catch(e => this.logger.error(e));
     }
   }
 

--- a/backend/src/prompts/curriculum.ts
+++ b/backend/src/prompts/curriculum.ts
@@ -1,0 +1,117 @@
+import { FunctionDeclaration, Type } from '@google/genai';
+
+export type JlptLevel = 'N5' | 'N4' | 'N3' | 'N2' | 'N1';
+
+export const JLPT_LEVEL_ORDER: JlptLevel[] = ['N5', 'N4', 'N3', 'N2', 'N1'];
+
+// Grammar points introduced at each level. getCumulativeGrammar() stacks these.
+const GRAMMAR_ADDITIONS: Record<JlptLevel, string[]> = {
+  N5: [
+    'Core particles: は、が、を、に、で、へ、も、と、から、まで',
+    'Polite present/past/negative: 〜ます、〜ません、〜ました、〜ませんでした',
+    'Plain forms: dictionary, ない-form, た-form, なかった-form',
+    'い-adjective and な-adjective conjugation (present/past/negative)',
+    'Demonstratives: これ/それ/あれ、ここ/そこ/あそこ',
+    'Numbers, counters, time expressions',
+    'Possession and noun-modification: の',
+    'て-form basics: 〜てください、〜ています、〜てもいいですか',
+    'Want to: 〜たい / 〜たくない',
+    'Question words: なに、だれ、どこ、いつ、どう、なぜ',
+    'Sentence-final particles: か (question)、よ (assertion)、ね (agreement)',
+    'Copula: です / じゃないです / でした',
+    'Existence: あります / います',
+    'Direction and goal: 〜に行く / 〜に来る',
+  ],
+  N4: [
+    'Potential form: 〜られる / 〜できる',
+    'Passive form: 〜られる',
+    'Causative form: 〜させる',
+    'て-form chaining for sequential and simultaneous actions',
+    'Conditionals: 〜たら、〜ば、〜と',
+    'Volitional: 〜よう / 〜ましょう',
+    'Progressive / resultant state: 〜ている',
+    'Experience: 〜たことがある',
+    'Obligation: 〜なければならない / 〜なくてはいけない',
+    'Permission / prohibition: 〜てもいい / 〜てはいけない',
+    'Purpose: 〜ために',
+    'Named / called: 〜という',
+    'Hearsay / appearance: 〜らしい、〜そうだ',
+    'Simultaneous actions: 〜ながら',
+    'Before / after: 〜まえに / 〜あとで',
+    'Giving and receiving: あげる、くれる、もらう and て-form compounds',
+  ],
+  N3: [
+    'Completion / regret: 〜てしまう',
+    'Do in advance: 〜ておく',
+    'Try doing: 〜てみる',
+    'Directional aspect: 〜てくる / 〜ていく',
+    'Causative-passive: 〜させられる',
+    'Strive toward / come to: 〜ようにする / 〜ようになる',
+    'Decision / outcome: 〜ことにする / 〜ことになる',
+    'Expectation: 〜はずだ / 〜はずがない',
+    'Ought to: 〜べきだ',
+    'Might: 〜かもしれない',
+    'Probability: 〜でしょう',
+    'In case of: 〜場合は',
+    'Noun-modifying (relative) clauses',
+    'Despite / for the purpose of: 〜のに',
+    'As soon as: 〜たとたん',
+    'While (contrast): 〜一方で',
+  ],
+  N2: [
+    'Resultant state: 〜てある',
+    'Despite: 〜にもかかわらず',
+    'Towards / regarding: 〜に対して',
+    'Depending on / by means of: 〜によって',
+    'In / at (formal): 〜において',
+    'As / in the capacity of: 〜として',
+    'As / following: 〜にしたがって',
+    'Although: 〜ものの',
+    'That is why: 〜わけだ / 〜わけではない',
+    'From the fact that: 〜ことから',
+    'No matter how: 〜いくら〜ても',
+    'Not only but also: 〜だけでなく〜も',
+  ],
+  N1: [
+    'Literary / classical auxiliary forms',
+    'Highly formal written patterns: 〜に際して、〜をもって、〜を踏まえて',
+    'Nuanced modal auxiliaries: 〜まい、〜ずにはいられない',
+    'Complex nominalization and sentence-final noun phrases',
+    'Advanced concessive patterns: 〜とはいえ、〜にせよ',
+  ],
+};
+
+export interface CurriculumLevelEntry {
+  level: JlptLevel;
+  note: string;
+  grammar: string[];
+}
+
+/**
+ * Returns all grammar the learner has covered up to and including `upToLevel`.
+ * Each entry explicitly notes it is additive on top of previous levels.
+ */
+export function getCumulativeGrammar(upToLevel: JlptLevel): CurriculumLevelEntry[] {
+  const idx = JLPT_LEVEL_ORDER.indexOf(upToLevel);
+  return JLPT_LEVEL_ORDER.slice(0, idx + 1).map((level, i) => ({
+    level,
+    note: i === 0
+      ? 'Foundation — every higher level builds on this and retains all these patterns'
+      : `Additive layer on top of ${JLPT_LEVEL_ORDER.slice(0, i).join(' + ')} — all previous grammar still applies`,
+    grammar: GRAMMAR_ADDITIONS[level],
+  }));
+}
+
+export const GET_USER_LEVEL_DECLARATION: FunctionDeclaration = {
+  name: 'get_user_level',
+  description:
+    'Returns the learner\'s current JLPT level and the complete cumulative grammar schema ' +
+    'covering everything they have studied up to that level. ' +
+    'Call this before writing any question so that surrounding sentence grammar and vocabulary ' +
+    'stays within what the learner already knows.',
+  parameters: {
+    type: Type.OBJECT,
+    properties: {},
+    required: [],
+  },
+};

--- a/backend/src/prompts/quiz.prompts.ts
+++ b/backend/src/prompts/quiz.prompts.ts
@@ -29,33 +29,25 @@ export type VocabQuestionType = keyof typeof VOCAB_QUESTION_OPTIONS;
  */
 export function buildVocabQuestionPrompt(questionType: VocabQuestionType): string {
   return `You are an expert Japanese tutor and quiz generator.
-You will be prompted with a single piece of Japanese Vocab: a word or grammar concept (the 'topic') and an optional reading and meaning.
+You will be prompted with a single piece of Japanese vocabulary or grammar (the 'topic') and an optional reading and meaning.
 Your task is to create a single, context-based question to test the user's understanding of that word or grammar concept.
-If a reading and/or meaning are provided, you MUST generate a question where the topic matches those specific constraints. Do not generate questions for alternative readings or meanings of the same word.
-You MUST generate a question using the following form:
-${VOCAB_QUESTION_OPTIONS[questionType]};
 
-You MUST return ONLY a valid JSON object with the following schema:
-{
-  "question": "The actual question that will be displayed to the user.",
-  "context": "OPTIONAL. Brief English context/hint only if needed for disambiguation.",
-  "answer": "The primary answer to the question.",
-  "accepted_alternatives": ["Array of other grammatically valid answers (e.g. different politeness levels)."]
-}
+FIRST: Call get_user_level to retrieve the learner's JLPT level and cumulative grammar schema before writing anything.
+
+THEN generate a question of the following form:
+${VOCAB_QUESTION_OPTIONS[questionType]}
+
 Rules:
 1.  The question must directly test the provided 'topic'.
 2.  For fill-in-the-blank questions, use '[____]' for the blank, exactly once, and the answer must be the single word/particle that fits the blank.
-3.  Do not use Romaji to indicate the reading of whatever is being tested. ${NO_ROMAJI}
-4.  The context field MUST be used for any "fill-in-the-blank" question that tests a noun or adjective, as these are often ambiguous. The context MUST provide a hint to differentiate the answer from common synonyms. (e.g., for 気分, a hint like (Context: a person's mood or feeling) is required).
+3.  ${NO_ROMAJI}
+4.  The context field MUST be used for any fill-in-the-blank question that tests a noun or adjective, providing a hint to differentiate the answer from common synonyms.
 5.  Ensure the generated question and any accepted answers make grammatical sense.
-6.  Do NOT use literal newlines inside the JSON string values. Use spaces instead.
-7.  If the provided English context does NOT strictly dictate a specific politeness level, you MUST include standard valid variations (plain form, polite 'masu' form) in the accepted_alternatives array.
-8.  Use simple, standard grammar and vocabulary (equivalent to JLPT N4) for the surrounding sentence structure. Ensure the sentence is easy to read, so the user focuses on the target blank, not on deciphering the rest of the sentence.
-9.  Relative Complexity Rule: The surrounding sentence MUST NOT be more difficult than the target word. If the target is advanced (N3+), use simple (N4/N5) grammar structure to ensure clarity. For advanced verbs/adjectives, prioritize questions that test conjugation or specific grammatical usage over complex semantic inference.
-10. The question tests a specific concept, but natural language often has valid variations based on politeness (e.g., 食べる vs. 食べます).
-11. Ambiguity Prevention: If other distinct words (synonyms) could be grammatically correct, use the English context to disambiguate by including the closest English translation/explanation of the target word.
-12. If the question requires conjugation of a verb and the answer is not the base form, provide enough context to disambiguate the answer.
-13. ${JSON_ONLY_OUTPUT}`;
+6.  If a reading and/or meaning are provided, generate a question where the topic matches those specific constraints only — do not test alternative readings.
+7.  For verb and adjective questions where the answer is a conjugated form, include valid politeness-level alternatives (plain form and polite 〜ます form) in accepted_alternatives unless the question specifically constrains the form.
+8.  LEVEL CONSTRAINT (critical): Use ONLY grammar patterns listed in the cumulative schema returned by get_user_level for the surrounding sentence. The target word itself may be more advanced — that is the point — but every other word and grammatical structure in the question must come from the learner's known schema.
+9.  Ambiguity prevention: if synonyms could fit the blank, use the context field to pin the exact meaning of the target word.
+10. If the question requires verb conjugation and the answer is not the base form, provide enough context to make the expected form unambiguous.`;
 }
 
 /**
@@ -96,12 +88,14 @@ export function buildNounParticleQuestionPrompt(): string {
 You will be given a Japanese noun (the 'topic') with its reading and meaning.
 Your task is to write a single Japanese sentence that uses that noun with a specific particle, then blank out the noun+particle pair together so the user must supply both.
 
+FIRST: Call get_user_level to retrieve the learner's JLPT level and cumulative grammar schema.
+
 Rules:
 1. The blank '[____]' replaces the noun AND its particle together — e.g. the answer might be 図書館で, 駅から, 友達と, 歯を.
 2. The 'context' field MUST follow this exact format: "Specify [English label] as [semantic role]" — where the semantic role describes the particle's function precisely enough that only one particle is correct.
 3. 'accepted_alternatives' MUST always be an empty array. The sentence structure uniquely determines the correct particle.
 4. Do NOT use は or が as the particle. Use action particles only: を, に, で, から, へ, と, まで.
-5. Use N4/N5 vocabulary for the surrounding sentence so the user focuses on the target noun and particle, not on decoding the rest.
+5. LEVEL CONSTRAINT: Use ONLY vocabulary and grammar from the cumulative schema returned by get_user_level for the surrounding sentence.
 6. ${NO_ROMAJI}`;
 }
 
@@ -161,24 +155,17 @@ Rule Name: ${mechanic.goalTitle}
 Structural Rule: ${mechanic.rule}
 Example Application: ${mechanic.simpleExample.japanese} (${mechanic.simpleExample.english})
 
-Your task is to generate a novel question to test this exact mechanic using this format:
-${CONCEPT_QUESTION_OPTIONS[questionType]}
+FIRST: Call get_user_level to retrieve the learner's JLPT level and cumulative grammar schema.
 
-You MUST return ONLY a valid JSON object with the following schema:
-{
-  "question": "The actual question. If fill-in-the-blank, use '[____]' exactly once.",
-  "context": "The English translation of the target sentence/fragment to guide the user.",
-  "answer": "The Japanese text that answers the question or fills the blank.",
-  "accepted_alternatives": ["Array of other valid Japanese answers"]
-}
+THEN generate a question using this format:
+${CONCEPT_QUESTION_OPTIONS[questionType]}
 
 Rules:
 1. The answer MUST require the user to apply the provided Structural Rule.
-2. The 'question' field MUST be written entirely in English. Any Japanese sentence being shown to the user (e.g. an error-correction sentence) must be embedded inline as a quoted string within the English question text — never write the instruction itself in Japanese.
+2. The 'question' field MUST be written entirely in English. Any Japanese sentence shown to the user must be embedded inline as a quoted string — never write the instruction itself in Japanese.
 3. ${NO_ROMAJI}
-4. For 'applied-cloze', the blank must encapsulate the conjugated rule (e.g., if the rule is modifying a noun, the blank should ideally be the modifier clause).
-5. Use standard, N4/N5 level vocabulary for the surrounding sentence so the user focuses strictly on the grammar mechanic.
-6. ${JSON_ONLY_OUTPUT}`;
+4. For fill-in-the-blank, the blank must encapsulate the conjugated rule application.
+5. LEVEL CONSTRAINT (critical): Use ONLY vocabulary and grammar patterns from the cumulative schema returned by get_user_level for the surrounding sentence. The mechanic being tested is the exception — everything else must be within the learner's known schema.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -24,6 +24,7 @@ import {
   buildConceptQuestionPrompt,
   ConceptMechanic,
 } from '../prompts/quiz.prompts';
+import { GET_USER_LEVEL_DECLARATION, getCumulativeGrammar, JlptLevel } from '../prompts/curriculum';
 
 const SUITABLE_RANK_THRESHOLD = 30;
 const RANK_CORRECT_DELTA = 5;
@@ -188,6 +189,30 @@ export class QuestionsService {
     return this.generateVocabQuestion(uid, topic, kuId, facetId);
   }
 
+  private buildLevelToolHandler(uid: string): Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>> {
+    return {
+      get_user_level: async () => {
+        const userDoc = await this.db.collection('users').doc(uid).get();
+        const level = ((userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5') as JlptLevel;
+        return {
+          jlptLevel: level,
+          cumulativeGrammar: getCumulativeGrammar(level),
+        };
+      },
+    };
+  }
+
+  private readonly questionResponseSchema = {
+    type: 'OBJECT',
+    properties: {
+      question: { type: 'STRING' },
+      context: { type: 'STRING' },
+      answer: { type: 'STRING' },
+      accepted_alternatives: { type: 'ARRAY', items: { type: 'STRING' } },
+    },
+    required: ['question', 'answer'],
+  };
+
   private async generateVocabQuestion(uid: string, topic: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
     let reading: string | undefined;
     let meaning: string | undefined;
@@ -210,7 +235,6 @@ export class QuestionsService {
 
     let systemPrompt: string;
     let fewShotTurns: Array<{ user: string; model: string }> | undefined;
-
     if (isVerb) {
       systemPrompt = buildVocabQuestionPrompt(pickRandomQuestionType(VOCAB_QUESTION_OPTIONS));
     } else {
@@ -223,18 +247,31 @@ export class QuestionsService {
       }
     }
 
+    // Capture the level returned by the tool for use in the saved difficulty field
+    let capturedLevel = 'N5';
+    const toolHandlers = {
+      ...this.buildLevelToolHandler(uid),
+      get_user_level: async (args: Record<string, unknown>) => {
+        const result = await this.buildLevelToolHandler(uid).get_user_level(args);
+        capturedLevel = result.jlptLevel as string;
+        return result;
+      },
+    };
+
     const userMessage = buildVocabQuestionUserMessage(topic, reading, meaning);
-
-    const questionString = await this.geminiService.generateQuestionAI(userMessage, systemPrompt, {}, fewShotTurns);
-
-    if (!questionString) throw new Error('AI response was empty.');
-
-    let parsed: { question: string; answer: string; context?: string; accepted_alternatives?: string[] };
-    try {
-      parsed = JSON.parse(questionString);
-    } catch {
-      throw new Error('Failed to parse AI JSON response');
-    }
+    const parsed = await this.geminiService.generateWithTools<{
+      question: string;
+      answer: string;
+      context?: string;
+      accepted_alternatives?: string[];
+    }>(
+      userMessage,
+      systemPrompt,
+      [GET_USER_LEVEL_DECLARATION],
+      toolHandlers,
+      this.questionResponseSchema,
+      { route: '/questions/generate', topic: topic, kuId },
+    );
 
     const ref = this.db.collection(QUESTIONS_COLLECTION).doc();
     const newQuestion: QuestionItem = {
@@ -245,7 +282,7 @@ export class QuestionsService {
         context: parsed.context,
         answer: parsed.answer,
         acceptedAlternatives: parsed.accepted_alternatives,
-        difficulty: 'JLPT-N5',
+        difficulty: `JLPT-${capturedLevel}` as import('@/types').LessonDifficulty,
       },
       rank: 50,
       rejectionCount: 0,
@@ -253,7 +290,7 @@ export class QuestionsService {
     };
 
     await ref.set(newQuestion);
-    this.logger.log(`Saved new question ${ref.id} for KU ${kuId}`);
+    this.logger.log(`Saved new question ${ref.id} for KU ${kuId} (level: ${capturedLevel})`);
 
     if (facetId) {
       await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);
@@ -266,16 +303,28 @@ export class QuestionsService {
     const selectedType = pickRandomQuestionType(CONCEPT_QUESTION_OPTIONS);
     const systemPrompt = buildConceptQuestionPrompt(mechanic, selectedType);
 
-    const questionString = await this.geminiService.generateQuestionAI('', systemPrompt, {});
+    let capturedLevel = 'N5';
+    const toolHandlers = {
+      get_user_level: async (args: Record<string, unknown>) => {
+        const result = await this.buildLevelToolHandler(uid).get_user_level(args);
+        capturedLevel = result.jlptLevel as string;
+        return result;
+      },
+    };
 
-    if (!questionString) throw new Error('AI response was empty.');
-
-    let parsed: { question: string; answer: string; context?: string; accepted_alternatives?: string[] };
-    try {
-      parsed = JSON.parse(questionString);
-    } catch {
-      throw new Error('Failed to parse AI JSON response for concept question');
-    }
+    const parsed = await this.geminiService.generateWithTools<{
+      question: string;
+      answer: string;
+      context?: string;
+      accepted_alternatives?: string[];
+    }>(
+      '',
+      systemPrompt,
+      [GET_USER_LEVEL_DECLARATION],
+      toolHandlers,
+      this.questionResponseSchema,
+      { route: '/questions/generate', topic: mechanic.goalTitle, kuId },
+    );
 
     const ref = this.db.collection(QUESTIONS_COLLECTION).doc();
     const newQuestion: QuestionItem = {
@@ -286,7 +335,7 @@ export class QuestionsService {
         context: parsed.context,
         answer: parsed.answer,
         acceptedAlternatives: parsed.accepted_alternatives,
-        difficulty: 'JLPT-N4',
+        difficulty: `JLPT-${capturedLevel}` as import('@/types').LessonDifficulty,
       },
       rank: 50,
       rejectionCount: 0,
@@ -294,7 +343,7 @@ export class QuestionsService {
     };
 
     await ref.set(newQuestion);
-    this.logger.log(`Saved new concept question ${ref.id} for KU ${kuId} (mechanic: ${mechanic.goalTitle})`);
+    this.logger.log(`Saved new concept question ${ref.id} for KU ${kuId} (mechanic: ${mechanic.goalTitle}, level: ${capturedLevel})`);
 
     if (facetId) {
       await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -21,8 +21,9 @@ export interface ApiLog {
     [key: string]: any;
   };
   responseData?: {
-    rawText?: string; // The raw text from the AI
-    parsedJson?: any; // The parsed JSON object (if applicable)
+    rawText?: string;
+    parsedJson?: any;
+    toolCalls?: Array<{ fn: string; args: Record<string, unknown>; response: Record<string, unknown> }>;
   };
   errorData?: {
     message?: string;


### PR DESCRIPTION
Summary                                                   
                                                                                                                                                                             
  - Curriculum-aware question generation: prompts/curriculum.ts defines a cumulative JLPT grammar schema (each level
  explicitly includes all previous levels). GeminiService.generateWithTools<T>() is a new general-purpose multi-turn     
  tool-calling loop. Question generation (generateVocabQuestion, generateConceptQuestion) now calls get_user_level as a function call before writing any question — the model receives the user's JLPT level and the full cumulative grammar   schema, and is constrained to use only known grammar for surrounding sentences while the target item itself may be more advanced. QuestionItem.data.difficulty is now derived from the tool response instead of hardcoded.
  - Improved logging: Tool calls and responses logged to stdout and captured in Firestore
  apilog.responseData.toolCalls[].                                                                                       
   
  Test plan                                                                                                              
                                                                                                             
  - Trigger a new AI question generation and confirm stdout logs show [generateWithTools] tool call lines and Firestore  
  log includes toolCalls array with get_user_level response                                                              
  - Check QuestionItem.data.difficulty in Firestore is JLPT-N5 (or user's actual level) not hardcoded   