### PR TITLE
feat: grammar in lesson queue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -702,6 +702,34 @@ Library page (`/learn`): Kanji items now show `data.meaning` in the hint column 
 
 ---
 
+**Admin tooling, lesson session polish, cascade delete, manage improvements (2026-05-06)**
+
+- **Admin prompt tester** (`frontend/src/app/admin/prompt-tester/page.tsx`) — left panel: preset dropdown (6 presets covering vocab and concept question types), system prompt, user message, tool toggle + UID field, response schema, Run button. Right panel: latency badge, collapsible tool-call cards, result display.
+- **API log latency graphs** (`frontend/src/app/admin/logs/page.tsx`) — new Latency tab. Per-route bar chart: avg (solid) + p95 (faint overlay); green < 3 s, amber < 8 s, red ≥ 8 s. `ApilogService.getLatencyStats(sampleSize)` groups by route and computes avg/p95/min/max. `GET /apilogs/latency` endpoint added.
+- **"Start Learning" button** on `/learn` page — inline style `backgroundColor: "#2E4B75"` (Tailwind JIT doesn't emit custom colour classes for first-use values; inline style is guaranteed). `useRouter` for navigation.
+- **Lesson session label changes** — "Preparing your Lessons" (was "Preparing your Session"); "Lessons Complete" (was "Session Complete").
+- **Grammar lesson slides** — `slideCount` for Grammar: `2 + (gl.notes ? 1 : 0) + (gl.examples?.length ?? 0)`. `renderSlide` Grammar branch uses dynamic index arithmetic: Pattern → Meaning → Notes (if any) → one slide per example. `GrammarExampleSlide` accepts `exampleIdx`.
+- **Vocab word slide** — word in a centred pill, "made of" section divider, component cards; other slides remain left-aligned.
+- **Cascade delete** (`KnowledgeUnitsService.cascadeDelete(uid, kuId)`) — deletes in order: `review-facets`, `user-kus`, `feed`, `questions` + `question-states` (per-user), `lessons/{kuId}`, `knowledge-units/{kuId}`. Returns `{ deleted: Record<string, number> }`. `DELETE /api/knowledge-units/:id` endpoint added.
+- **Delete button on `/manage`** — two-click UI (Delete → Confirm + ✕). `confirmDeleteId` / `deletingId` state. Calls `DELETE /api/knowledge-units/:id`.
+- **JLPT + WaniKani fields in edit modal** for Kanji type (`EditKnowledgeUnitModal.tsx`). Previously Vocab-only. `useEffect`, `hasChanges`, and JSX condition updated to `type === 'Vocab' || type === 'Kanji'`. Kanji definition falls back to `data.meaning`.
+
+---
+
+**Grammar in learning queue + tool-based grammar matching (2026-05-06)**
+
+- **`LessonsService.getQueue`** — split corpus queries: `Vocab`/`Kanji` get up to 7 slots; `Grammar` gets a dedicated parallel query with up to 3 slots. Enrolled-but-not-started Grammar from `user-kus` (no facets yet) is prioritised first, then the corpus fills remaining Grammar slots. Final result: `[...grammarItems, ...vocabKanjiItems].slice(0, 10)`. Requires Firestore composite index on `(type, data.jlptLevel)`.
+- **`GET_GRAMMAR_PATTERNS_DECLARATION`** added to `backend/src/prompts/curriculum.ts` — tool that instructs Gemini to call `get_grammar_patterns(jlptLevel)` before finalising scenario grammar references.
+- **`generateWithTools` `responseSchema` made optional** — when absent, the final turn uses `responseMimeType: 'application/json'` without a strict schema. Allows scenario generation to benefit from the tool loop without requiring a fully-specified output schema.
+- **`GeminiService.generateScenario`** — signature extended with optional `toolDeclarations` + `toolHandlers`; when provided, delegates to `generateWithTools` (tool-call loop → JSON output). Also changed return type from `string` to `any` (parsed object). Falls back to the original direct `generateContent` path when no tools are passed.
+- **Scenario prompts** (`buildArchitectPrompt`, `buildImportPrompt`) — grammar requirement rewritten: AI must call `get_grammar_patterns(level)`, then select 1–2 patterns from the returned pool. Output schema replaces `grammarNotes` with `grammarMatches: [{ kuId, exampleFromConversation: { japanese, english, fragments, accepted_alternatives } }]`. `kuId` must be an exact ID returned by the tool — never invented.
+- **`GrammarMatch` interface** added to `backend/src/types/scenario.ts`. `Scenario.grammarNotes` made optional (backward compat). `Scenario.grammarMatches?: GrammarMatch[]` added.
+- **`ScenariosService.buildGrammarToolHandlers()`** — private method. `get_grammar_patterns` handler queries `knowledge-units` for `type === 'Grammar'` + `data.jlptLevel === level`, returns `{ patterns: [{ kuId, content, title, explanation }] }`.
+- **`ScenariosService.advanceState`** — `grammarMatches` path (new): iterates matches, calls `userKnowledgeUnitsService.create` + `lessonsService.createUserGrammarLesson` directly using the exact `kuId` — no fuzzy matching. Legacy `grammarNotes` path retained as fallback for scenarios created before this change.
+- **Grammar KU JLPT level migration** — imported Grammar KUs had `jlptLevel` at the document root instead of `data.jlptLevel` (inconsistent with Vocab/Kanji). `KnowledgeUnitsService.migrateGrammarJlptLevel()` batch-updates all affected Grammar KUs: copies `jlptLevel` → `data.jlptLevel`, deletes the root field. `POST /api/knowledge-units/migrate/grammar-jlpt-level` admin endpoint. 333 records migrated; 18 without any level skipped.
+
+---
+
 - **Firebase Console prerequisites** for project `gen-lang-client-0878434798`:
   1. Authentication → Sign-in method → **Email/Password** enabled.
   2. Authentication → Sign-in method → **Email link (passwordless sign-in)** enabled (sub-toggle under Email/Password).

--- a/backend/src/gemini/gemini.service.ts
+++ b/backend/src/gemini/gemini.service.ts
@@ -340,22 +340,32 @@ export class GeminiService implements OnModuleInit {
 
   }
 
-  // ... existing imports ...
-  // ... existing class definition ...
+  async generateScenario(
+    userMessage: string,
+    toolDeclarations?: FunctionDeclaration[],
+    toolHandlers?: Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>>,
+  ): Promise<any> {
+    if (toolDeclarations?.length && toolHandlers) {
+      return this.generateWithTools<any>(
+        userMessage,
+        '',
+        toolDeclarations,
+        toolHandlers,
+        undefined,
+        { route: '/scenarios/generate', topic: userMessage.slice(0, 60) },
+      );
+    }
 
-  async generateScenario(userMessage: string) {
     const initialLogData: ApiLog = {
       timestamp: Timestamp.now(),
       route: "/scenarios/generate",
       status: "pending",
       modelUsed: this.modelName,
-      requestData: {
-        userMessage: userMessage,
-      },
+      requestData: { userMessage },
     };
 
     const logRef = await this.apilogService.startLog(initialLogData);
-    let startTime = performance.now();
+    const startTime = performance.now();
     let errorOccurred = false;
     let capturedError: any;
     let scenarioString: string | undefined;
@@ -372,7 +382,6 @@ export class GeminiService implements OnModuleInit {
 
       if (!apiResponse || !apiResponse?.text) throw new Error("AI response was empty.");
 
-      // Defensive Parsing
       scenarioString = apiResponse.text;
       const jsonStart = scenarioString.indexOf("{");
       const jsonEnd = scenarioString.lastIndexOf("}");
@@ -384,32 +393,25 @@ export class GeminiService implements OnModuleInit {
         throw new Error("AI response did not contain a valid JSON object.");
       }
 
-      return scenarioString;
+      return JSON.parse(scenarioString);
 
     } catch (error) {
       errorOccurred = true;
       capturedError = error;
       this.logger.error('Gemini Service Error (Scenario):', error);
-
-      // Re-throw appropriate exception (simplified from generateLesson for brevity, acts the same)
       throw new InternalServerErrorException("Failed to generate scenario");
     } finally {
       if (logRef) {
-        const endTime = performance.now();
-        const durationMs = (endTime - startTime) / 1000;
-
-        // FIX: Initialize with safe values only. Do not explicitly set keys to undefined.
+        const durationMs = (performance.now() - startTime) / 1000;
         const updateData: Partial<ApiLog> = {
           durationMs,
           status: errorOccurred ? "error" : "success",
         };
-
         if (errorOccurred) {
           updateData.errorData = { message: capturedError?.message };
         } else {
           updateData.responseData = { parsedJson: scenarioString || null };
         }
-
         try {
           await this.apilogService.completeLog(logRef, updateData);
         } catch (logError) {
@@ -787,7 +789,7 @@ export class GeminiService implements OnModuleInit {
     systemPrompt: string,
     toolDeclarations: FunctionDeclaration[],
     toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<Record<string, unknown>>>,
-    responseSchema: Record<string, unknown>,
+    responseSchema?: Record<string, unknown>,
     logContext?: Record<string, any>,
   ): Promise<T> {
     const startTime = performance.now();
@@ -859,9 +861,9 @@ export class GeminiService implements OnModuleInit {
         model: this.modelName,
         contents,
         config: {
-          systemInstruction: { parts: [{ text: systemPrompt }] },
+          systemInstruction: systemPrompt ? { parts: [{ text: systemPrompt }] } : undefined,
           responseMimeType: 'application/json',
-          responseSchema: responseSchema as any,
+          ...(responseSchema ? { responseSchema: responseSchema as any } : {}),
         },
       });
 

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -104,4 +104,9 @@ export class KnowledgeUnitsController {
         return { id: kuId, isNew: isNewKu };
     }
 
+    @Post('migrate/grammar-jlpt-level')
+    async migrateGrammarJlptLevel() {
+        return this.knowledgeUnitsService.migrateGrammarJlptLevel();
+    }
+
 }

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -8,7 +8,7 @@ import {
     USER_KUS_SUBCOLLECTION,
     QUESTION_STATES_SUBCOLLECTION,
 } from '../firebase/firebase.module';
-import { Firestore, Timestamp, DocumentReference } from '@google-cloud/firestore';
+import { Firestore, Timestamp, DocumentReference, FieldValue } from '@google-cloud/firestore';
 import { Inject } from '@nestjs/common';
 // Removed CURRENT_USER_ID import
 import { KnowledgeUnit } from '@/types';
@@ -341,32 +341,29 @@ export class KnowledgeUnitsService {
         } as unknown as KnowledgeUnit;
     }
 
-    async ensureGrammarKU(note: GrammarNote): Promise<string> {
+    async ensureGrammarKU(note: GrammarNote): Promise<string | null> {
         const content = note.pattern ?? note.title;
-        const existing = await this.findByContent(content, 'Grammar');
 
-        if (existing) {
-            return existing.id;
+        // Exact match first
+        const existing = await this.findByContent(content, 'Grammar');
+        if (existing) return existing.id;
+
+        // Prefix search fallback — handles minor AI wording variations
+        const prefixSnap = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
+            .where('type', '==', 'Grammar')
+            .where('content', '>=', content)
+            .where('content', '<=', content + '')
+            .limit(1)
+            .get();
+
+        if (!prefixSnap.empty) {
+            const matched = prefixSnap.docs[0];
+            this.logger.log(`Grammar KU fuzzy-matched "${content}" → "${matched.data().content}"`);
+            return matched.id;
         }
 
-        const newRef = this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc();
-        await newRef.set({
-            content,
-            type: 'Grammar',
-            data: {
-                title: note.title,
-                explanation: note.explanation,
-                exampleInContext: note.exampleInContext,
-            },
-            status: 'learning',
-            facet_count: 0,
-            createdAt: Timestamp.now(),
-            relatedUnits: [],
-            personalNotes: '',
-        });
-
-        this.logger.log(`Created Grammar KU for pattern "${content}"`);
-        return newRef.id;
+        this.logger.warn(`Grammar KU not found in pool for pattern "${content}" — skipping creation`);
+        return null;
     }
 
     async findOne(id: string): Promise<KnowledgeUnit> {
@@ -420,5 +417,41 @@ export class KnowledgeUnitsService {
 
         this.logger.log(`Cascade deleted KU ${kuId} for user ${uid}: ${JSON.stringify(deleted)}`);
         return { deleted };
+    }
+
+    async migrateGrammarJlptLevel(): Promise<{ migrated: number; skipped: number }> {
+        // Grammar KUs imported from corpus have jlptLevel at top level.
+        // This migrates them to data.jlptLevel to be consistent with Vocab/Kanji.
+        const snap = await this.db
+            .collection(KNOWLEDGE_UNITS_COLLECTION)
+            .where('type', '==', 'Grammar')
+            .get();
+
+        let migrated = 0;
+        let skipped = 0;
+        const BATCH_SIZE = 500;
+
+        const toMigrate = snap.docs.filter(doc => {
+            const d = doc.data();
+            return d.jlptLevel && !d.data?.jlptLevel;
+        });
+
+        for (let i = 0; i < toMigrate.length; i += BATCH_SIZE) {
+            const chunk = toMigrate.slice(i, i + BATCH_SIZE);
+            const batch = this.db.batch();
+            for (const doc of chunk) {
+                const jlptLevel = doc.data().jlptLevel;
+                batch.update(doc.ref, {
+                    'data.jlptLevel': jlptLevel,
+                    jlptLevel: FieldValue.delete(),
+                });
+            }
+            await batch.commit();
+            migrated += chunk.length;
+        }
+
+        skipped = snap.size - migrated;
+        this.logger.log(`migrateGrammarJlptLevel: migrated=${migrated}, skipped=${skipped}`);
+        return { migrated, skipped };
     }
 }

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -257,26 +257,67 @@ export class LessonsService {
       ? this.db.collection(REVIEW_FACETS_COLLECTION).where('userId', '==', uid)
       : this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
 
-    // Exclude KUs the user has already started (has review facets) OR that are already
-    // in their library via a UKU record (scenario-extracted words land here before being taught).
     const [facetsSnap, ukuSnap] = await Promise.all([
       facetsCol.get(),
       this.db.collection('users').doc(uid).collection('user-kus').get(),
     ]);
-    const seenKuIds = new Set([
-      ...facetsSnap.docs.map(d => d.data().kuId as string).filter(Boolean),
-      ...ukuSnap.docs.map(d => d.data().kuId as string).filter(Boolean),
+
+    // Separate facet KU ids from UKU KU ids so we can compute enrolled-but-not-started
+    const facetKuIds = new Set(facetsSnap.docs.map(d => d.data().kuId as string).filter(Boolean));
+    const ukuKuIds = ukuSnap.docs.map(d => d.data().kuId as string).filter(Boolean);
+    const seenKuIds = new Set([...facetKuIds, ...ukuKuIds]);
+
+    // ── Path 1a: Vocab / Kanji corpus ─────────────────────────────────────
+    // ── Path 1b: Grammar corpus ────────────────────────────────────────────
+    // Run separately so Grammar always gets guaranteed slots regardless of
+    // how many Vocab/Kanji items exist at the same JLPT level.
+    const [vocabKanjiSnap, grammarCorpusSnap] = await Promise.all([
+      this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
+        .where('data.jlptLevel', '==', jlptLevel)
+        .where('type', 'in', ['Vocab', 'Kanji'])
+        .limit(200)
+        .get(),
+      this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
+        .where('data.jlptLevel', '==', jlptLevel)
+        .where('type', '==', 'Grammar')
+        .limit(50)
+        .get(),
     ]);
 
-    const kuSnap = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
-      .where('data.jlptLevel', '==', jlptLevel)
-      .limit(200)
-      .get();
-
-    return kuSnap.docs
+    const vocabKanjiItems = vocabKanjiSnap.docs
       .filter(d => !seenKuIds.has(d.id))
-      .slice(0, 10)
+      .slice(0, 7)
       .map(d => ({ kuId: d.id, content: d.data().content as string, type: d.data().type as string }));
+
+    const grammarCorpusItems = grammarCorpusSnap.docs
+      .filter(d => !seenKuIds.has(d.id))
+      .slice(0, 3)
+      .map(d => ({ kuId: d.id, content: d.data().content as string, type: d.data().type as string }));
+
+    // ── Path 2: Enrolled Grammar queue ────────────────────────────────────
+    // Grammar KUs the user enrolled via a scenario (UKU exists) but hasn't
+    // started in review yet (no facets).
+    const enrolledNotStarted = ukuKuIds.filter(id => !facetKuIds.has(id));
+
+    let enrolledGrammarItems: { kuId: string; content: string; type: string }[] = [];
+    if (enrolledNotStarted.length > 0) {
+      const chunk = enrolledNotStarted.slice(0, 30);
+      const enrolledSnap = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION)
+        .where('__name__', 'in', chunk)
+        .get();
+      enrolledGrammarItems = enrolledSnap.docs
+        .filter(d => d.data().type === 'Grammar')
+        .slice(0, 3)
+        .map(d => ({ kuId: d.id, content: d.data().content as string, type: d.data().type as string }));
+    }
+
+    // Enrolled grammar first, then corpus grammar, then vocab/kanji
+    const grammarItems = [
+      ...enrolledGrammarItems,
+      ...grammarCorpusItems.filter(g => !enrolledGrammarItems.some(e => e.kuId === g.kuId)),
+    ].slice(0, 3);
+
+    return [...grammarItems, ...vocabKanjiItems].slice(0, 10);
   }
 
   async processBatch(uid: string, vocabValues: { id: string; content: string }[]) {

--- a/backend/src/prompts/curriculum.ts
+++ b/backend/src/prompts/curriculum.ts
@@ -115,3 +115,21 @@ export const GET_USER_LEVEL_DECLARATION: FunctionDeclaration = {
     required: [],
   },
 };
+
+export const GET_GRAMMAR_PATTERNS_DECLARATION: FunctionDeclaration = {
+  name: 'get_grammar_patterns',
+  description:
+    'Returns the available Grammar KUs in the learner pool for a given JLPT level. ' +
+    'Call this to see which grammar patterns you can reference. ' +
+    'Your grammarMatches MUST only contain kuIds returned by this tool.',
+  parameters: {
+    type: Type.OBJECT,
+    properties: {
+      jlptLevel: {
+        type: Type.STRING,
+        description: 'JLPT level to query (e.g. "N4"). Returns patterns at that level.',
+      },
+    },
+    required: ['jlptLevel'],
+  },
+};

--- a/backend/src/prompts/scenario.prompts.ts
+++ b/backend/src/prompts/scenario.prompts.ts
@@ -47,7 +47,7 @@ Create a "Genki-style" learning scenario for an ADULT traveler/expat (not a stud
 **Requirements:**
 1. **Dialogue:** Create a natural, realistic dialogue (6-12 lines). Use a mix of polite and casual forms appropriate for the setting.
 2. **Vocabulary:** STRICTLY LIMIT vocabulary to ${dto.difficulty} level. Introduce exactly 3-5 "Target Words" required for the specific goal.
-3. **Grammar Notes:** Identify 1-2 key grammar points used in the dialogue and explain them like a textbook (Genki style).
+3. **Grammar Matches:** Call \`get_grammar_patterns("${dto.difficulty}")\` to see the available grammar pool. Identify 1-2 patterns from those results that naturally appear in your dialogue. For each, provide a short example sentence taken directly from the conversation (with fragments for the typing exercise). If no patterns from the pool fit the dialogue, return an empty \`grammarMatches\` array.
 4. **Visual Context:** Provide a descriptive prompt that could be used to generate an image of the scene.
 5. **Role Constraints:**
 ${dto.userRole && dto.aiRole
@@ -64,8 +64,9 @@ ${dto.userRole && dto.aiRole
      - \`reading\`: Kana reading ONLY (e.g., "ほんや"). No Romaji.
      - \`meaning\`: English definition ONLY.
      - \`jlptLevel\`: JLPT level hint for this word (e.g., "N4"). MUST be one of: N5, N4, N3, N2, N1. Use your best judgement for the level of each individual word.
-   - For \`grammarNotes\`:
-     - \`pattern\`: The extractable grammar pattern in isolation (e.g., "～をお願いします", "～ている"). This should be concise and reusable across contexts.
+   - For \`grammarMatches\`:
+     - \`kuId\`: The exact kuId returned by \`get_grammar_patterns\`. Never invent an ID.
+     - \`exampleFromConversation\`: A sentence taken from your dialogue that demonstrates the pattern. Fragments must follow the fragment contract below.
 
 **Output Schema (Return ONLY raw JSON):**
 {
@@ -98,14 +99,12 @@ ${dto.userRole && dto.aiRole
       "jlptLevel": "N4"
     }
   ],
-  "grammarNotes": [
+  "grammarMatches": [
     {
-      "pattern": "The extractable grammar pattern, e.g. ～をお願いします",
-      "title": "Grammar Point Name",
-      "explanation": "Clear explanation",
-      "exampleInContext": {
-        "japanese": "The example sentence in Japanese only, no furigana or Romaji",
-        "english": "The English translation of the example",
+      "kuId": "exact-ku-id-from-tool",
+      "exampleFromConversation": {
+        "japanese": "Sentence from the dialogue in Japanese only, no furigana or Romaji",
+        "english": "English translation of the example",
         "fragments": ["minimal", "meaningful", "chunks", "of", "the", "sentence"],
         "accepted_alternatives": ["array of valid re-orderings or omittable-particle variants, or empty array"]
       }
@@ -113,7 +112,7 @@ ${dto.userRole && dto.aiRole
   ]
 }
 
-**Grammar Note Fragments Rules:**
+**Grammar Match Fragments Rules:**
 - ${FRAGMENT_CONTRACT}
 - ${ACCEPTED_ALTERNATIVES_DEF}
 `;
@@ -210,15 +209,16 @@ ${dto.conversationText}
    - Add an accurate English translation for each line.
 2. **Setting:** Infer location, participants, goal, timeOfDay, and visualPrompt from the conversation.${dto.sceneNotes ? ' Use the provided scene context as your primary guide.' : ''}
 3. **Vocabulary:** Extract 3-5 key vocabulary items the learner needs to participate in this conversation.
-4. **Grammar Notes:** Identify 1-3 grammar patterns used in the conversation and explain them Genki-style.
+4. **Grammar Matches:** Call \`get_grammar_patterns("${dto.difficulty ?? 'N4'}")\` to see the available grammar pool. Identify 1-3 patterns from those results that appear in the conversation. For each, provide a short example sentence from the conversation (with fragments for the typing exercise). If no patterns from the pool fit, return an empty \`grammarMatches\` array.
 5. **Title & Description:** Write a short English title and description for this scenario.
 
 **Data Formatting Rules:**
 - \`title\`, \`description\`, and all \`setting\` fields in English.
 - **NO ROMAJI**. Never include Romaji in any field — including grammar explanations. Write Japanese words in Japanese script (e.g. です, の) not romanised text (e.g. 'desu', 'no').
 - Extracted KUs: \`content\` = Japanese only, \`reading\` = kana only, \`meaning\` = English definition, \`jlptLevel\` = one of N5/N4/N3/N2/N1.
-- Grammar note fragments: ${FRAGMENT_CONTRACT}
+- Grammar match fragments: ${FRAGMENT_CONTRACT}
 - ${ACCEPTED_ALTERNATIVES_DEF}
+- \`grammarMatches[].kuId\`: Must be an exact kuId returned by \`get_grammar_patterns\`. Never invent IDs.
 
 **Output Schema (Return ONLY raw JSON):**
 {
@@ -241,12 +241,10 @@ ${dto.conversationText}
   "extractedKUs": [
     { "content": "本屋", "reading": "ほんや", "meaning": "Bookstore", "type": "vocab", "jlptLevel": "N4" }
   ],
-  "grammarNotes": [
+  "grammarMatches": [
     {
-      "pattern": "～をお願いします",
-      "title": "Grammar Point Name",
-      "explanation": "Clear explanation",
-      "exampleInContext": {
+      "kuId": "exact-ku-id-from-tool",
+      "exampleFromConversation": {
         "japanese": "Example sentence from the conversation",
         "english": "English translation",
         "fragments": ["minimal", "chunks"],

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -15,6 +15,8 @@ import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } 
 import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
 import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildImportPrompt, buildChatSystemPrompt } from '../prompts/scenario.prompts';
+import { GET_GRAMMAR_PATTERNS_DECLARATION } from '../prompts/curriculum';
+import { GrammarMatch } from '../types/scenario';
 
 import { ScenarioTemplate, SCENARIO_TEMPLATES } from './templates';
 
@@ -38,6 +40,33 @@ export class ScenariosService {
       return this.db.collection(SCENARIOS_COLLECTION);
     }
     return this.db.collection('users').doc(uid).collection(SCENARIOS_COLLECTION);
+  }
+
+  private buildGrammarToolHandlers() {
+    return {
+      get_grammar_patterns: async (args: Record<string, unknown>) => {
+        const jlptLevel = (args.jlptLevel as string) || 'N4';
+        const snap = await this.db
+          .collection('knowledge-units')
+          .where('type', '==', 'Grammar')
+          .where('data.jlptLevel', '==', jlptLevel)
+          .limit(60)
+          .get();
+
+        const patterns = snap.docs.map(doc => {
+          const d = doc.data();
+          return {
+            kuId: doc.id,
+            content: d.content as string,
+            title: (d.data as any)?.title ?? '',
+            explanation: (d.data as any)?.explanation ?? '',
+          };
+        });
+
+        this.logger.log(`get_grammar_patterns(${jlptLevel}) → ${patterns.length} patterns`);
+        return { patterns };
+      },
+    };
   }
 
   async getAllScenarios(userId: string, limitDays?: number, state?: string): Promise<Scenario[]> {
@@ -95,8 +124,11 @@ export class ScenariosService {
     const prompt = buildArchitectPrompt(resolvedDto);
 
     try {
-      const jsonString = await this.geminiService.generateScenario(prompt);
-      const data = JSON.parse(jsonString);
+      const data = await this.geminiService.generateScenario(
+        prompt,
+        [GET_GRAMMAR_PATTERNS_DECLARATION],
+        this.buildGrammarToolHandlers(),
+      );
 
       const docRef = this.scenariosColRef(userId).doc();
       const id = docRef.id;
@@ -128,7 +160,7 @@ export class ScenariosService {
           status: 'new',
           jlptLevel: ku.jlptLevel ?? null,
         })),
-        grammarNotes: data.grammarNotes,
+        grammarMatches: Array.isArray(data.grammarMatches) ? data.grammarMatches : [],
         state: 'encounter',
         createdAt: Timestamp.now(),
         chatHistory: [],
@@ -179,7 +211,8 @@ export class ScenariosService {
         status: 'new' as const,
         jlptLevel: ku.jlptLevel ?? null,
       })),
-      grammarNotes: data.grammarNotes ?? [],
+      grammarMatches: Array.isArray(data.grammarMatches) ? data.grammarMatches : [],
+      ...(data.grammarNotes ? { grammarNotes: data.grammarNotes } : {}),
       state: 'encounter' as const,
       createdAt: Timestamp.now(),
       chatHistory: [],
@@ -213,8 +246,11 @@ export class ScenariosService {
     });
 
     try {
-      const jsonString = await this.geminiService.generateScenario(prompt);
-      const data = JSON.parse(jsonString);
+      const data = await this.geminiService.generateScenario(
+        prompt,
+        [GET_GRAMMAR_PATTERNS_DECLARATION],
+        this.buildGrammarToolHandlers(),
+      );
 
       const docRef = this.scenariosColRef(uid).doc();
       const id = docRef.id;
@@ -245,7 +281,7 @@ export class ScenariosService {
           status: 'new',
           jlptLevel: ku.jlptLevel ?? null,
         })),
-        grammarNotes: data.grammarNotes,
+        grammarMatches: Array.isArray(data.grammarMatches) ? data.grammarMatches : [],
         state: 'encounter',
         createdAt: Timestamp.now(),
         chatHistory: [],
@@ -316,11 +352,31 @@ export class ScenariosService {
           updateData.extractedKUs = updatedKUs;
         }
 
-        // Emit Grammar KUs + UKUs + UserGrammarLessons for each grammar note
-        if (scenario.grammarNotes && scenario.grammarNotes.length > 0) {
+        // Link Grammar KUs — prefer grammarMatches (tool-based, exact kuIds) over legacy grammarNotes
+        if (scenario.grammarMatches && scenario.grammarMatches.length > 0) {
+          let linked = 0;
+          for (const match of scenario.grammarMatches) {
+            try {
+              await this.userKnowledgeUnitsService.create(uid, match.kuId, { type: 'scenario', id: scenario.id });
+              await this.lessonsService.createUserGrammarLesson(
+                uid,
+                match.kuId,
+                { sourceType: 'scenario', sourceId: scenario.id, sourceTitle: scenario.title },
+                match.exampleFromConversation,
+              );
+              linked++;
+            } catch (err) {
+              this.logger.error(`Failed to link grammar match kuId="${match.kuId}"`, err);
+            }
+          }
+          this.logger.log(`Grammar matches: linked ${linked}/${scenario.grammarMatches.length} for scenarioId=${scenario.id}`);
+        } else if (scenario.grammarNotes && scenario.grammarNotes.length > 0) {
+          // Legacy path: scenarios created before tool-based matching
+          let matched = 0;
           for (const note of scenario.grammarNotes) {
             try {
               const kuId = await this.knowledgeUnitsService.ensureGrammarKU(note);
+              if (!kuId) continue;
               await this.userKnowledgeUnitsService.create(uid, kuId, { type: 'scenario', id: scenario.id });
               await this.lessonsService.createUserGrammarLesson(
                 uid,
@@ -328,11 +384,12 @@ export class ScenariosService {
                 { sourceType: 'scenario', sourceId: scenario.id, sourceTitle: scenario.title },
                 note.exampleInContext,
               );
+              matched++;
             } catch (err) {
               this.logger.error(`Failed to process grammar note "${note.title}"`, err);
             }
           }
-          this.logger.log(`Processed ${scenario.grammarNotes.length} grammar notes for uid=${uid} scenarioId=${scenario.id}`);
+          this.logger.log(`Grammar notes (legacy): ${matched}/${scenario.grammarNotes.length} matched to pool for scenarioId=${scenario.id}`);
         }
 
         newState = 'drill';

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -42,6 +42,16 @@ export interface GrammarNote {
     };
 }
 
+export interface GrammarMatch {
+    kuId: string;
+    exampleFromConversation: {
+        japanese: string;
+        english: string;
+        fragments: string[];
+        accepted_alternatives: string[];
+    };
+}
+
 export interface ScenarioEvaluation {
     success: boolean;
     rating: number;
@@ -93,7 +103,8 @@ export interface Scenario {
 
     dialogue: ScenarioDialogueLine[];
     extractedKUs: ExtractedKU[];
-    grammarNotes: GrammarNote[];
+    grammarNotes?: GrammarNote[];
+    grammarMatches?: GrammarMatch[];
 
     /** @deprecated - migrating to User state models */
     state: ScenarioState;
@@ -143,7 +154,8 @@ export interface ScenarioTemplate {
     };
     dialogue: ScenarioDialogueLine[];
     extractedKUs: ExtractedKU[];
-    grammarNotes: GrammarNote[];
+    grammarNotes?: GrammarNote[];
+    grammarMatches?: GrammarMatch[];
     roles?: {
         user: string;
         ai: string | string[];

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -29,7 +29,7 @@ function slideCount(loaded: LoadedItem): number {
   if (item.type === "Kanji") return 4;
   if (item.type === "Grammar" && lesson.type === "Grammar") {
     const gl = lesson as GrammarLesson;
-    return 3 + (gl.notes ? 1 : 0);
+    return 2 + (gl.notes ? 1 : 0) + (gl.examples?.length ?? 0);
   }
   return 1;
 }
@@ -126,14 +126,30 @@ function VocabKanjiSlide({ loaded }: { loaded: LoadedItem }) {
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto">
       <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">Building Blocks</span>
-      <div className="text-4xl font-bold text-shodo-ink">{loaded.item.content}</div>
-      <div className="space-y-4">
+
+      {/* The word — framed and centred so it reads as the subject */}
+      <div className="flex justify-center">
+        <div className="px-10 py-4 rounded-xl bg-shodo-paper-dark border border-shodo-ink/10">
+          <span className="text-5xl font-bold text-shodo-ink">{loaded.item.content}</span>
+        </div>
+      </div>
+
+      {/* Visual connector */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-px bg-shodo-ink/10" />
+        <span className="text-xs text-shodo-ink-faint uppercase tracking-widest">made of</span>
+        <div className="flex-1 h-px bg-shodo-ink/10" />
+      </div>
+
+      {/* Component kanji — each in its own card */}
+      <div className="space-y-3">
         {kanji.map((k, i) => (
-          <div key={i} className="flex items-baseline gap-4 border-b border-shodo-ink/5 pb-4 last:border-0 last:pb-0">
-            <span className="text-4xl font-bold text-shodo-stamp-red w-12 shrink-0">{k.kanji}</span>
+          <div key={i} className="flex items-center gap-4 px-4 py-3 rounded-lg bg-shodo-paper-dark">
+            <span className="text-4xl font-bold text-shodo-stamp-red w-14 text-center shrink-0">{k.kanji}</span>
+            <div className="w-px self-stretch bg-shodo-ink/10" />
             <div className="flex flex-col gap-0.5">
-              <span className="text-lg text-shodo-ink">{k.meaning}</span>
-              <span className="text-sm text-shodo-ink-faint">In this word: {k.reading}</span>
+              <span className="text-lg text-shodo-ink font-medium">{k.meaning}</span>
+              <span className="text-sm text-shodo-ink-faint">{k.reading}</span>
             </div>
           </div>
         ))}
@@ -283,22 +299,22 @@ function GrammarMeaningSlide({ loaded }: { loaded: LoadedItem }) {
   );
 }
 
-function GrammarExampleSlide({ loaded }: { loaded: LoadedItem }) {
+function GrammarExampleSlide({ loaded, exampleIdx }: { loaded: LoadedItem; exampleIdx: number }) {
   const gl = loaded.lesson as GrammarLesson;
+  const ex = gl.examples[exampleIdx];
+  if (!ex) return null;
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto">
-      <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">
-        {gl.examples.length > 1 ? `Examples (${gl.examples.length})` : "Example"}
-      </span>
-      <div className="text-4xl font-bold text-shodo-matcha">{gl.pattern}</div>
-      <div className="space-y-6">
-        {gl.examples.slice(0, 2).map((ex, i) => (
-          <div key={i}>
-            <p className="text-2xl text-shodo-ink">{ex.japanese}</p>
-            <p className="text-lg text-shodo-ink-light mt-1">{ex.english}</p>
-          </div>
-        ))}
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">
+          Example {exampleIdx + 1} of {gl.examples.length}
+        </span>
+        {ex.context && (
+          <span className="text-xs text-shodo-ink-faint italic">{ex.context}</span>
+        )}
       </div>
+      <p className="text-3xl text-shodo-ink leading-relaxed">{ex.japanese}</p>
+      <p className="text-xl text-shodo-ink-light mt-2">{ex.english}</p>
     </div>
   );
 }
@@ -336,12 +352,14 @@ function renderSlide(loaded: LoadedItem, slideIdx: number, onAudio: (text: strin
     }
   }
   if (item.type === "Grammar" && lesson.type === "Grammar") {
-    switch (slideIdx) {
-      case 0: return <GrammarPatternSlide loaded={loaded} />;
-      case 1: return <GrammarMeaningSlide loaded={loaded} />;
-      case 2: return <GrammarExampleSlide loaded={loaded} />;
-      case 3: return <GrammarNotesSlide loaded={loaded} />;
-    }
+    const gl = lesson as GrammarLesson;
+    let s = slideIdx;
+    if (s === 0) return <GrammarPatternSlide loaded={loaded} />;
+    s--;
+    if (s === 0) return <GrammarMeaningSlide loaded={loaded} />;
+    s--;
+    if (gl.notes) { if (s === 0) return <GrammarNotesSlide loaded={loaded} />; s--; }
+    if (s < gl.examples.length) return <GrammarExampleSlide loaded={loaded} exampleIdx={s} />;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
                                                                                                                         
  - **Grammar in lesson queue**: `LessonsService.getQueue` now runs two separate parallel corpus queries — Vocab/Kanji   
  (up to 7 slots) and Grammar (up to 3 dedicated slots) — so Grammar KUs are no longer crowded out.                      
  Enrolled-but-not-started Grammar from `user-kus` fills Grammar slots first, then the corpus tops up.                   
  - **Tool-based grammar matching for scenarios**: Scenario generation (both generate and import) now uses a             
  `get_grammar_patterns(jlptLevel)` Gemini tool. The AI receives real `kuId` values from the Grammar pool and returns    
  `grammarMatches: [{kuId, exampleFromConversation}]` instead of free-text `grammarNotes`. `advanceState` uses the exact 
  `kuId` directly with a fallback legacy path for scenarios created before this change.                                  
  - **Grammar lesson slides**: Lesson session now supports Grammar KUs. Slide sequence is dynamic: Pattern → Meaning →   
  Notes (if present) → one slide per example.                                                                         
  - **Grammar KU data normalisation**: Imported Grammar KUs had `jlptLevel` at document root instead of `data.jlptLevel`.
   Migration endpoint (`POST /api/knowledge-units/migrate/grammar-jlpt-level`) corrected 333 records.       