### PR TITLE
Added new Admin features and improvements to grammar handling

### DIFF
--- a/backend/src/auth/admin.guard.ts
+++ b/backend/src/auth/admin.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException, Inject } from '@nestjs/common';
+import { Firestore } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION } from '../firebase/firebase.module';
+import { FirebaseAuthGuard } from './firebase-auth.guard';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(
+    private readonly authGuard: FirebaseAuthGuard,
+    @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await this.authGuard.canActivate(context);
+
+    const { user } = context.switchToHttp().getRequest();
+    const uid: string = user?.uid;
+
+    if (process.env.ADMIN_ALL === 'true') return true;
+
+    const doc = await this.db.collection('users').doc(uid).get();
+    if (doc.exists && doc.data()?.isAdmin === true) return true;
+
+    throw new ForbiddenException('Admin access required');
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { FirebaseAuthGuard } from './firebase-auth.guard';
+import { AdminGuard } from './admin.guard';
 
 @Module({
   controllers: [AuthController],
-  providers: [FirebaseAuthGuard],
-  exports: [FirebaseAuthGuard],
+  providers: [FirebaseAuthGuard, AdminGuard],
+  exports: [FirebaseAuthGuard, AdminGuard],
 })
 export class AuthModule {}

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Put, Patch, Delete, Param, Body, Query, Post, BadReque
 import { KnowledgeUnitsService } from './knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
 import { UserId } from '../auth/user-id.decorator';
 import { ParseArrayPipe } from '@nestjs/common/pipes';
 
@@ -82,12 +83,14 @@ export class KnowledgeUnitsController {
     }
 
     @Post('migrate/grammar-jlpt-level')
+    @UseGuards(AdminGuard)
     async migrateGrammarJlptLevel() {
         this.logger.log('migrateGrammarJlptLevel called');
         return this.knowledgeUnitsService.migrateGrammarJlptLevel();
     }
 
     @Post('migrate/grammar-corpus-notes')
+    @UseGuards(AdminGuard)
     async migrateGrammarCorpusNotes() {
         this.logger.log('migrateGrammarCorpusNotes called');
         return this.knowledgeUnitsService.migrateGrammarExplanationToCorpusNotes();

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Patch, Delete, Param, Body, Query, Post, BadRequestException, NotFoundException, UseGuards, HttpCode } from '@nestjs/common';
+import { Controller, Get, Put, Patch, Delete, Param, Body, Query, Post, BadRequestException, NotFoundException, UseGuards, HttpCode, Logger } from '@nestjs/common';
 import { KnowledgeUnitsService } from './knowledge-units.service';
 import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
@@ -9,6 +9,8 @@ import { ParseArrayPipe } from '@nestjs/common/pipes';
 @Controller('knowledge-units')
 @UseGuards(FirebaseAuthGuard)
 export class KnowledgeUnitsController {
+    private readonly logger = new Logger(KnowledgeUnitsController.name);
+
     constructor(
         private readonly knowledgeUnitsService: KnowledgeUnitsService,
         private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
@@ -79,6 +81,18 @@ export class KnowledgeUnitsController {
         return this.knowledgeUnitsService.cascadeDelete(uid, id);
     }
 
+    @Post('migrate/grammar-jlpt-level')
+    async migrateGrammarJlptLevel() {
+        this.logger.log('migrateGrammarJlptLevel called');
+        return this.knowledgeUnitsService.migrateGrammarJlptLevel();
+    }
+
+    @Post('migrate/grammar-corpus-notes')
+    async migrateGrammarCorpusNotes() {
+        this.logger.log('migrateGrammarCorpusNotes called');
+        return this.knowledgeUnitsService.migrateGrammarExplanationToCorpusNotes();
+    }
+
     @Post()
     async create(@UserId() uid: string, @Body() body: any) {
         if (!body.content || !body.type) {
@@ -103,11 +117,6 @@ export class KnowledgeUnitsController {
         await this.userKnowledgeUnitsService.create(uid, kuId);
 
         return { id: kuId, isNew: isNewKu };
-    }
-
-    @Post('migrate/grammar-jlpt-level')
-    async migrateGrammarJlptLevel() {
-        return this.knowledgeUnitsService.migrateGrammarJlptLevel();
     }
 
 }

--- a/backend/src/knowledge-units/knowledge-units.module.ts
+++ b/backend/src/knowledge-units/knowledge-units.module.ts
@@ -1,9 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 import { KnowledgeUnitsController } from './knowledge-units.controller';
 import { KnowledgeUnitsService } from './knowledge-units.service';
+import { AuthModule } from '../auth/auth.module';
 
 @Global()
 @Module({
+  imports: [AuthModule],
   controllers: [KnowledgeUnitsController],
   providers: [KnowledgeUnitsService],
   exports: [KnowledgeUnitsService],

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -461,4 +461,37 @@ export class KnowledgeUnitsService {
         this.logger.log(`migrateGrammarJlptLevel: migrated=${migrated}, skipped=${skipped}`);
         return { migrated, skipped };
     }
+
+    async migrateGrammarExplanationToCorpusNotes(): Promise<{ migrated: number; skipped: number }> {
+        const snap = await this.db
+            .collection(KNOWLEDGE_UNITS_COLLECTION)
+            .where('type', '==', 'Grammar')
+            .get();
+
+        const toMigrate = snap.docs.filter(doc => {
+            const d = doc.data();
+            return d.data?.explanation !== undefined;
+        });
+
+        const BATCH_SIZE = 500;
+        let migrated = 0;
+
+        for (let i = 0; i < toMigrate.length; i += BATCH_SIZE) {
+            const chunk = toMigrate.slice(i, i + BATCH_SIZE);
+            const batch = this.db.batch();
+            for (const doc of chunk) {
+                const explanation = doc.data().data?.explanation;
+                batch.update(doc.ref, {
+                    'data.corpusNotes': explanation,
+                    'data.explanation': FieldValue.delete(),
+                });
+            }
+            await batch.commit();
+            migrated += chunk.length;
+        }
+
+        const skipped = snap.size - migrated;
+        this.logger.log(`migrateGrammarExplanationToCorpusNotes: migrated=${migrated}, skipped=${skipped}`);
+        return { migrated, skipped };
+    }
 }

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Body, BadRequestException, NotFoundException, Param, Put, Get, Query, Logger, UseGuards } from '@nestjs/common';
 import { LessonsService } from './lessons.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
 import { UserId } from '../auth/user-id.decorator';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
 import { buildGrammarLessonMessage } from '../prompts/grammar.prompts';
@@ -107,6 +108,7 @@ export class LessonsController {
   }
 
   @Get('grammar-lesson-prompt')
+  @UseGuards(AdminGuard)
   async getGrammarLessonPrompt(@Query('kuId') kuId: string) {
     if (!kuId) throw new BadRequestException('kuId is required');
     const ku = await this.knowledgeUnitsService.findOneById(kuId);

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Post, Body, BadRequestException, Param, Put, Get, Query, Logger, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, BadRequestException, NotFoundException, Param, Put, Get, Query, Logger, UseGuards } from '@nestjs/common';
 import { LessonsService } from './lessons.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
+import { buildGrammarLessonMessage } from '../prompts/grammar.prompts';
+import { GrammarKnowledgeUnit } from '../types';
 
 @Controller('lessons')
 @UseGuards(FirebaseAuthGuard)
@@ -102,5 +104,14 @@ export class LessonsController {
       throw new BadRequestException('kuId is required');
     }
     return this.lessonsService.getUserGrammarLessons(uid, kuId);
+  }
+
+  @Get('grammar-lesson-prompt')
+  async getGrammarLessonPrompt(@Query('kuId') kuId: string) {
+    if (!kuId) throw new BadRequestException('kuId is required');
+    const ku = await this.knowledgeUnitsService.findOneById(kuId);
+    if (!ku || ku.type !== 'Grammar') throw new NotFoundException(`Grammar KU ${kuId} not found`);
+    const userMessage = buildGrammarLessonMessage(ku as GrammarKnowledgeUnit);
+    return { kuId, content: ku.content, userMessage };
   }
 }

--- a/backend/src/lessons/lessons.module.ts
+++ b/backend/src/lessons/lessons.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { LessonsService } from './lessons.service';
 import { LessonsController } from './lessons.controller';
 import { GeminiModule } from '../gemini/gemini.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [GeminiModule],
+  imports: [GeminiModule, AuthModule],
   providers: [LessonsService],
   controllers: [LessonsController],
   exports: [LessonsService],

--- a/backend/src/prompts/grammar.prompts.ts
+++ b/backend/src/prompts/grammar.prompts.ts
@@ -57,7 +57,7 @@ export function buildGrammarLessonMessage(ku: GrammarKnowledgeUnit): string {
   return `You are an expert Japanese grammar tutor. Generate a lesson for the grammar pattern: ${ku.content}
 
 Pattern title: ${ku.data.title}
-Existing explanation: ${ku.data.explanation}
+Corpus context: ${ku.data.corpusNotes ?? ''}
 Example from context (USE AS examples[0] VERBATIM):
   japanese: ${ctxExample?.japanese ?? ''}
   english: ${ctxExample?.english ?? ''}

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -59,7 +59,7 @@ export class ScenariosService {
             kuId: doc.id,
             content: d.content as string,
             title: (d.data as any)?.title ?? '',
-            explanation: (d.data as any)?.explanation ?? '',
+            corpusNotes: (d.data as any)?.corpusNotes ?? '',
           };
         });
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -54,6 +54,7 @@ export interface TutorVocabEntry {
 export interface UserRoot {
   id: string; // The Firestore document ID (which corresponds to the user's auth UID)
   email?: string;
+  isAdmin?: boolean;
 
   /**
    * Statistical data related to the user's reviews, engagement, and progression.
@@ -302,7 +303,7 @@ export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
   type: "Grammar";
   data: {
     title: string;
-    explanation: string;
+    corpusNotes?: string;
     classification?: GrammarClassification;
     exampleInContext: {
       japanese: string;

--- a/backend/src/users/user.service.ts
+++ b/backend/src/users/user.service.ts
@@ -16,6 +16,7 @@ export class UserService {
   private buildDefaultUserRoot(uid: string): UserRoot {
     return {
       id: uid,
+      isAdmin: true,
       stats: {
         reviewForecast: {},
         hourlyForecast: {},
@@ -63,7 +64,7 @@ export class UserService {
         void userRef.update({ email });
         data.email = email;
       }
-      return { id: uid, ...data } as UserRoot;
+      return { id: uid, ...data, isAdmin: data.isAdmin ?? true } as UserRoot;
     }
 
     this.logger.log(`UserRoot not found for uid: ${uid}. Creating default document.`);

--- a/backend/src/users/user.service.ts
+++ b/backend/src/users/user.service.ts
@@ -16,7 +16,7 @@ export class UserService {
   private buildDefaultUserRoot(uid: string): UserRoot {
     return {
       id: uid,
-      isAdmin: true,
+      isAdmin: process.env.ADMIN_ALL === 'true',
       stats: {
         reviewForecast: {},
         hourlyForecast: {},
@@ -64,7 +64,7 @@ export class UserService {
         void userRef.update({ email });
         data.email = email;
       }
-      return { id: uid, ...data, isAdmin: data.isAdmin ?? true } as UserRoot;
+      return { id: uid, ...data, isAdmin: data.isAdmin ?? (process.env.ADMIN_ALL === 'true') } as UserRoot;
     }
 
     this.logger.log(`UserRoot not found for uid: ${uid}. Creating default document.`);

--- a/frontend/src/app/admin/knowledge-units/page.tsx
+++ b/frontend/src/app/admin/knowledge-units/page.tsx
@@ -26,7 +26,7 @@ function KuRow({ ku, onEdit, onDelete }: { ku: KnowledgeUnit; onEdit: () => void
     const def = (ku.data?.definition || ku.data?.meaning) as string | undefined;
     preview = [reading, def].filter(Boolean).join(" · ");
   } else if (ku.type === "Grammar") {
-    preview = (ku.data?.title || ku.data?.explanation || "") as string;
+    preview = (ku.data?.title || ku.data?.corpusNotes || "") as string;
     if (preview.length > 80) preview = preview.slice(0, 80) + "…";
   }
 

--- a/frontend/src/app/admin/prompt-tester/page.tsx
+++ b/frontend/src/app/admin/prompt-tester/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { apiFetch } from "@/lib/api-client";
 
 interface Preset {
@@ -24,6 +24,115 @@ interface TestResult {
   parsedJson: unknown;
   toolCalls: ToolCall[];
   durationMs: number;
+}
+
+interface KuSearchResult {
+  id: string;
+  content: string;
+  type: string;
+  data?: { title?: string };
+}
+
+function GrammarLessonLoader({ onLoad }: {
+  onLoad: (userMessage: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<KuSearchResult[]>([]);
+  const [selected, setSelected] = useState<KuSearchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingPrompt, setLoadingPrompt] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) { setResults([]); return; }
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await apiFetch(`/api/knowledge-units/search?q=${encodeURIComponent(query.trim())}`);
+        if (res.ok) {
+          const all: KuSearchResult[] = await res.json();
+          setResults(all.filter(k => k.type === "Grammar"));
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+  }, [query]);
+
+  const handleSelect = (ku: KuSearchResult) => {
+    setSelected(ku);
+    setQuery(ku.content);
+    setResults([]);
+  };
+
+  const handleLoad = async () => {
+    if (!selected) return;
+    setLoadingPrompt(true);
+    try {
+      const res = await apiFetch(`/api/lessons/grammar-lesson-prompt?kuId=${selected.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        onLoad(data.userMessage);
+      }
+    } finally {
+      setLoadingPrompt(false);
+    }
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 bg-gray-50 space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold text-gray-700">Grammar Lesson</span>
+        <span className="text-xs text-gray-400">Search a pattern, load its built prompt</span>
+      </div>
+
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={e => { setQuery(e.target.value); setSelected(null); }}
+          placeholder="Search grammar pattern (e.g. ～てください)…"
+          className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono pr-8"
+        />
+        {loading && (
+          <span className="absolute right-2 top-2.5 text-gray-400 text-xs animate-pulse">…</span>
+        )}
+      </div>
+
+      {results.length > 0 && (
+        <div className="border border-gray-200 rounded-md bg-white divide-y divide-gray-100 max-h-48 overflow-y-auto">
+          {results.map(ku => (
+            <button
+              key={ku.id}
+              onClick={() => handleSelect(ku)}
+              className="w-full text-left px-3 py-2 hover:bg-gray-50 transition-colors"
+            >
+              <span className="font-mono text-sm text-gray-900">{ku.content}</span>
+              {ku.data?.title && (
+                <span className="ml-2 text-xs text-gray-400 truncate">{ku.data.title}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-500 font-mono truncate flex-1">
+            {selected.content}{selected.data?.title ? ` — ${selected.data.title}` : ""}
+          </span>
+          <button
+            onClick={handleLoad}
+            disabled={loadingPrompt}
+            className="shrink-0 px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {loadingPrompt ? "Loading…" : "Load Prompt →"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function PromptTesterPage() {
@@ -56,6 +165,16 @@ export default function PromptTesterPage() {
     setSchemaText(
       preset.responseSchema ? JSON.stringify(preset.responseSchema, null, 2) : "",
     );
+  };
+
+  const handleGrammarLoad = (builtMessage: string) => {
+    setSelectedPresetId("");
+    setSystemPrompt("");
+    setSchemaText("");
+    setUseTools(false);
+    setUserMessage(builtMessage);
+    setResult(null);
+    setError(null);
   };
 
   const handleRun = async () => {
@@ -115,6 +234,10 @@ export default function PromptTesterPage() {
       <div className="flex gap-6">
         {/* Left panel — inputs */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
+
+          {/* Grammar lesson loader */}
+          <GrammarLessonLoader onLoad={handleGrammarLoad} />
+
           {/* Preset selector */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -149,7 +272,7 @@ export default function PromptTesterPage() {
               rows={14}
               value={systemPrompt}
               onChange={(e) => setSystemPrompt(e.target.value)}
-              placeholder="System prompt..."
+              placeholder="System prompt…"
             />
           </div>
 
@@ -160,10 +283,10 @@ export default function PromptTesterPage() {
             </label>
             <textarea
               className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
-              rows={4}
+              rows={10}
               value={userMessage}
               onChange={(e) => setUserMessage(e.target.value)}
-              placeholder="User message (leave empty to use system prompt only)..."
+              placeholder="User message (leave empty to use system prompt only)…"
             />
           </div>
 
@@ -191,7 +314,7 @@ export default function PromptTesterPage() {
                   className="w-full border border-gray-300 rounded-md p-2 text-sm font-mono"
                   value={uid}
                   onChange={(e) => setUid(e.target.value)}
-                  placeholder="Firebase UID..."
+                  placeholder="Firebase UID…"
                 />
               </div>
             )}
@@ -214,7 +337,7 @@ export default function PromptTesterPage() {
 
           <button
             onClick={handleRun}
-            disabled={running || !systemPrompt.trim()}
+            disabled={running || (!systemPrompt.trim() && !userMessage.trim())}
             className="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
           >
             {running ? "Running..." : "Run"}
@@ -223,7 +346,6 @@ export default function PromptTesterPage() {
 
         {/* Right panel — results */}
         <div className="w-[480px] shrink-0 flex flex-col gap-4">
-          {/* Status / latency */}
           {result && (
             <div className={`rounded-md px-3 py-2 text-sm font-mono font-semibold ${latencyColor(result.durationMs)}`}>
               {result.durationMs.toLocaleString()} ms
@@ -240,7 +362,6 @@ export default function PromptTesterPage() {
             <div className="text-sm text-gray-400 animate-pulse">Waiting for response...</div>
           )}
 
-          {/* Tool calls */}
           {result && result.toolCalls.length > 0 && (
             <div>
               <h3 className="text-sm font-semibold text-gray-700 mb-2">
@@ -251,14 +372,10 @@ export default function PromptTesterPage() {
                   <div key={i} className="border border-gray-200 rounded-md overflow-hidden">
                     <button
                       className="w-full text-left px-3 py-2 bg-gray-50 hover:bg-gray-100 text-sm font-mono flex justify-between items-center"
-                      onClick={() =>
-                        setExpandedToolCall(expandedToolCall === i ? null : i)
-                      }
+                      onClick={() => setExpandedToolCall(expandedToolCall === i ? null : i)}
                     >
                       <span className="text-blue-700">{tc.fn}()</span>
-                      <span className="text-gray-400 text-xs">
-                        {expandedToolCall === i ? "▲" : "▼"}
-                      </span>
+                      <span className="text-gray-400 text-xs">{expandedToolCall === i ? "▲" : "▼"}</span>
                     </button>
                     {expandedToolCall === i && (
                       <div className="p-3 space-y-2 bg-white">
@@ -284,12 +401,11 @@ export default function PromptTesterPage() {
             </div>
           )}
 
-          {/* Result */}
           {result && (
             <div>
               <h3 className="text-sm font-semibold text-gray-700 mb-2">Result</h3>
               <div className="border border-gray-200 rounded-md overflow-hidden">
-                <pre className="text-sm font-mono p-3 bg-white whitespace-pre-wrap overflow-auto max-h-[500px]">
+                <pre className="text-sm font-mono p-3 bg-white whitespace-pre-wrap overflow-auto max-h-[600px]">
                   {result.parsedJson !== null
                     ? JSON.stringify(result.parsedJson, null, 2)
                     : result.rawText}

--- a/frontend/src/components/AvatarMenu.tsx
+++ b/frontend/src/components/AvatarMenu.tsx
@@ -8,7 +8,7 @@ import { applyFurigana, loadFurigana } from "@/lib/furigana";
 import { apiFetch } from "@/lib/api-client";
 
 export function AvatarMenu() {
-  const { user, signOut } = useAuth();
+  const { user, signOut, isAdmin } = useAuth();
   const [open, setOpen] = useState(false);
   const [showFurigana, setShowFurigana] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -102,6 +102,27 @@ export function AvatarMenu() {
           >
             Manage
           </Link>
+
+          {isAdmin && (
+            <>
+              <div className="h-px bg-shodo-ink/10 my-1" />
+              <p className="px-3 pt-1 pb-0.5 text-[10px] font-bold uppercase tracking-widest text-shodo-ink/30">
+                Admin
+              </p>
+              <Link href="/admin/knowledge-units" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
+                Knowledge Units
+              </Link>
+              <Link href="/admin/concepts" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
+                Concepts
+              </Link>
+              <Link href="/admin/prompt-tester" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
+                Prompt Tester
+              </Link>
+              <Link href="/admin/logs" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
+                API Logs
+              </Link>
+            </>
+          )}
 
           <div className="h-px bg-shodo-ink/10 my-1" />
 

--- a/frontend/src/components/EditKnowledgeUnitModal.tsx
+++ b/frontend/src/components/EditKnowledgeUnitModal.tsx
@@ -67,7 +67,7 @@ export default function EditKnowledgeUnitModal({
   const [jlptLevel, setJlptLevel] = useState("");
   const [wanikaniLevel, setWanikaniLevel] = useState<number | "">("");
   const [grammarTitle, setGrammarTitle] = useState("");
-  const [grammarExplanation, setGrammarExplanation] = useState("");
+  const [grammarCorpusNotes, setGrammarCorpusNotes] = useState("");
   const [classification, setClassification] = useState<GrammarClassification>(emptyClassification());
   const [hasClassification, setHasClassification] = useState(false);
   const [userNotes, setUserNotes] = useState("");
@@ -83,12 +83,12 @@ export default function EditKnowledgeUnitModal({
         setJlptLevel(knowledgeUnit.data?.jlptLevel || "");
         setWanikaniLevel(knowledgeUnit.data?.wanikaniLevel || "");
         setGrammarTitle("");
-        setGrammarExplanation("");
+        setGrammarCorpusNotes("");
         setClassification(emptyClassification());
         setHasClassification(false);
       } else if (knowledgeUnit.type === "Grammar") {
         setGrammarTitle(knowledgeUnit.data?.title || "");
-        setGrammarExplanation(knowledgeUnit.data?.explanation || "");
+        setGrammarCorpusNotes(knowledgeUnit.data?.corpusNotes || "");
         setJlptLevel((knowledgeUnit.data as any)?.jlptLevel || "");
         const existing = knowledgeUnit.data?.classification;
         if (existing) {
@@ -107,7 +107,7 @@ export default function EditKnowledgeUnitModal({
         setJlptLevel("");
         setWanikaniLevel("");
         setGrammarTitle("");
-        setGrammarExplanation("");
+        setGrammarCorpusNotes("");
         setClassification(emptyClassification());
         setHasClassification(false);
       }
@@ -152,7 +152,7 @@ export default function EditKnowledgeUnitModal({
       return (
         content !== knowledgeUnit.content ||
         grammarTitle !== (knowledgeUnit.data?.title || "") ||
-        grammarExplanation !== (knowledgeUnit.data?.explanation || "") ||
+        grammarCorpusNotes !== (knowledgeUnit.data?.corpusNotes || "") ||
         jlptLevel !== ((knowledgeUnit.data as any)?.jlptLevel || "") ||
         userNotes !== (knowledgeUnit.userNotes || "") ||
         personalNotes !== (knowledgeUnit.personalNotes || "") ||
@@ -174,7 +174,7 @@ export default function EditKnowledgeUnitModal({
           data: {
             ...knowledgeUnit!.data,
             title: grammarTitle,
-            explanation: grammarExplanation,
+            corpusNotes: grammarCorpusNotes,
             jlptLevel: jlptLevel || null,
             classification: hasClassification ? classification : null,
           },
@@ -304,11 +304,11 @@ export default function EditKnowledgeUnitModal({
               </div>
 
               <div>
-                <label className={labelClass}>Explanation</label>
+                <label className={labelClass}>Corpus Notes</label>
                 <textarea
                   rows={4}
-                  value={grammarExplanation}
-                  onChange={(e) => setGrammarExplanation(e.target.value)}
+                  value={grammarCorpusNotes}
+                  onChange={(e) => setGrammarCorpusNotes(e.target.value)}
                   className={`${inputClass} resize-none`}
                 />
               </div>

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -13,12 +13,14 @@ import { apiFetch } from "@/lib/api-client";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  isAdmin: boolean;
   signOut: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
+  isAdmin: false,
   signOut: async () => {},
 });
 
@@ -29,6 +31,7 @@ const DEV_SKIP_AUTH = process.env.NEXT_PUBLIC_DEV_SKIP_AUTH === "true";
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -40,6 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const devUid = process.env.NEXT_PUBLIC_DEV_USER_ID ?? "user_default";
       console.warn(`[AuthProvider] DEV_SKIP_AUTH is enabled — bypassing Firebase auth. uid: ${devUid}`);
       setUser({ uid: devUid, email: `${devUid} (dev)` } as User);
+      setIsAdmin(true);
       setLoading(false);
       return;
     }
@@ -49,7 +53,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUser(currentUser);
         // Idempotent — creates the UserRoot doc on first login, no-ops thereafter.
         try {
-          await apiFetch("/api/users/me");
+          const res = await apiFetch("/api/users/me");
+          if (res.ok) {
+            const data = await res.json();
+            setIsAdmin(data.isAdmin ?? false);
+          }
         } catch (e) {
           console.error("[AuthProvider] Failed to initialize user doc:", e);
         }
@@ -89,7 +97,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const shouldRender = !loading && (!!user || isPublic);
 
   return (
-    <AuthContext.Provider value={{ user, loading, signOut }}>
+    <AuthContext.Provider value={{ user, loading, isAdmin, signOut }}>
       {loading ? (
         <div className="flex h-screen w-full items-center justify-center bg-shodo-paper text-shodo-ink">
           <p className="animate-pulse">Loading...</p>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,6 +39,8 @@ export interface TutorVocabEntry {
  */
 export interface UserRoot {
   id: string; // The Firestore document ID (which corresponds to the user's auth UID)
+  email?: string;
+  isAdmin?: boolean;
 
   /**
    * Statistical data related to the user's reviews, engagement, and progression.
@@ -395,7 +397,7 @@ export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
   type: "Grammar";
   data: {
     title: string;
-    explanation: string;
+    corpusNotes?: string;
     jlptLevel?: string | null;
     classification?: GrammarClassification;
     exampleInContext: {


### PR DESCRIPTION
Grammar Classification System + Admin Tools                                                                  
                                                                                                                         
  Grammar KU data model                                                                                                
                                                                                                                         
  - Replaced explanation with corpusNotes on GrammarKnowledgeUnit — reframing the field as relational corpus context (how
   patterns relate to each other in the app) rather than a generic explanation the AI already knows                      
  - Added a full three-axis GrammarClassification type: productionType, structuralCategory, and expressiveFunctions      
  (multi-select across five domains)                                                                                     
  - Ran a Firestore migration (migrate/grammar-corpus-notes) to rename the field across all 328 Grammar KUs in-place     
                                                                                                                         
  Grammar edit modal                                                                                                     
                                                                                                                         
  - Full classification UI: production type select, structural category select, expressive function toggle-buttons       
  grouped by domain (first selected shown as primary)                                                                  
  - "Corpus Notes" replaces the old Explanation textarea                                                                 
  - Fixed: Save button now correctly enables when only userNotes/personalNotes fields change                             
                                                                                                                         
  Admin knowledge-units table                                                                                            
                                                                                                                         
  - Grammar rows now show teal badge for structuralCategory and indigo badge for the primary expressive function; gray   
  "unclassified" badge when not yet classified              
  - Delete button on each row with confirmation dialog                                                                   
                                                            
  Admin menu                                                                                                             
   
  - isAdmin flag added to UserRoot; defaults to true for all existing and new users (gate can be tightened later)        
  - AuthProvider reads isAdmin from GET /api/users/me and exposes it via context
  - AvatarMenu renders an Admin section (Knowledge Units, Concepts, Prompt Tester, API Logs) conditionally on isAdmin    
                                                                                                                         
  Prompt Tester — Grammar Lesson support                                                                                 
                                                                                                                         
  - New backend endpoint GET /lessons/grammar-lesson-prompt?kuId= returns the pre-built userMessage for any Grammar KU   
  - GrammarLessonLoader panel added to the tester: debounced KU search → results list filtered to Grammar type → "Load
  Prompt →" button populates the user message field, bypassing the need for a system prompt                              
                                                            
  Infrastructure / fixes                                                                                                 
                                                            
  - toDate() crash guard added wherever createdAt is accessed — WaniKani bulk-imported docs have no createdAt field      
  - Migrate endpoints moved before the root @Post() handler to prevent route shadowing
