### PR TITLE
feat: prompt tester and api latency

### DIFF
--- a/backend/src/apilog/apilog.controller.ts
+++ b/backend/src/apilog/apilog.controller.ts
@@ -1,9 +1,49 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Post, Query, Body, Inject } from '@nestjs/common';
+import { Firestore } from 'firebase-admin/firestore';
 import { ApilogService } from './apilog.service';
+import { GeminiService } from '../gemini/gemini.service';
+import { FIRESTORE_CONNECTION } from '../firebase/firebase.module';
+import { GET_USER_LEVEL_DECLARATION, getCumulativeGrammar, JlptLevel } from '../prompts/curriculum';
+import {
+    buildVocabQuestionPrompt,
+    buildNounParticleQuestionPrompt,
+    buildConceptQuestionPrompt,
+    VOCAB_QUESTION_OPTIONS,
+    CONCEPT_QUESTION_OPTIONS,
+} from '../prompts/quiz.prompts';
+
+const QUESTION_RESPONSE_SCHEMA = {
+    type: 'OBJECT',
+    properties: {
+        question: { type: 'STRING' },
+        context: { type: 'STRING' },
+        answer: { type: 'STRING' },
+        accepted_alternatives: { type: 'ARRAY', items: { type: 'STRING' } },
+    },
+    required: ['question', 'answer'],
+};
+
+const EXAMPLE_MECHANIC = {
+    goalTitle: 'Connecting reasons with ので',
+    englishIntent: 'Express a reason or cause naturally',
+    rule: '[plain form] + ので + [result]',
+    simpleExample: { japanese: '雨が降っているので、傘を持ってください。', english: 'Because it is raining, please take an umbrella.', highlight: 'ので' },
+    naturalExample: {
+        japanese: '明日は早いので、今日は早く寝ます。',
+        english: 'Because I have an early start tomorrow, I will sleep early today.',
+        highlight: 'ので',
+        fragments: ['明日は早いので', '今日は早く寝ます'],
+        accepted_alternatives: [],
+    },
+};
 
 @Controller('apilogs')
 export class ApilogController {
-    constructor(private readonly apilogService: ApilogService) { }
+    constructor(
+        private readonly apilogService: ApilogService,
+        private readonly geminiService: GeminiService,
+        @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+    ) { }
 
     @Get()
     async getLogs(
@@ -16,5 +56,102 @@ export class ApilogController {
         const safeLimit = Math.min(Math.max(limit, 1), 100);
 
         return this.apilogService.findAll(safeLimit, route, status);
+    }
+
+    @Get('latency')
+    async getLatency(@Query('sample') sampleArg?: string) {
+        const sample = Math.min(parseInt(sampleArg ?? '200', 10) || 200, 500);
+        return this.apilogService.getLatencyStats(sample);
+    }
+
+    @Post('prompt-test')
+    async runPromptTest(@Body() body: {
+        systemPrompt: string;
+        userMessage?: string;
+        useTools?: boolean;
+        uid?: string;
+        responseSchema?: Record<string, unknown>;
+    }) {
+        const { systemPrompt, userMessage = '', useTools = false, uid, responseSchema } = body;
+
+        const toolDeclarations = useTools ? [GET_USER_LEVEL_DECLARATION] : [];
+        const toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>> = {};
+
+        if (useTools) {
+            toolHandlers.get_user_level = async () => {
+                if (!uid) return { jlptLevel: 'N5', cumulativeGrammar: getCumulativeGrammar('N5') };
+                const userDoc = await this.db.collection('users').doc(uid).get();
+                const level = ((userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5') as JlptLevel;
+                return { jlptLevel: level, cumulativeGrammar: getCumulativeGrammar(level) };
+            };
+        }
+
+        return this.geminiService.runPromptTest({
+            systemPrompt,
+            userMessage,
+            toolDeclarations,
+            toolHandlers,
+            responseSchema,
+        });
+    }
+
+    @Get('prompt-presets')
+    getPromptPresets() {
+        return [
+            {
+                id: 'vocab-conjugation',
+                name: 'Vocab: Conjugation',
+                systemPrompt: buildVocabQuestionPrompt('conjugation'),
+                exampleUserMessage: 'Topic: 食べる\nReading: たべる\nMeaning: to eat',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: VOCAB_QUESTION_OPTIONS['conjugation'],
+            },
+            {
+                id: 'vocab-translation',
+                name: 'Vocab: Translation',
+                systemPrompt: buildVocabQuestionPrompt('translation'),
+                exampleUserMessage: 'Topic: 勉強する\nReading: べんきょうする\nMeaning: to study',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: VOCAB_QUESTION_OPTIONS['translation'],
+            },
+            {
+                id: 'vocab-fill-in-the-blank',
+                name: 'Vocab: Fill-in-the-Blank',
+                systemPrompt: buildVocabQuestionPrompt('fill-in-the-blank'),
+                exampleUserMessage: 'Topic: 図書館\nReading: としょかん\nMeaning: library',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: VOCAB_QUESTION_OPTIONS['fill-in-the-blank'],
+            },
+            {
+                id: 'noun-particle',
+                name: 'Noun: Particle Fill-in',
+                systemPrompt: buildNounParticleQuestionPrompt(),
+                exampleUserMessage: 'Topic: 駅\nReading: えき\nMeaning: train station',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: 'Noun + particle fill-in-the-blank (noun+particle blanked together)',
+            },
+            {
+                id: 'concept-error-correction',
+                name: 'Concept: Error Correction',
+                systemPrompt: buildConceptQuestionPrompt(EXAMPLE_MECHANIC, 'error-correction'),
+                exampleUserMessage: '',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: CONCEPT_QUESTION_OPTIONS['error-correction'],
+            },
+            {
+                id: 'concept-novel-translation',
+                name: 'Concept: Novel Translation',
+                systemPrompt: buildConceptQuestionPrompt(EXAMPLE_MECHANIC, 'novel-translation'),
+                exampleUserMessage: '',
+                useTools: true,
+                responseSchema: QUESTION_RESPONSE_SCHEMA,
+                description: CONCEPT_QUESTION_OPTIONS['novel-translation'],
+            },
+        ];
     }
 }

--- a/backend/src/apilog/apilog.module.ts
+++ b/backend/src/apilog/apilog.module.ts
@@ -1,9 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 import { ApilogService } from './apilog.service';
 import { ApilogController } from './apilog.controller';
+import { GeminiModule } from '../gemini/gemini.module';
 
 @Global()
 @Module({
+  imports: [GeminiModule],
   controllers: [ApilogController],
   providers: [ApilogService],
   exports: [ApilogService]

--- a/backend/src/apilog/apilog.service.ts
+++ b/backend/src/apilog/apilog.service.ts
@@ -54,4 +54,40 @@ export class ApilogService {
             } as ApiLog;
         });
     }
+
+    async getLatencyStats(sampleSize = 200): Promise<Array<{
+        route: string;
+        count: number;
+        avgMs: number;
+        p95Ms: number;
+        minMs: number;
+        maxMs: number;
+    }>> {
+        const snapshot = await this.db.collection(API_LOGS_COLLECTION)
+            .orderBy('timestamp', 'desc')
+            .limit(sampleSize)
+            .get();
+
+        const byRoute: Record<string, number[]> = {};
+        snapshot.docs.forEach(doc => {
+            const data = doc.data();
+            if (typeof data.durationMs === 'number' && data.route) {
+                if (!byRoute[data.route]) byRoute[data.route] = [];
+                byRoute[data.route].push(data.durationMs);
+            }
+        });
+
+        return Object.entries(byRoute).map(([route, durations]) => {
+            const sorted = [...durations].sort((a, b) => a - b);
+            const p95Idx = Math.floor(sorted.length * 0.95);
+            return {
+                route,
+                count: durations.length,
+                avgMs: Math.round(durations.reduce((a, b) => a + b, 0) / durations.length),
+                p95Ms: sorted[p95Idx] ?? sorted[sorted.length - 1],
+                minMs: sorted[0],
+                maxMs: sorted[sorted.length - 1],
+            };
+        }).sort((a, b) => b.avgMs - a.avgMs);
+    }
 }

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -1143,4 +1143,82 @@ export class GeminiService implements OnModuleInit {
       await this.apilogService.completeLog(logRef, updateData).catch(e => this.logger.error(e));
     }
   }
+
+  async runPromptTest(opts: {
+    systemPrompt: string;
+    userMessage: string;
+    toolDeclarations: FunctionDeclaration[];
+    toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>>;
+    responseSchema?: Record<string, unknown>;
+  }): Promise<{ rawText: string; parsedJson: any; toolCalls: Array<{ fn: string; args: any; response: any }>; durationMs: number }> {
+    const { systemPrompt, userMessage, toolDeclarations, toolHandlers, responseSchema } = opts;
+    const start = performance.now();
+    const toolCallLog: Array<{ fn: string; args: any; response: any }> = [];
+
+    const contents: Content[] = [
+      { role: 'user', parts: [{ text: userMessage || '(no user message)' }] },
+    ];
+
+    // Tool-calling loop (cap 5)
+    if (toolDeclarations.length > 0) {
+      for (let i = 0; i < 5; i++) {
+        const response = await this.client.models.generateContent({
+          model: this.modelName,
+          contents,
+          config: {
+            systemInstruction: { parts: [{ text: systemPrompt }] },
+            tools: [{ functionDeclarations: toolDeclarations }],
+            toolConfig: { functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO } },
+          },
+        });
+
+        const calls = response.functionCalls;
+        if (!calls || calls.length === 0) break;
+
+        contents.push({ role: 'model', parts: response.candidates![0].content!.parts! });
+
+        const responseParts = await Promise.all(
+          calls.map(async (fc) => {
+            const handler = toolHandlers[fc.name!];
+            const args = (fc.args as Record<string, unknown>) ?? {};
+            const handlerResult = handler
+              ? await handler(args)
+              : { error: `Unknown function: ${fc.name}` };
+            toolCallLog.push({ fn: fc.name!, args, response: handlerResult });
+            return createPartFromFunctionResponse(fc.id ?? fc.name!, fc.name!, handlerResult);
+          }),
+        );
+
+        contents.push({ role: 'user', parts: responseParts });
+      }
+    }
+
+    // Final generation
+    const finalConfig: any = {
+      systemInstruction: { parts: [{ text: systemPrompt }] },
+    };
+    if (responseSchema) {
+      finalConfig.responseMimeType = 'application/json';
+      finalConfig.responseSchema = responseSchema;
+    }
+
+    const finalResponse = await this.client.models.generateContent({
+      model: this.modelName,
+      contents,
+      config: finalConfig,
+    });
+
+    const rawText = finalResponse.text ?? '';
+    let parsedJson: any = null;
+    if (responseSchema) {
+      try { parsedJson = JSON.parse(rawText); } catch { /* leave null */ }
+    }
+
+    return {
+      rawText,
+      parsedJson,
+      toolCalls: toolCallLog,
+      durationMs: Math.round(performance.now() - start),
+    };
+  }
 }

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Patch, Param, Body, Query, Post, BadRequestException, NotFoundException, UseGuards, HttpCode } from '@nestjs/common';
+import { Controller, Get, Put, Patch, Delete, Param, Body, Query, Post, BadRequestException, NotFoundException, UseGuards, HttpCode } from '@nestjs/common';
 import { KnowledgeUnitsService } from './knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
@@ -71,6 +71,11 @@ export class KnowledgeUnitsController {
             throw new BadRequestException('Request body must be an array of Knowledge Units');
         }
         return this.knowledgeUnitsService.bulkIngest(body);
+    }
+
+    @Delete(':id')
+    async remove(@UserId() uid: string, @Param('id') id: string) {
+        return this.knowledgeUnitsService.cascadeDelete(uid, id);
     }
 
     @Post()

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -1,5 +1,13 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { FIRESTORE_CONNECTION, KNOWLEDGE_UNITS_COLLECTION } from '../firebase/firebase.module';
+import {
+    FIRESTORE_CONNECTION,
+    KNOWLEDGE_UNITS_COLLECTION,
+    LESSONS_COLLECTION,
+    QUESTIONS_COLLECTION,
+    REVIEW_FACETS_COLLECTION,
+    USER_KUS_SUBCOLLECTION,
+    QUESTION_STATES_SUBCOLLECTION,
+} from '../firebase/firebase.module';
 import { Firestore, Timestamp, DocumentReference } from '@google-cloud/firestore';
 import { Inject } from '@nestjs/common';
 // Removed CURRENT_USER_ID import
@@ -365,5 +373,52 @@ export class KnowledgeUnitsService {
         const ku = await this.findOneById(id);
         if (!ku) throw new NotFoundException(`Knowledge Unit ${id} not found`);
         return ku;
+    }
+
+    async cascadeDelete(uid: string, kuId: string): Promise<{ deleted: Record<string, number> }> {
+        const userRef = this.db.collection('users').doc(uid);
+        const deleted: Record<string, number> = {};
+
+        const deleteSubcollectionDocs = async (subcollection: string, field: string) => {
+            const snap = await userRef.collection(subcollection).where(field, '==', kuId).get();
+            if (snap.empty) return 0;
+            const batch = this.db.batch();
+            snap.docs.forEach(d => batch.delete(d.ref));
+            await batch.commit();
+            return snap.size;
+        };
+
+        deleted['review-facets'] = await deleteSubcollectionDocs(REVIEW_FACETS_COLLECTION, 'kuId');
+        deleted['user-kus'] = await deleteSubcollectionDocs(USER_KUS_SUBCOLLECTION, 'kuId');
+        deleted['feed'] = await deleteSubcollectionDocs('feed', 'kuId');
+
+        // Global: questions (and their per-user question-states)
+        const questionsSnap = await this.db.collection(QUESTIONS_COLLECTION).where('kuId', '==', kuId).get();
+        if (!questionsSnap.empty) {
+            // Delete question-states for each question
+            const stateSnap = await userRef.collection(QUESTION_STATES_SUBCOLLECTION)
+                .where('kuId', '==', kuId).get();
+            const batch = this.db.batch();
+            questionsSnap.docs.forEach(d => batch.delete(d.ref));
+            stateSnap.docs.forEach(d => batch.delete(d.ref));
+            await batch.commit();
+            deleted['questions'] = questionsSnap.size;
+            deleted['question-states'] = stateSnap.size;
+        }
+
+        // Global: lesson doc (keyed by kuId)
+        const lessonRef = this.db.collection(LESSONS_COLLECTION).doc(kuId);
+        const lessonSnap = await lessonRef.get();
+        if (lessonSnap.exists) {
+            await lessonRef.delete();
+            deleted['lessons'] = 1;
+        }
+
+        // Global: KU itself
+        await this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(kuId).delete();
+        deleted['knowledge-units'] = 1;
+
+        this.logger.log(`Cascade deleted KU ${kuId} for user ${uid}: ${JSON.stringify(deleted)}`);
+        return { deleted };
     }
 }

--- a/frontend/src/app/admin/logs/page.tsx
+++ b/frontend/src/app/admin/logs/page.tsx
@@ -1,230 +1,334 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { ApiLog } from "@/types";
 import { JsonDisplay } from "@/components/JSONDisplay";
 import { apiFetch } from "@/lib/api-client";
 
+interface LatencyStat {
+  route: string;
+  count: number;
+  avgMs: number;
+  p95Ms: number;
+  minMs: number;
+  maxMs: number;
+}
+
 export default function LogsPage() {
+  const [activeTab, setActiveTab] = useState<"logs" | "latency">("logs");
+
+  // Logs state
   const [logs, setLogs] = useState<ApiLog[]>([]);
   const [loading, setLoading] = useState(true);
-
-  // Filters
   const [limit, setLimit] = useState(50);
   const [route, setRoute] = useState("");
   const [status, setStatus] = useState<"" | "success" | "error">("");
-
-  // Expanded row state
   const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
 
-  const fetchLogs = async () => {
+  // Latency state
+  const [latencyStats, setLatencyStats] = useState<LatencyStat[]>([]);
+  const [latencyLoading, setLatencyLoading] = useState(false);
+  const [latencyLoaded, setLatencyLoaded] = useState(false);
+
+  const fetchLogs = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams();
       params.append("limit", limit.toString());
       if (route) params.append("route", route);
       if (status) params.append("status", status);
-
       const res = await apiFetch(`/api/apilogs?${params.toString()}`);
       if (!res.ok) throw new Error("Failed to fetch logs");
-
-      const data = await res.json();
-      setLogs(data);
+      setLogs(await res.json());
     } catch (error) {
       console.error("Error fetching logs:", error);
     } finally {
       setLoading(false);
     }
-  };
+  }, [limit, route, status]);
+
+  const fetchLatency = useCallback(async () => {
+    setLatencyLoading(true);
+    try {
+      const res = await apiFetch("/api/apilogs/latency");
+      if (!res.ok) throw new Error("Failed to fetch latency stats");
+      setLatencyStats(await res.json());
+      setLatencyLoaded(true);
+    } catch (error) {
+      console.error("Error fetching latency:", error);
+    } finally {
+      setLatencyLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     fetchLogs();
   }, []);
 
-  const handleRefresh = () => {
-    fetchLogs();
-  };
+  useEffect(() => {
+    if (activeTab === "latency" && !latencyLoaded) {
+      fetchLatency();
+    }
+  }, [activeTab]);
 
   const toggleExpand = (id: string) => {
     setExpandedLogId(expandedLogId === id ? null : id);
   };
 
+  const latencyBarColor = (ms: number) => {
+    if (ms < 3000) return "bg-green-500";
+    if (ms < 8000) return "bg-yellow-400";
+    return "bg-red-500";
+  };
+
+  const latencyTextColor = (ms: number) => {
+    if (ms < 3000) return "text-green-700";
+    if (ms < 8000) return "text-yellow-700";
+    return "text-red-700";
+  };
+
+  const formatMs = (ms: number) =>
+    ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+
+  const maxAvg = Math.max(...latencyStats.map((s) => s.avgMs), 1);
+
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-6">System Log Viewer</h1>
-
-      {/* Filters */}
-      <div className="bg-white p-4 rounded-lg shadow mb-6 border border-gray-200 flex flex-wrap gap-4 items-end">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Route
-          </label>
-          <input
-            type="text"
-            className="border border-gray-300 rounded-md p-2 w-64 focus:ring-blue-500 focus:border-blue-500"
-            placeholder="/api/..."
-            value={route}
-            onChange={(e) => setRoute(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Status
-          </label>
-          <select
-            className="border border-gray-300 rounded-md p-2 w-40 focus:ring-blue-500 focus:border-blue-500"
-            value={status}
-            onChange={(e) =>
-              setStatus(e.target.value as "" | "success" | "error")
-            }
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold mb-4">API Logs</h1>
+        <div className="flex border-b border-gray-200">
+          <button
+            className={`py-2 px-4 font-medium focus:outline-none ${activeTab === "logs" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500 hover:text-gray-700"}`}
+            onClick={() => setActiveTab("logs")}
           >
-            <option value="">All</option>
-            <option value="success">Success</option>
-            <option value="error">Error</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Limit
-          </label>
-          <select
-            className="border border-gray-300 rounded-md p-2 w-24 focus:ring-blue-500 focus:border-blue-500"
-            value={limit}
-            onChange={(e) => setLimit(Number(e.target.value))}
+            Log Viewer
+          </button>
+          <button
+            className={`py-2 px-4 font-medium focus:outline-none ${activeTab === "latency" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500 hover:text-gray-700"}`}
+            onClick={() => setActiveTab("latency")}
           >
-            <option value={25}>25</option>
-            <option value={50}>50</option>
-            <option value={100}>100</option>
-          </select>
+            Latency
+          </button>
         </div>
-        <button
-          onClick={handleRefresh}
-          className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ml-auto"
-        >
-          Refresh
-        </button>
       </div>
 
-      {/* Logs Table */}
-      <div className="bg-white rounded-lg shadow overflow-hidden border border-gray-200">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Timestamp
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Route
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Status
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Latency
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Model
-              </th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {loading ? (
-              <tr>
-                <td colSpan={6} className="px-6 py-4 text-center text-gray-500">
-                  Loading logs...
-                </td>
-              </tr>
-            ) : logs.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="px-6 py-4 text-center text-gray-500">
-                  No logs found.
-                </td>
-              </tr>
-            ) : (
-              logs.map((log) => (
-                <>
-                  <tr
-                    key={log.id}
-                    className={`hover:bg-gray-50 cursor-pointer ${expandedLogId === log.id ? "bg-blue-50" : ""}`}
-                    onClick={() => toggleExpand(log.id!)}
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {new Date(log.timestamp).toLocaleString()}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      {log.route}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                          log.status === "success"
-                            ? "bg-green-100 text-green-800"
-                            : log.status === "error"
-                              ? "bg-red-100 text-red-800"
-                              : "bg-yellow-100 text-yellow-800"
-                        }`}
-                      >
-                        {log.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {log.durationMs ? `${log.durationMs}ms` : "-"}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {log.modelUsed || "-"}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <span className="text-blue-600 hover:text-blue-900">
-                        {expandedLogId === log.id
-                          ? "Hide Details"
-                          : "View Details"}
-                      </span>
-                    </td>
-                  </tr>
+      {/* ── Log Viewer Tab ── */}
+      {activeTab === "logs" && (
+        <>
+          <div className="bg-white p-4 rounded-lg shadow mb-6 border border-gray-200 flex flex-wrap gap-4 items-end">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Route</label>
+              <input
+                type="text"
+                className="border border-gray-300 rounded-md p-2 w-64 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="/api/..."
+                value={route}
+                onChange={(e) => setRoute(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+              <select
+                className="border border-gray-300 rounded-md p-2 w-40 focus:ring-blue-500 focus:border-blue-500"
+                value={status}
+                onChange={(e) => setStatus(e.target.value as "" | "success" | "error")}
+              >
+                <option value="">All</option>
+                <option value="success">Success</option>
+                <option value="error">Error</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Limit</label>
+              <select
+                className="border border-gray-300 rounded-md p-2 w-24 focus:ring-blue-500 focus:border-blue-500"
+                value={limit}
+                onChange={(e) => setLimit(Number(e.target.value))}
+              >
+                <option value={25}>25</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+              </select>
+            </div>
+            <button
+              onClick={fetchLogs}
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ml-auto"
+            >
+              Refresh
+            </button>
+          </div>
 
-                  {/* Expanded Details Panel */}
-                  {expandedLogId === log.id && (
-                    <tr className="bg-gray-50">
-                      <td colSpan={6} className="px-6 py-4">
-                        <div className="grid grid-cols-2 gap-4">
-                          <div className="border rounded-md bg-white p-3">
-                            <h3 className="font-semibold text-gray-700 mb-2 border-b pb-1">
-                              Request Data
-                            </h3>
-                            <pre className="text-xs text-gray-600 whitespace-pre-wrap font-mono overflow-auto max-h-96">
-                              <JsonDisplay data={log.requestData} />
-                            </pre>
-                          </div>
-                          <div className="border rounded-md bg-white p-3">
-                            <h3 className="font-semibold text-gray-700 mb-2 border-b pb-1">
-                              Response / Error Data
-                            </h3>
-                            {log.errorData ? (
-                              <div className="text-red-600">
-                                <p className="font-bold">Error:</p>
-                                <pre className="text-xs whitespace-pre-wrap font-mono overflow-auto max-h-96">
-                                  <JsonDisplay data={log.errorData} />
+          <div className="bg-white rounded-lg shadow overflow-hidden border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Route</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Latency</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Model</th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {loading ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-4 text-center text-gray-500">Loading logs...</td>
+                  </tr>
+                ) : logs.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-4 text-center text-gray-500">No logs found.</td>
+                  </tr>
+                ) : (
+                  logs.map((log) => (
+                    <>
+                      <tr
+                        key={log.id}
+                        className={`hover:bg-gray-50 cursor-pointer ${expandedLogId === log.id ? "bg-blue-50" : ""}`}
+                        onClick={() => toggleExpand(log.id!)}
+                      >
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(log.timestamp).toLocaleString()}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                          {log.route}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                            log.status === "success"
+                              ? "bg-green-100 text-green-800"
+                              : log.status === "error"
+                                ? "bg-red-100 text-red-800"
+                                : "bg-yellow-100 text-yellow-800"
+                          }`}>
+                            {log.status}
+                          </span>
+                        </td>
+                        <td className={`px-6 py-4 whitespace-nowrap text-sm ${
+                          log.durationMs
+                            ? latencyTextColor(log.durationMs)
+                            : "text-gray-400"
+                        }`}>
+                          {log.durationMs ? formatMs(log.durationMs) : "-"}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {log.modelUsed || "-"}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                          <span className="text-blue-600 hover:text-blue-900">
+                            {expandedLogId === log.id ? "Hide Details" : "View Details"}
+                          </span>
+                        </td>
+                      </tr>
+
+                      {expandedLogId === log.id && (
+                        <tr className="bg-gray-50">
+                          <td colSpan={6} className="px-6 py-4">
+                            <div className="grid grid-cols-2 gap-4">
+                              <div className="border rounded-md bg-white p-3">
+                                <h3 className="font-semibold text-gray-700 mb-2 border-b pb-1">Request Data</h3>
+                                <pre className="text-xs text-gray-600 whitespace-pre-wrap font-mono overflow-auto max-h-96">
+                                  <JsonDisplay data={log.requestData} />
                                 </pre>
                               </div>
-                            ) : (
-                              <pre className="text-xs text-green-700 whitespace-pre-wrap font-mono overflow-auto max-h-96">
-                                <JsonDisplay data={log.responseData} />
-                              </pre>
-                            )}
+                              <div className="border rounded-md bg-white p-3">
+                                <h3 className="font-semibold text-gray-700 mb-2 border-b pb-1">Response / Error Data</h3>
+                                {log.errorData ? (
+                                  <div className="text-red-600">
+                                    <p className="font-bold">Error:</p>
+                                    <pre className="text-xs whitespace-pre-wrap font-mono overflow-auto max-h-96">
+                                      <JsonDisplay data={log.errorData} />
+                                    </pre>
+                                  </div>
+                                ) : (
+                                  <pre className="text-xs text-green-700 whitespace-pre-wrap font-mono overflow-auto max-h-96">
+                                    <JsonDisplay data={log.responseData} />
+                                  </pre>
+                                )}
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {/* ── Latency Tab ── */}
+      {activeTab === "latency" && (
+        <div>
+          <div className="flex justify-between items-center mb-4">
+            <p className="text-sm text-gray-500">
+              Aggregated over last 200 logged calls. Color: green &lt; 3s, yellow &lt; 8s, red ≥ 8s.
+            </p>
+            <button
+              onClick={() => { setLatencyLoaded(false); fetchLatency(); }}
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 text-sm"
+            >
+              Refresh
+            </button>
+          </div>
+
+          {latencyLoading ? (
+            <p className="text-gray-400 text-sm">Loading latency data...</p>
+          ) : latencyStats.length === 0 ? (
+            <p className="text-gray-400 text-sm">No latency data available yet.</p>
+          ) : (
+            <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden">
+              <table className="min-w-full">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/3">Route</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-16">n</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-20">Avg</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-20">P95</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Distribution</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {latencyStats.map((stat) => {
+                    const avgPct = Math.round((stat.avgMs / maxAvg) * 100);
+                    const p95Pct = Math.round((stat.p95Ms / maxAvg) * 100);
+                    return (
+                      <tr key={stat.route} className="hover:bg-gray-50">
+                        <td className="px-6 py-3 text-sm font-mono text-gray-800 truncate max-w-xs" title={stat.route}>
+                          {stat.route}
+                        </td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-500">{stat.count}</td>
+                        <td className={`px-4 py-3 text-right text-sm font-semibold ${latencyTextColor(stat.avgMs)}`}>
+                          {formatMs(stat.avgMs)}
+                        </td>
+                        <td className={`px-4 py-3 text-right text-sm ${latencyTextColor(stat.p95Ms)}`}>
+                          {formatMs(stat.p95Ms)}
+                        </td>
+                        <td className="px-6 py-3">
+                          <div className="relative h-5 bg-gray-100 rounded overflow-hidden w-full">
+                            {/* P95 bar (lighter, background) */}
+                            <div
+                              className={`absolute top-0 left-0 h-full opacity-30 rounded ${latencyBarColor(stat.p95Ms)}`}
+                              style={{ width: `${p95Pct}%` }}
+                            />
+                            {/* Avg bar (solid, foreground) */}
+                            <div
+                              className={`absolute top-0 left-0 h-full rounded ${latencyBarColor(stat.avgMs)}`}
+                              style={{ width: `${avgPct}%` }}
+                            />
                           </div>
-                        </div>
-                      </td>
-                    </tr>
-                  )}
-                </>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/admin/prompt-tester/page.tsx
+++ b/frontend/src/app/admin/prompt-tester/page.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { apiFetch } from "@/lib/api-client";
+
+interface Preset {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  exampleUserMessage: string;
+  useTools: boolean;
+  responseSchema?: Record<string, unknown>;
+  description: string;
+}
+
+interface ToolCall {
+  fn: string;
+  args: Record<string, unknown>;
+  response: Record<string, unknown>;
+}
+
+interface TestResult {
+  rawText: string;
+  parsedJson: unknown;
+  toolCalls: ToolCall[];
+  durationMs: number;
+}
+
+export default function PromptTesterPage() {
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [selectedPresetId, setSelectedPresetId] = useState<string>("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [userMessage, setUserMessage] = useState("");
+  const [useTools, setUseTools] = useState(false);
+  const [uid, setUid] = useState("");
+  const [schemaText, setSchemaText] = useState("");
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<TestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedToolCall, setExpandedToolCall] = useState<number | null>(null);
+
+  useEffect(() => {
+    apiFetch("/api/apilogs/prompt-presets")
+      .then((r) => r.json())
+      .then(setPresets)
+      .catch(console.error);
+  }, []);
+
+  const applyPreset = (id: string) => {
+    const preset = presets.find((p) => p.id === id);
+    if (!preset) return;
+    setSelectedPresetId(id);
+    setSystemPrompt(preset.systemPrompt);
+    setUserMessage(preset.exampleUserMessage);
+    setUseTools(preset.useTools);
+    setSchemaText(
+      preset.responseSchema ? JSON.stringify(preset.responseSchema, null, 2) : "",
+    );
+  };
+
+  const handleRun = async () => {
+    setRunning(true);
+    setResult(null);
+    setError(null);
+    setExpandedToolCall(null);
+
+    let parsedSchema: Record<string, unknown> | undefined;
+    if (schemaText.trim()) {
+      try {
+        parsedSchema = JSON.parse(schemaText);
+      } catch {
+        setError("Invalid JSON in Response Schema field.");
+        setRunning(false);
+        return;
+      }
+    }
+
+    try {
+      const res = await apiFetch("/api/apilogs/prompt-test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          systemPrompt,
+          userMessage,
+          useTools,
+          uid: uid || undefined,
+          responseSchema: parsedSchema,
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Server error ${res.status}: ${text}`);
+      }
+
+      const data = await res.json();
+      setResult(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const latencyColor = (ms: number) => {
+    if (ms < 3000) return "text-green-700 bg-green-50";
+    if (ms < 8000) return "text-yellow-700 bg-yellow-50";
+    return "text-red-700 bg-red-50";
+  };
+
+  return (
+    <div className="container mx-auto p-4 max-w-screen-xl">
+      <h1 className="text-2xl font-bold mb-6">Prompt Tester</h1>
+
+      <div className="flex gap-6">
+        {/* Left panel — inputs */}
+        <div className="flex-1 min-w-0 flex flex-col gap-4">
+          {/* Preset selector */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Preset
+            </label>
+            <select
+              className="w-full border border-gray-300 rounded-md p-2 text-sm"
+              value={selectedPresetId}
+              onChange={(e) => applyPreset(e.target.value)}
+            >
+              <option value="">— select a preset —</option>
+              {presets.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            {selectedPresetId && (
+              <p className="text-xs text-gray-500 mt-1">
+                {presets.find((p) => p.id === selectedPresetId)?.description}
+              </p>
+            )}
+          </div>
+
+          {/* System prompt */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              System Prompt
+            </label>
+            <textarea
+              className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
+              rows={14}
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              placeholder="System prompt..."
+            />
+          </div>
+
+          {/* User message */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              User Message
+            </label>
+            <textarea
+              className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
+              rows={4}
+              value={userMessage}
+              onChange={(e) => setUserMessage(e.target.value)}
+              placeholder="User message (leave empty to use system prompt only)..."
+            />
+          </div>
+
+          {/* Tools + UID */}
+          <div className="flex gap-4 items-start">
+            <div className="flex items-center gap-2 pt-1">
+              <input
+                type="checkbox"
+                id="useTools"
+                checked={useTools}
+                onChange={(e) => setUseTools(e.target.checked)}
+                className="w-4 h-4"
+              />
+              <label htmlFor="useTools" className="text-sm font-medium text-gray-700">
+                Enable <code className="text-xs bg-gray-100 px-1 rounded">get_user_level</code> tool
+              </label>
+            </div>
+            {useTools && (
+              <div className="flex-1">
+                <label className="block text-xs text-gray-500 mb-1">
+                  User UID (optional — defaults to N5 if blank)
+                </label>
+                <input
+                  type="text"
+                  className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
+                  value={uid}
+                  onChange={(e) => setUid(e.target.value)}
+                  placeholder="Firebase UID..."
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Response schema */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Response Schema{" "}
+              <span className="text-gray-400 font-normal">(JSON — leave empty for raw text)</span>
+            </label>
+            <textarea
+              className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
+              rows={6}
+              value={schemaText}
+              onChange={(e) => setSchemaText(e.target.value)}
+              placeholder='{ "type": "OBJECT", "properties": { ... }, "required": [...] }'
+            />
+          </div>
+
+          <button
+            onClick={handleRun}
+            disabled={running || !systemPrompt.trim()}
+            className="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+          >
+            {running ? "Running..." : "Run"}
+          </button>
+        </div>
+
+        {/* Right panel — results */}
+        <div className="w-[480px] shrink-0 flex flex-col gap-4">
+          {/* Status / latency */}
+          {result && (
+            <div className={`rounded-md px-3 py-2 text-sm font-mono font-semibold ${latencyColor(result.durationMs)}`}>
+              {result.durationMs.toLocaleString()} ms
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md px-3 py-2 text-sm bg-red-50 text-red-700 font-mono whitespace-pre-wrap">
+              {error}
+            </div>
+          )}
+
+          {running && (
+            <div className="text-sm text-gray-400 animate-pulse">Waiting for response...</div>
+          )}
+
+          {/* Tool calls */}
+          {result && result.toolCalls.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                Tool Calls ({result.toolCalls.length})
+              </h3>
+              <div className="space-y-2">
+                {result.toolCalls.map((tc, i) => (
+                  <div key={i} className="border border-gray-200 rounded-md overflow-hidden">
+                    <button
+                      className="w-full text-left px-3 py-2 bg-gray-50 hover:bg-gray-100 text-sm font-mono flex justify-between items-center"
+                      onClick={() =>
+                        setExpandedToolCall(expandedToolCall === i ? null : i)
+                      }
+                    >
+                      <span className="text-blue-700">{tc.fn}()</span>
+                      <span className="text-gray-400 text-xs">
+                        {expandedToolCall === i ? "▲" : "▼"}
+                      </span>
+                    </button>
+                    {expandedToolCall === i && (
+                      <div className="p-3 space-y-2 bg-white">
+                        {Object.keys(tc.args).length > 0 && (
+                          <div>
+                            <p className="text-xs text-gray-500 mb-1">Args</p>
+                            <pre className="text-xs font-mono bg-gray-50 p-2 rounded overflow-auto max-h-40">
+                              {JSON.stringify(tc.args, null, 2)}
+                            </pre>
+                          </div>
+                        )}
+                        <div>
+                          <p className="text-xs text-gray-500 mb-1">Response</p>
+                          <pre className="text-xs font-mono bg-gray-50 p-2 rounded overflow-auto max-h-60">
+                            {JSON.stringify(tc.response, null, 2)}
+                          </pre>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Result */}
+          {result && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 mb-2">Result</h3>
+              <div className="border border-gray-200 rounded-md overflow-hidden">
+                <pre className="text-sm font-mono p-3 bg-white whitespace-pre-wrap overflow-auto max-h-[500px]">
+                  {result.parsedJson !== null
+                    ? JSON.stringify(result.parsedJson, null, 2)
+                    : result.rawText}
+                </pre>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { KnowledgeUnit } from "@/types";
 import { apiFetch } from "@/lib/api-client";
 
@@ -36,6 +37,7 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export default function LearnListPage() {
+  const router = useRouter();
   const [items, setItems] = useState<KUWithStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -132,11 +134,20 @@ export default function LearnListPage() {
 
   return (
     <main className="container mx-auto max-w-3xl p-6">
-      <header className="mb-6">
-        <h1 className="text-3xl font-bold text-shodo-ink dark:text-white">My Library</h1>
-        <p className="text-sm text-shodo-ink-light dark:text-gray-400 mt-1">
-          {isLoading ? "Loading…" : `${items.length} items`}
-        </p>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-shodo-ink dark:text-white">My Library</h1>
+          <p className="text-sm text-shodo-ink-light dark:text-gray-400 mt-1">
+            {isLoading ? "Loading…" : `${items.length} items`}
+          </p>
+        </div>
+        <button
+          onClick={() => router.push("/learn/session")}
+          style={{ backgroundColor: "#2E4B75" }}
+          className="mt-1 px-5 py-2 rounded-lg text-white text-sm font-semibold shrink-0 hover:opacity-90 transition-opacity"
+        >
+          Start Learning
+        </button>
       </header>
 
       {error && (

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -488,7 +488,7 @@ export default function LessonSessionPage() {
     return (
       <main className="container mx-auto max-w-2xl p-8">
         <div>
-          <h1 className="text-2xl font-bold text-shodo-ink mb-2">Preparing your lesson</h1>
+          <h1 className="text-2xl font-bold text-shodo-ink mb-2">Preparing your Lessons</h1>
           <p className="text-shodo-ink-faint mb-8 text-sm">
             {totalCount === 0 ? "Finding items…" : `Generating ${loadedCount} of ${totalCount}`}
           </p>
@@ -594,7 +594,7 @@ export default function LessonSessionPage() {
       ) : (
         <div>
           <div className="text-5xl mb-6">✨</div>
-          <h1 className="text-3xl font-bold text-shodo-ink mb-2">Lesson complete!</h1>
+          <h1 className="text-3xl font-bold text-shodo-ink mb-2">Lessons Complete</h1>
           <p className="text-shodo-ink-light mb-2">
             You studied {loadedItems.length} {loadedItems.length === 1 ? "item" : "items"}.
           </p>

--- a/frontend/src/app/manage/page.tsx
+++ b/frontend/src/app/manage/page.tsx
@@ -37,6 +37,10 @@ export default function KnowledgeManagementPage() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editingKu, setEditingKu] = useState<KnowledgeUnit | null>(null);
 
+  // --- Delete State ---
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
   // --- Search & Enroll State ---
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<KnowledgeUnit[]>([]);
@@ -178,6 +182,22 @@ export default function KnowledgeManagementPage() {
     }
   };
 
+  // --- Delete Handler ---
+  const handleDelete = async (kuId: string) => {
+    setDeletingId(kuId);
+    try {
+      const res = await apiFetch(`/api/knowledge-units/${kuId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+      await fetchData();
+      window.dispatchEvent(new CustomEvent("refreshStats"));
+    } catch (err) {
+      setError("Failed to delete unit — please try again.");
+    } finally {
+      setDeletingId(null);
+      setConfirmDeleteId(null);
+    }
+  };
+
   // --- Search & Enroll Handlers ---
   const handleSearchChange = (q: string) => {
     setSearchQuery(q);
@@ -256,6 +276,31 @@ export default function KnowledgeManagementPage() {
                 >
                   Edit
                 </button>
+
+                {confirmDeleteId === ku.id ? (
+                  <div className="ml-2 flex items-center gap-1">
+                    <button
+                      onClick={() => handleDelete(ku.id)}
+                      disabled={deletingId === ku.id}
+                      className="text-sm px-3 py-1 bg-red-600 hover:bg-red-700 disabled:bg-red-900 text-white rounded transition-colors"
+                    >
+                      {deletingId === ku.id ? "Deleting…" : "Confirm"}
+                    </button>
+                    <button
+                      onClick={() => setConfirmDeleteId(null)}
+                      className="text-sm px-2 py-1 bg-gray-600 hover:bg-gray-500 text-white rounded transition-colors"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setConfirmDeleteId(ku.id)}
+                    className="ml-2 text-sm px-3 py-1 bg-gray-700 hover:bg-red-700 text-gray-300 hover:text-white rounded transition-colors"
+                  >
+                    Delete
+                  </button>
+                )}
               </div>
 
               {ku.type === "Vocab" && ku.data.reading && (

--- a/frontend/src/components/EditKnowledgeUnitModal.tsx
+++ b/frontend/src/components/EditKnowledgeUnitModal.tsx
@@ -28,9 +28,9 @@ export default function EditKnowledgeUnitModal({
   useEffect(() => {
     if (knowledgeUnit) {
       setContent(knowledgeUnit.content || "");
-      if (knowledgeUnit.type === "Vocab") {
+      if (knowledgeUnit.type === "Vocab" || knowledgeUnit.type === "Kanji") {
         setReading(knowledgeUnit.data?.reading || "");
-        setDefinition(knowledgeUnit.data?.definition || "");
+        setDefinition(knowledgeUnit.data?.definition || knowledgeUnit.data?.meaning || "");
         setJlptLevel(knowledgeUnit.data?.jlptLevel || "");
         setWanikaniLevel(knowledgeUnit.data?.wanikaniLevel || "");
       } else {
@@ -48,7 +48,7 @@ export default function EditKnowledgeUnitModal({
 
   const hasChanges = () => {
     if (!knowledgeUnit) return false;
-    const vocabData = knowledgeUnit.type === "Vocab" ? knowledgeUnit.data : null;
+    const vocabData = (knowledgeUnit.type === "Vocab" || knowledgeUnit.type === "Kanji") ? knowledgeUnit.data : null;
     const currentReading = vocabData?.reading || "";
     const currentDefinition = vocabData?.definition || "";
     const currentJlptLevel = vocabData?.jlptLevel || "";
@@ -145,8 +145,8 @@ export default function EditKnowledgeUnitModal({
             />
           </div>
 
-          {/* Vocab Specific Fields */}
-          {knowledgeUnit.type === "Vocab" && (
+          {/* Vocab / Kanji Fields */}
+          {(knowledgeUnit.type === "Vocab" || knowledgeUnit.type === "Kanji") && (
             <>
               <div className="grid grid-cols-2 gap-4">
                 <div>


### PR DESCRIPTION
## Prompt Tester & Latency Graphs                                                                                      
                                                                                                                       
  ### Backend                                                                                                            
  - `GeminiService.runPromptTest()` — debug-friendly Gemini call that runs the tool-calling loop and returns `{ rawText,
  parsedJson, toolCalls[], durationMs }` directly                                                                        
  - `ApilogService.getLatencyStats(sampleSize)` — fetches last N logs, groups by route, computes avg / p95 / min / max
  - `ApilogModule` — now imports `GeminiModule` so `GeminiService` is injectable into the controller                     
  - Three new endpoints on `ApilogController`:                                                                           
    - `GET /api/apilogs/latency` — per-route latency stats                                                               
    - `GET /api/apilogs/prompt-presets` — 6 presets (vocab conjugation, translation, fill-in-the-blank, noun-particle,   
  concept error-correction, concept novel-translation) with full system prompts and example user messages                
    - `POST /api/apilogs/prompt-test` — runs a prompt with optional `get_user_level` tool and optional response schema,  
  returns full debug output                                                                                              
                                                            
  ### Frontend                                                                                                           
  - `/admin/logs` — added **Latency tab** alongside the log viewer. Per-route bar chart showing avg (solid bar) and p95
  (faint overlay), coloured green / yellow / red by threshold (< 3s / < 8s / ≥ 8s)                                       
  - `/admin/prompt-tester` — new page with two-panel layout:
    - Left: preset dropdown (auto-populates system prompt + user message), editable textareas, `get_user_level` tool     
  toggle + UID field, response schema textarea, Run button                                                               
    - Right: latency badge, collapsible tool call cards showing args and response, result panel (parsed JSON or raw text)
                                                                                                                         
  ---                                                                                                                    
                                                                                                                         
  ## Learn Page — Start Learning Button                                                                                  
                                                            
  - Added **Start Learning** button to the `/learn` page header, linking to `/learn/session`                             
  - Uses inline `style` for colour (`#2E4B75`) consistent with the rest of the page's pattern
  - Text changes: interstitial heading → **"Preparing your Lessons"**, complete screen → **"Lessons Complete"**          
                                                                                                                         
  ---                                                                                                                    
                                                                                                                         
  ## Cascade Delete                                         

  ### Backend                                                                                                            
  - `KnowledgeUnitsService.cascadeDelete(uid, kuId)` — deletes in order:
    1. `users/{uid}/review-facets` (where `kuId` matches)                                                                
    2. `users/{uid}/user-kus`                                                                                            
    3. `users/{uid}/feed`                                                                                                
    4. `questions` (global) + `users/{uid}/question-states`                                                              
    5. `lessons/{kuId}` (global)                                                                                         
    6. `knowledge-units/{kuId}` (global)                                                                                 
    - Returns `{ deleted: { "review-facets": n, ... } }` summary                                                         
  - `DELETE /api/knowledge-units/:id` — new endpoint wired to the above                                                  
                                                                                                                         
  ### Frontend (`/manage`)                                                                                               
  - Two-click delete on each KU row: first click shows inline **Confirm** + **✕ cancel**, second click fires the delete  
  - List and stats refresh automatically on success                                                                      
                                                                                                                         
  ---                                                                                                                    
                                                                                                                         
  ## Edit Modal — Kanji JLPT & WaniKani                                                                                  
  
  - `EditKnowledgeUnitModal` previously showed JLPT Level and WaniKani Level fields for `Vocab` KUs only                 
  - Extended to also show for `Kanji` KUs (which carry the same `jlptLevel` / `wanikaniLevel` fields in their data)
  - Definition field falls back to `data.meaning` for Kanji so it pre-populates correctly         