### PR TITLE
fix: address data model anomalies

### DIFF
--- a/DATA-MODEL.md
+++ b/DATA-MODEL.md
@@ -1,0 +1,226 @@
+# AIGENKI Data Model
+
+Entity-relationship diagram for all Firestore collections.
+Global collections are independent of any user. Per-user collections live under `users/{uid}/`.
+
+---
+
+## Diagram
+
+```mermaid
+erDiagram
+
+    %% ═══════════════════════════════════════════════════════
+    %% GLOBAL COLLECTIONS
+    %% ═══════════════════════════════════════════════════════
+
+    KnowledgeUnit {
+        string id PK
+        string content       "canonical identifier: pattern (Grammar), word (Vocab/Kanji)"
+        string type          "Vocab | Kanji | Grammar | ExampleSentence"
+        string data_title    "Grammar only"
+        string data_corpusNotes "Grammar only — AI prompt context, not lesson content"
+        string data_jlptLevel   "Grammar only — MISSING from backend type, present in frontend type"
+        object data_classification "Grammar only — hand-authored, never AI-generated"
+        object data_exampleInContext "Grammar only — seed for lesson generation"
+        string data_reading      "Vocab only"
+        string data_definition   "Vocab only"
+        string data_conjugationType "Vocab only"
+        number data_wanikaniLevel "Vocab/Kanji"
+        string data_meaning  "Kanji only"
+    }
+
+    Concept {
+        string id PK
+        string content
+        string data_title
+        string data_overview
+        string data_reading  "optional kana reading of title"
+        array  data_mechanics
+        array  data_examples
+    }
+
+    Lesson {
+        string kuId PK       "= KnowledgeUnit.id — one lesson per KU"
+        string type          "Vocab | Kanji | Grammar"
+        string pattern       "Grammar — overridden with KU.content at read time"
+        string title         "Grammar — overridden with KU.data.title at read time"
+        string notes         "Grammar — editable; admin writes to global doc, users to overlay"
+        string formation     "Grammar — string or string[]"
+        array  examples      "Grammar"
+        string reading       "Vocab"
+        array  definitions   "Vocab"
+        array  context_examples "Vocab"
+        array  component_kanji  "Vocab"
+        string classification "Grammar — should NOT be here; classification is KU-level only"
+    }
+
+    Question {
+        string id PK
+        string kuId             "FK → KnowledgeUnit.id OR Concept.id (POLYMORPHIC)"
+        string sourceCollection "knowledge-units | concepts | scenarios — optional, absent on old docs"
+        number rank             "0–100, starts 50, suitable threshold 30"
+        number rejectionCount
+    }
+
+    %% ═══════════════════════════════════════════════════════
+    %% PER-USER  (users/{uid}/...)
+    %% ═══════════════════════════════════════════════════════
+
+    UserRoot {
+        string uid PK        "= Firebase Auth UID"
+        string email
+        boolean isAdmin
+        object  stats        "reviewForecast, streak, totals, levelProgress"
+        object  tutorContext "frontierVocab, leechVocab, allowedGrammar, weakGrammarPoints, currentCurriculumNode"
+        object  preferences  "showFurigana, jlptLevel, preferredUserRole"
+    }
+
+    UserKnowledgeUnit {
+        string kuId PK       "= KnowledgeUnit.id"
+        string status        "learning | reviewing | mastered — owned by LearningProgressService"
+        number facet_count
+        string source_type   "scenario | lesson"
+        string source_id     "FK → Scenario.id OR Lesson.kuId"
+    }
+
+    ReviewFacet {
+        string id PK
+        string kuId             "FK — collection varies; use sourceCollection to resolve"
+        string sourceCollection "knowledge-units | concepts | scenarios — optional, absent on old docs; use resolveKuCollection() helper"
+        string facetType
+        number srsStage         "0–8"
+        timestamp nextReviewAt
+        number consecutiveFailures
+        string currentQuestionId "FK → Question.id"
+        string source_type      "lesson | concept — MISSING: scenario"
+        string source_id
+        boolean selfCertified
+        object data             "facet-type-specific payload"
+    }
+
+    Scenario {
+        string id PK
+        string sourceKuId    "FK → KnowledgeUnit.id (optional)"
+        string state         "encounter | drill | simulate | completed"
+        array  grammarMatches "kuId refs FK → KnowledgeUnit.id (Grammar) — AI-generated, UNVALIDATED"
+        array  extractedKUs  "kuId refs FK → KnowledgeUnit.id"
+        boolean vocabReady
+        object  roles
+        object  progress     "keyed by ScenarioDifficulty (N5..N1)"
+    }
+
+    UserGrammarLesson {
+        string id PK         "= {kuId}_{sourceType}_{sourceId} (deterministic)"
+        string kuId          "FK → KnowledgeUnit.id (Grammar type only)"
+        string sourceType    "scenario | concept"
+        string sourceId      "FK → Scenario.id OR Concept.id"
+        object contextExample "japanese, english, fragments, accepted_alternatives"
+    }
+
+    UserLessonOverlay {
+        string kuId PK       "= KnowledgeUnit.id — merged on top of Lesson at read time"
+        string notes         "Grammar: overrides Lesson.notes"
+        string meaning_explanation "Vocab: overrides Lesson field"
+    }
+
+    UserQuestionState {
+        string questionId PK "FK → Question.id"
+        string kuId          "denormalized from Question.kuId"
+        boolean rejected
+        number  consecutiveFailures
+    }
+
+    UserConcept {
+        string id PK
+        string conceptId     "FK → Concept.id"
+        timestamp startedAt
+        number facetCount
+    }
+
+    FeedItem {
+        string id PK
+        string type          "review | learn | leech-repair"
+        string targetId      "FK → ReviewFacet.id OR KnowledgeUnit.id (POLYMORPHIC)"
+        string kuId          "FK → KnowledgeUnit.id"
+        string kuType
+        number priority
+        string status        "pending | completed | skipped"
+    }
+
+    %% ═══════════════════════════════════════════════════════
+    %% RELATIONSHIPS
+    %% ═══════════════════════════════════════════════════════
+
+    KnowledgeUnit ||--o| Lesson : "generates (keyed by kuId)"
+    KnowledgeUnit ||--o| UserLessonOverlay : "overlay (keyed by kuId)"
+    KnowledgeUnit ||--o{ UserKnowledgeUnit : "enrolled as"
+    KnowledgeUnit ||--o{ ReviewFacet : "drilled by (Vocab/Kanji/Grammar facets)"
+    KnowledgeUnit ||--o{ Question : "questions drawn from"
+    KnowledgeUnit ||--o{ UserGrammarLesson : "encountered as grammar"
+    KnowledgeUnit o|--o{ Scenario : "sourceKuId"
+    KnowledgeUnit ||--o{ FeedItem : "referenced by"
+
+    Concept ||--o{ ReviewFacet : "drilled by (Concept facets)"
+    Concept ||--o{ Question : "questions drawn from"
+    Concept ||--o{ UserConcept : "enrolled as"
+    Concept ||--o{ UserGrammarLesson : "introduces grammar via concept"
+
+    Scenario ||--o{ ReviewFacet : "drilled by (sentence-assembly facets)"
+    Scenario ||--o{ UserGrammarLesson : "introduces grammar via scenario"
+
+    Question ||--o{ UserQuestionState : "per-user state"
+    ReviewFacet o|--o| Question : "currentQuestionId"
+
+    UserRoot ||--o{ UserKnowledgeUnit : "owns"
+    UserRoot ||--o{ ReviewFacet : "owns"
+    UserRoot ||--o{ Scenario : "owns"
+    UserRoot ||--o{ UserGrammarLesson : "owns"
+    UserRoot ||--o{ UserLessonOverlay : "owns"
+    UserRoot ||--o{ UserQuestionState : "owns"
+    UserRoot ||--o{ UserConcept : "owns"
+    UserRoot ||--o{ FeedItem : "owns"
+```
+
+---
+
+## Anomalies & Inconsistencies
+
+### 1. `ReviewFacet.kuId` is polymorphic
+Points to `knowledge-units/{id}`, `concepts/{id}`, OR `users/{uid}/scenarios/{id}` depending on `facetType`. No field on the facet document indicates which collection to query — callers must know the implicit mapping from `facetType` to collection. This is the root cause of the vocab-gate problem documented in ARCHITECTURE.md. FIXED
+### 2. `Question.kuId` is polymorphic
+Same issue as ReviewFacet — points to `knowledge-units` OR `concepts`. `QuestionsService.generateAndSave` handles this with a try/catch fallback but there is no discriminant on the document. FIXED
+### 3. `Concept` is not in `knowledge-units`
+`ConceptKnowledgeUnit` is a subtype of `KnowledgeUnit` in the TypeScript union, but `Concept` documents live in the separate `concepts` collection. Code that queries `knowledge-units` never returns Concepts. The type definition implies a unified collection that does not exist.
+
+**Decision (2026-05-10):** The ideal fix is to migrate Concept documents into `knowledge-units` and move the rich content (`overview`, `mechanics`, `examples`) into the `lessons` collection as a new `ConceptLesson` type — mirroring how Grammar works. Decided not to pursue this for now: the migration is large (two Firestore documents per concept, atomic writes, `UserConcept` → `UserKnowledgeUnit` backfill across all user sub-collections, frontend routing changes, and the freshly-written `sourceCollection: 'concepts'` values on review facets would become incorrect). Revisit when there is capacity for a coordinated migration script.
+
+### 4. `GrammarKnowledgeUnit.data.jlptLevel` type mismatch
+`jlptLevel` is present in the **frontend** `GrammarKnowledgeUnit.data` type and in Firestore data, but is **absent** from the **backend** type. Backend code accesses it via `(ku.data as any)?.jlptLevel`. The two type files are out of sync. FIXED
+
+### 5. `GrammarLesson.classification` should not exist
+`GrammarLesson` has `classification?: GrammarClassification`. Classification is hand-authored editorial data that lives on the KU and must never come from the AI. The field on the lesson type implies the AI could populate it, which it must not. FIXED
+
+### 6. `GrammarKnowledgeUnit.data.corpusNotes` is architecturally misplaced
+Corpus notes are AI prompt context — instructions that guide lesson generation — not intrinsic properties of the grammar pattern. They belong in a separate collection (discussed but not yet implemented).
+
+### 7. `ReviewFacet.source.type` is incomplete
+NOT APPLICABLE. Scenarios never create facets directly. `sentence-assembly` facets are only created by Concepts (`concepts.service.ts`). The only values ever written to `source.type` are `'lesson'` and `'concept'`, which matches the union. A dead `'scenario'` branch in `resolveKuCollection` was removed.
+
+### 8. `Scenario.grammarMatches[].kuId` is unvalidated
+NOT APPLICABLE to current code. The `get_grammar_patterns` tool queries Firestore and returns real document IDs; the AI selects from that list. The prompt also instructs "Never invent IDs." Hallucination is structurally prevented for new scenarios. The legacy `grammarNotes` free-text path (`ensureGrammarKU`) does fuzzy-match and carries some risk, but only fires for scenarios created before the tool-based flow existed.
+
+### 9. `UserGrammarLesson.userId` is redundant
+Stored inside a path-scoped sub-collection (`users/{uid}/user-grammar-lessons`). The `uid` is already implicit in the Firestore path. The field adds nothing and can drift if the document is ever copied. FIXED — removed from type and write path; old documents are not backfilled (field is simply ignored on read).
+
+### 10. `UserQuestionState.kuId` is denormalized
+Copied from `Question.kuId` at creation time. If a Question document's `kuId` were ever corrected, the `UserQuestionState` would be stale. Low risk in practice but structurally fragile. FIXED — `kuId` removed from type and write path; nothing reads it back from state.
+
+### 11. Dual-path collections for admin vs users
+`review-facets` (root, admin) vs `users/{uid}/review-facets` (per-user), and `scenarios` (root, admin) vs `users/{uid}/scenarios` (per-user). Routing handled by helpers (`facetsColRef`, `scenariosColRef`) but every service that touches these must know to use the helper.
+
+### 12. `KnowledgeUnitBase` carries deprecated user-state fields
+`userId`, `personalNotes`, `userNotes`, `facet_count`, `history` are marked `@deprecated` on the global KU base type. These belong on `UserKnowledgeUnit`. They persist on Firestore documents and are read by some code paths. FIXED
+
+### 13. `GrammarNote.explanation` vs `GrammarKnowledgeUnit.data.corpusNotes`
+Scenario grammar extraction produces `GrammarNote` objects with an `explanation` field. The KU stores the same conceptual data as `corpusNotes`. Different field names for the same idea, in types that exist alongside each other. FIXED — `explanation` removed from `GrammarNote` type and tool schema; `ensureGrammarKU` never read it, and the `grammarNotes` path is legacy-only.

--- a/backend/src/kanji/kanji.service.ts
+++ b/backend/src/kanji/kanji.service.ts
@@ -33,18 +33,7 @@ export class KanjiService {
         // 2. Fetch Contextual Data (Related Vocab from DB)
         const relatedVocab = await this.knowledgeUnitsService.findByKanjiComponent(kanjiChar);
 
-        // 3. Fetch User Data (Personal Mnemonic) if kuId exists
-        let personalMnemonic = '';
-        if (kuId) {
-            try {
-                const ku = await this.knowledgeUnitsService.findOne(kuId);
-                personalMnemonic = ku.personalNotes || ''; // Or a specific field if you added one
-            } catch (e) {
-                // Ignore if KU doesn't exist yet (unlikely if coming from lesson page)
-            }
-        }
-
-        // 4. Assemble the KanjiLesson Object
+        // 3. Assemble the KanjiLesson Object
         return {
             kuId,
             type: 'Kanji',
@@ -73,7 +62,6 @@ export class KanjiService {
                 classic_nelson: apiData.references?.classic_nelson,
             },
 
-            personalMnemonic,
             mnemonic_meaning: '', // TODO: Fetch from AI or DB?
             mnemonic_reading: '', // TODO: Fetch from AI or DB?
 

--- a/backend/src/knowledge-units/knowledge-units.controller.ts
+++ b/backend/src/knowledge-units/knowledge-units.controller.ts
@@ -50,9 +50,6 @@ export class KnowledgeUnitsController {
         const ku = await this.knowledgeUnitsService.findOneById(id);
         if (!ku) throw new NotFoundException(`Knowledge Unit ${id} not found`);
 
-        // Direct owner (user_default managing corpus) or user has a UKU for this KU
-        if (ku.userId === uid) return ku;
-
         const uku = await this.userKnowledgeUnitsService.findByKuId(uid, id);
         if (uku) return ku;
 

--- a/backend/src/knowledge-units/knowledge-units.service.ts
+++ b/backend/src/knowledge-units/knowledge-units.service.ts
@@ -171,10 +171,8 @@ export class KnowledgeUnitsService {
                 ...(hint?.jlptLevel ? { jlptLevel: hint.jlptLevel } : {}),
             },
             status: 'learning',
-            facet_count: 0,
             createdAt: Timestamp.now(),
             relatedUnits: [],
-            personalNotes: '',
         });
 
         return newRef.id;
@@ -204,7 +202,6 @@ export class KnowledgeUnitsService {
             data: body.data || {},
             createdAt: Timestamp.now(),
             status: "learning",
-            facet_count: 0,
         };
         delete newKuData.userId; // KUs are global; no user ownership
 
@@ -308,10 +305,7 @@ export class KnowledgeUnitsService {
                     type: item.type,
                     data: item.data || {},
                     relatedUnits: item.relatedUnits || [],
-                    personalNotes: item.personalNotes || '',
-                    userNotes: item.userNotes || '',
                     status: 'learning',
-                    facet_count: 0,
                     createdAt: Timestamp.now(),
                 },
             });

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -10,6 +10,13 @@ import { buildVocabLessonMessage, buildVocabCacheContext, buildKanjiLessonPrompt
 import { GRAMMAR_INSTRUCTIONS, buildGrammarLessonMessage } from '../prompts/grammar.prompts';
 import { ADMIN_USER_ID } from '../lib/constants';
 
+function applyKuOverrides(lesson: Lesson, ku: KnowledgeUnit): Lesson {
+  if (ku.type !== 'Grammar') return lesson;
+  const overrides: Partial<GrammarLesson> = { pattern: ku.content };
+  if (ku.data?.title) overrides.title = ku.data.title;
+  return { ...lesson, ...overrides } as Lesson;
+}
+
 @Injectable()
 export class LessonsService {
   private readonly logger = new Logger(LessonsService.name);
@@ -47,10 +54,8 @@ export class LessonsService {
         void lessonDbRef.update({ userId: FieldValue.delete() });
         delete data.userId;
       }
-      if (overlayDoc.exists) {
-        return { ...data, ...overlayDoc.data() } as Lesson;
-      }
-      return data as Lesson;
+      const merged = overlayDoc.exists ? { ...data, ...overlayDoc.data() } : data;
+      return applyKuOverrides(merged as Lesson, ku);
     }
 
     this.logger.log(`No existing lesson for KU ${kuId}. Generating new lesson`);
@@ -74,12 +79,14 @@ export class LessonsService {
       }
 
       await lessonDbRef.set(lessonJson);
-      return lessonJson;
+      return applyKuOverrides(lessonJson, ku);
     }
 
     if (ku.type === "Kanji") {
       userMessage = buildKanjiLessonPrompt(ku.content);
     } else {
+      // TODO: pass ku.data.corpusNotes into buildVocabLessonMessage so Vocab/Kanji corpus
+      // notes are injected into the prompt, mirroring how Grammar uses corpusNotes.
       userMessage = buildVocabLessonMessage(ku.content, !!cachedContentName);
     }
 
@@ -191,8 +198,13 @@ export class LessonsService {
       valueToSave = content;
     }
 
-    const overlayRef = this.db.collection('users').doc(uid).collection(USER_LESSONS_SUBCOLLECTION).doc(kuId);
-    await overlayRef.set({ [section]: valueToSave }, { merge: true });
+    const isAdmin = uid === ADMIN_USER_ID || process.env.ADMIN_ALL === 'true';
+    if (isAdmin) {
+      await this.db.collection(LESSONS_COLLECTION).doc(kuId).update({ [section]: valueToSave });
+    } else {
+      const overlayRef = this.db.collection('users').doc(uid).collection(USER_LESSONS_SUBCOLLECTION).doc(kuId);
+      await overlayRef.set({ [section]: valueToSave }, { merge: true });
+    }
 
     return { success: true };
   }
@@ -222,7 +234,6 @@ export class LessonsService {
     const ref = this.db.collection('users').doc(uid).collection(USER_GRAMMAR_LESSONS_SUBCOLLECTION).doc(docId);
 
     const data: Omit<UserGrammarLesson, 'id'> = {
-      userId: uid,
       kuId,
       lessonId: kuId,
       sourceType: source.sourceType,

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -16,7 +16,7 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
 
 **Content Guidelines:**
 
-1. 'overview': Define the concept strictly in terms of how Japanese works — do not reference English grammar rules, relative pronouns, or words like "who", "which", or "that". Maximum two sentences.
+1. 'overview': Define the concept strictly in terms of how Japanese works — do not reference English grammar rules, relative pronouns, or words like "who", "which", or "that". Use your judegement on how much detail to provide to land the concept, but be thoughtful of the learner's experience. 
 
 2. 'mechanics': Break the grammar down by the learner's communicative intent, not just structural formulas. Each mechanic must contain:
    - 'goalTitle': An action-oriented title describing what the learner wants to express (e.g., "Describe a noun using a habitual or future action").

--- a/backend/src/prompts/grammar.prompts.ts
+++ b/backend/src/prompts/grammar.prompts.ts
@@ -12,8 +12,10 @@ import { USER_TARGET_LEVEL } from './fragments';
 
 /** Static schema and rules appended to every grammar lesson user message. */
 export const GRAMMAR_INSTRUCTIONS = `
-The lesson should be in English. The use of Romaji anywhere in the lesson is forbidden.
-
+Instructions:
+ - The lesson should be in English. The use of Romaji anywhere in the lesson is forbidden.
+ - Avoid using the following terminology: "copula", "predicate". Use of "particle" and "modifier" is acceptable.
+ 
 Generate a complete grammar lesson matching this JSON schema exactly:
 {
   "type": "Grammar",
@@ -21,7 +23,7 @@ Generate a complete grammar lesson matching this JSON schema exactly:
   "title": "Human-readable name (e.g. Making Requests with ～をお願いします)",
   "jlptLevel": "One of: N5, N4, N3, N2, N1",
   "meaning": "One-line summary of what this pattern expresses",
-  "formation": "How to form it (e.g. noun + をお願いします)",
+  "formation": ["How to form it (e.g. noun + をお願いします)", "Add more entries for variant forms or multiple patterns"],
   "notes": "Nuance, register, common mistakes, contrast with similar patterns",
   "examples": [
     {
@@ -36,11 +38,11 @@ Generate a complete grammar lesson matching this JSON schema exactly:
 
 Rules:
 - Provide exactly 3 examples
-- When provided ALWAYS copy 'Example from context' data VERBATIM into examples[0], including its exact fragments and accepted_alternatives
+- When provided, ALWAYS copy the 'Example from context' data VERBATIM into examples[0], including its exact fragments and accepted_alternatives
 - examples[1] and examples[2] MUST use completely different Japanese sentences with their own unique fragments
 - fragments must be the Japanese sentence split into meaningful chunks for sentence-assembly drills — each example must have different fragments matching its own sentence
 - NEVER copy fragments from one example to another
-- ${USER_TARGET_LEVEL}
+- Keep all example sentences at or below JLPT ${USER_TARGET_LEVEL}, even if the target grammar pattern is at a higher level
 `;
 
 // ---------------------------------------------------------------------------
@@ -54,9 +56,11 @@ Rules:
  */
 export function buildGrammarLessonMessage(ku: GrammarKnowledgeUnit): string {
   const ctxExample = ku.data.exampleInContext;
-  return `You are an expert Japanese grammar tutor. Generate a lesson for the grammar pattern: ${ku.content}
+  return `You are an expert Japanese grammar tutor for the Japanese Language learning app: AIGENKI. AIGENKI uses AI generate lessons for Japanese Grammar, Vocab and Concepts along with SRS based reviews with a mix of questions types designed to advance users through their Japanese learning experience. The "Corpus context" section provides additional information about the Grammar pattern being taught and how it exists within the context of the knowledge corpus within AIGENKI 
+  
+Your Task: Generate a complete AIGENKI lesson at the user's current level, for the grammar pattern: ${ku.content}
 
-Pattern title: ${ku.data.title}
+Grammar title: ${ku.data.title}
 Corpus context: ${ku.data.corpusNotes ?? ''}
 Example from context (USE AS examples[0] VERBATIM):
   japanese: ${ctxExample?.japanese ?? ''}

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -277,6 +277,7 @@ export class QuestionsService {
     const newQuestion: QuestionItem = {
       id: ref.id,
       kuId,
+      sourceCollection: 'knowledge-units',
       data: {
         question: parsed.question,
         context: parsed.context,
@@ -330,6 +331,7 @@ export class QuestionsService {
     const newQuestion: QuestionItem = {
       id: ref.id,
       kuId,
+      sourceCollection: 'concepts',
       data: {
         question: parsed.question,
         context: parsed.context,
@@ -360,9 +362,9 @@ export class QuestionsService {
 
     if (result === 'pass') {
       batch.update(questionRef, { rank: FieldValue.increment(RANK_CORRECT_DELTA) });
-      batch.set(stateRef, { questionId, kuId, consecutiveFailures: 0 }, { merge: true });
+      batch.set(stateRef, { questionId, consecutiveFailures: 0 }, { merge: true });
     } else {
-      batch.set(stateRef, { questionId, kuId, consecutiveFailures: FieldValue.increment(1) }, { merge: true });
+      batch.set(stateRef, { questionId, consecutiveFailures: FieldValue.increment(1) }, { merge: true });
     }
 
     try {

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -22,6 +22,17 @@ import { ScenariosService } from '../scenarios/scenarios.service';
 import { LearningProgressService } from '../learning-progress/learning-progress.service';
 import { buildAnswerEvaluatorPrompt } from '../prompts/evaluation.prompts';
 
+/**
+ * Resolves which Firestore collection a ReviewFacet's kuId points to.
+ * New facets carry sourceCollection explicitly; old documents fall back to
+ * inferring from source.type, defaulting to 'knowledge-units'.
+ */
+export function resolveKuCollection(facet: Pick<ReviewFacet, 'sourceCollection' | 'source'>): 'knowledge-units' | 'concepts' | 'scenarios' {
+    if (facet.sourceCollection) return facet.sourceCollection;
+    if (facet.source?.type === 'concept') return 'concepts';
+    return 'knowledge-units';
+}
+
 @Injectable()
 export class ReviewsService {
     private readonly logger = new Logger(ReviewsService.name);
@@ -316,6 +327,7 @@ export class ReviewsService {
                     if (!existingKanjiTypes.has('Kanji-Component-Meaning')) {
                         batch.set(this.facetsColRef(uid).doc(), {
                             kuId: kanjiKuId,
+                            sourceCollection: 'knowledge-units',
                             facetType: 'Kanji-Component-Meaning',
                             srsStage: 0,
                             nextReviewAt: now,
@@ -331,6 +343,7 @@ export class ReviewsService {
                     if (!existingKanjiTypes.has('Kanji-Component-Reading')) {
                         batch.set(this.facetsColRef(uid).doc(), {
                             kuId: kanjiKuId,
+                            sourceCollection: 'knowledge-units',
                             facetType: 'Kanji-Component-Reading',
                             srsStage: 0,
                             nextReviewAt: now,
@@ -374,6 +387,7 @@ export class ReviewsService {
             const newFacetRef = this.facetsColRef(uid).doc();
             batch.set(newFacetRef, {
                 kuId: targetKuId,
+                sourceCollection: 'knowledge-units',
                 facetType: key,
                 srsStage: startStage,
                 nextReviewAt,
@@ -484,11 +498,13 @@ export class ReviewsService {
     ): Promise<number> {
         const batch = this.db.batch();
         const now = Timestamp.now();
+        const sourceCollection = resolveKuCollection({ source });
 
         for (const facet of facets) {
             const ref = this.facetsColRef(uid).doc();
             batch.set(ref, {
                 kuId: facet.kuId,
+                sourceCollection,
                 facetType: facet.facetType,
                 srsStage: 0,
                 nextReviewAt: now,

--- a/backend/src/tutor/tutor-tool.registry.ts
+++ b/backend/src/tutor/tutor-tool.registry.ts
@@ -221,7 +221,6 @@ export const TOOL_REGISTRY: AiToolDefinition[] = [
                 description: 'The grammar pattern template (e.g. "～をお願いします").',
               },
               title: { type: 'string' },
-              explanation: { type: 'string' },
               exampleInContext: {
                 type: 'object',
                 properties: {
@@ -241,7 +240,7 @@ export const TOOL_REGISTRY: AiToolDefinition[] = [
                 required: ['japanese', 'english', 'fragments', 'accepted_alternatives'],
               },
             },
-            required: ['title', 'explanation', 'exampleInContext'],
+            required: ['title', 'exampleInContext'],
           },
         },
       },

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -214,9 +214,8 @@ export interface GrammarLesson {
   pattern: string;       // e.g. "～をお願いします"
   title: string;         // e.g. "Making Requests with ～をお願いします"
   jlptLevel: string;
-  classification?: GrammarClassification;
   meaning: string;       // one-line summary
-  formation: string;     // "noun + をお願いします"
+  formation: string | string[];
   notes: string;         // nuance, pitfalls
   examples: {
     japanese: string;
@@ -229,7 +228,6 @@ export interface GrammarLesson {
 
 export interface UserGrammarLesson {
   id: string;
-  userId: string;
   kuId: string;
   lessonId: string;      // = kuId (Grammar lessons stored at lessons/{kuId})
   sourceType: 'scenario' | 'concept';
@@ -255,26 +253,13 @@ export type KnowledgeUnitType =
 
 // ─── KnowledgeUnit discriminated union ───────────────────────────────────────
 
-/**
- * Fields shared by every KU sub-type.
- * Deprecated fields remain here until the User state migration is complete.
- */
+/** Fields shared by every KU sub-type. */
 export interface KnowledgeUnitBase {
   id: string;
   content: string; // The main "thing" (e.g., "食べる", "家族")
   relatedUnits: string[]; // Array of other KnowledgeUnit IDs
-  /** @deprecated migrating to User state models */
-  userId: string;
-  /** @deprecated migrating to User state models */
-  personalNotes: string;
-  /** @deprecated migrating to User state models */
-  userNotes?: string;
-  /** @deprecated migrating to User state models */
   createdAt: Timestamp;
-  /** @deprecated migrating to User state models */
-  facet_count: number;
-  /** @deprecated migrating to User state models */
-  history?: any[];
+  data: Record<string, any>;
 }
 
 export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
@@ -285,6 +270,7 @@ export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
     conjugationType?: 'godan' | 'ichidan' | 'irregular';
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
+    corpusNotes?: string;
     [key: string]: any;
   };
 }
@@ -295,6 +281,7 @@ export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
     meaning?: string;
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
+    corpusNotes?: string;
     [key: string]: any;
   };
 }
@@ -304,6 +291,7 @@ export interface GrammarKnowledgeUnit extends KnowledgeUnitBase {
   data: {
     title: string;
     corpusNotes?: string;
+    jlptLevel?: string | null;
     classification?: GrammarClassification;
     exampleInContext: {
       japanese: string;
@@ -380,8 +368,6 @@ export interface UserKnowledgeUnit {
   id: string;
   userId: string;
   kuId: string; // Bridges to KnowledgeUnit.id
-  personalNotes: string;
-  userNotes?: string;
   createdAt: Timestamp;
   status: "learning" | "reviewing" | "mastered";
   facet_count: number;
@@ -422,7 +408,8 @@ export type FacetType =
 export interface ReviewFacet {
   id: string;
   userId: string;
-  kuId: string; // ID of the parent KnowledgeUnit
+  kuId: string;
+  sourceCollection?: 'knowledge-units' | 'concepts' | 'scenarios';
   facetType: FacetType;
   srsStage: number; // 0 (new) to 8 (mastered)
   nextReviewAt: Timestamp; // ISO string
@@ -465,6 +452,7 @@ export type LessonDifficulty =
 export interface QuestionItem {
   id: string;
   kuId: string;
+  sourceCollection?: 'knowledge-units' | 'concepts' | 'scenarios';
   data: {
     context?: string;
     question: string;
@@ -475,23 +463,10 @@ export interface QuestionItem {
   rank: number;        // 0–100, starts at 50; suitable threshold is 30
   rejectionCount: number; // tracked for observability; not used for ranking
   createdAt: string | Timestamp;
-  /** @deprecated */
-  userId?: string;
-  /** @deprecated */
-  status?: "active" | "flagged" | "inactive";
-  /** @deprecated */
-  lastUsed?: string | Timestamp;
-  /** @deprecated */
-  previousAnswers?: {
-    answer: string;
-    result: "pass" | "fail";
-    timestamp: Timestamp;
-  }[];
 }
 
 export interface UserQuestionState {
   questionId: string;
-  kuId: string;
   rejected: boolean;       // user will never see this question again
   consecutiveFailures: number; // resets on correct answer; 3+ triggers rotation
 }

--- a/backend/src/types/scenario.ts
+++ b/backend/src/types/scenario.ts
@@ -33,7 +33,6 @@ export interface ExtractedKU {
 export interface GrammarNote {
     pattern?: string;  // the extractable pattern, e.g. "～をお願いします"
     title: string;
-    explanation: string;
     exampleInContext: {
         japanese: string;
         english: string;

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -49,8 +49,6 @@ export class UserKnowledgeUnitsService {
       result.push({
         id: kuDoc.id,
         ...kuData,
-        personalNotes: uku.personalNotes,
-        userNotes: uku.userNotes,
         createdAt: typeof kuData.createdAt?.toDate === 'function'
                 ? kuData.createdAt.toDate().toISOString()
                 : kuData.createdAt,
@@ -105,7 +103,6 @@ export class UserKnowledgeUnitsService {
     const payload: Omit<UserKnowledgeUnit, 'id'> = {
       userId: uid,
       kuId,
-      personalNotes: '',
       createdAt: now,
       status: 'learning',
       facet_count: 0,

--- a/frontend/src/app/admin/knowledge-units/page.tsx
+++ b/frontend/src/app/admin/knowledge-units/page.tsx
@@ -32,7 +32,7 @@ function KuRow({ ku, onEdit, onDelete }: { ku: KnowledgeUnit; onEdit: () => void
 
   return (
     <div className="flex items-center gap-3 px-4 py-2.5 border-b border-shodo-mist hover:bg-shodo-paper-warm transition-colors">
-      <span className="text-base font-medium text-shodo-ink w-40 shrink-0 truncate">
+      <span title={ku.content} className="text-base font-medium text-shodo-ink w-40 shrink-0 truncate cursor-default">
         {ku.content}
       </span>
 

--- a/frontend/src/app/learn/[kuId]/page.tsx
+++ b/frontend/src/app/learn/[kuId]/page.tsx
@@ -767,7 +767,7 @@ export default function LearnItemPage() {
       )}
       <main className="container mx-auto max-w-4xl p-8">
         <header className="mb-8">
-          <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-2 break-all">
+          <h1 className={`font-bold text-gray-900 dark:text-white mb-2 break-all ${lesson?.type === "Grammar" ? "text-4xl" : "text-6xl"}`}>
             {isLoading
               ? "..."
               : lesson?.type === "Vocab"
@@ -778,7 +778,7 @@ export default function LearnItemPage() {
                 : lesson?.type === "Kanji" && (lesson as KanjiLesson).kanji
                   ? (lesson as KanjiLesson).kanji
                   : lesson?.type === "Grammar"
-                    ? (lesson as GrammarLesson).pattern
+                    ? (lesson as GrammarLesson).title
                     : ku?.content || "..."}
           </h1>
           {lesson && lesson?.type === "Vocab" && (

--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -79,20 +79,22 @@ export default function LearnListPage() {
                 ${i < rows.length - 1 ? "border-b border-shodo-paper-dark" : ""}
                 dark:hover:bg-gray-700`}
             >
-              {/* Japanese content — coloured by type */}
+              {/* Primary label — coloured by type */}
               <span
                 style={{ color: TYPE_COLORS[ku.type] }}
-                className="text-xl font-bold min-w-[5rem] dark:text-white"
+                className={`font-bold min-w-[5rem] dark:text-white ${ku.type === "Grammar" ? "text-base" : "text-xl"}`}
               >
-                {ku.content}
+                {ku.type === "Grammar" && (ku as any).data?.title
+                  ? (ku as any).data.title
+                  : ku.content}
               </span>
 
               {/* Reading / definition hint — always flex-1 to anchor fixed columns */}
               <span className="flex-1 truncate text-sm text-shodo-ink-light dark:text-gray-400">
                 {ku.type === "Vocab" && (ku as any).data?.reading && (ku as any).data.reading !== ku.content
                   ? (ku as any).data.reading
-                  : ku.type === "Grammar" && (ku as any).data?.title
-                    ? (ku as any).data.title
+                  : ku.type === "Grammar"
+                    ? ku.content
                     : ku.type === "Kanji" && (ku as any).data?.meaning
                       ? (ku as any).data.meaning
                       : ""}

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -321,11 +321,16 @@ function GrammarExampleSlide({ loaded, exampleIdx }: { loaded: LoadedItem; examp
 
 function GrammarNotesSlide({ loaded }: { loaded: LoadedItem }) {
   const gl = loaded.lesson as GrammarLesson;
+  const paragraphs = gl.notes.replace(/\\n/g, '\n').split(/\n\n+/);
   return (
     <div className="flex flex-col gap-6 max-w-2xl mx-auto">
       <span className="text-xs font-semibold uppercase tracking-widest text-shodo-ink-faint">Notes</span>
       <div className="text-4xl font-bold text-shodo-matcha">{gl.pattern}</div>
-      <p className="text-lg text-shodo-ink-light leading-relaxed">{gl.notes}</p>
+      <div className="flex flex-col gap-3">
+        {paragraphs.map((para, i) => (
+          <p key={i} className="text-lg text-shodo-ink-light leading-relaxed">{para}</p>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/manage/page.tsx
+++ b/frontend/src/app/manage/page.tsx
@@ -27,7 +27,6 @@ export default function KnowledgeManagementPage() {
   const [newKuDefinition, setNewKuDefinition] = useState("");
   const [newKuJlptLevel, setNewKuJlptLevel] = useState("");
   const [newKuWanikaniLevel, setNewKuWanikaniLevel] = useState<number | "">("");
-  const [newKuNotes, setNewKuNotes] = useState(""); // Personal Notes
   const [newUserNotes, setNewUserNotes] = useState(""); // User Notes (Context)
   const [generatingFacetKuId, setGeneratingFacetKuId] = useState<string | null>(
     null,
@@ -112,6 +111,7 @@ export default function KnowledgeManagementPage() {
       if (newKuJlptLevel !== "") kuData.jlptLevel = newKuJlptLevel;
       if (newKuWanikaniLevel !== "") kuData.wanikaniLevel = Number(newKuWanikaniLevel);
     }
+    if (newUserNotes) kuData.corpusNotes = newUserNotes;
 
     try {
       // TODO needs nextjs rewrite
@@ -124,8 +124,6 @@ export default function KnowledgeManagementPage() {
           type: newKuType,
           content: newKuContent,
           data: kuData,
-          personalNotes: newKuNotes,
-          userNotes: newUserNotes,
         }),
       });
 
@@ -140,7 +138,6 @@ export default function KnowledgeManagementPage() {
       setNewKuDefinition("");
       setNewKuJlptLevel("");
       setNewKuWanikaniLevel("");
-      setNewKuNotes("");
       setNewUserNotes("");
 
       await fetchData(); // Refetch all data
@@ -313,11 +310,6 @@ export default function KnowledgeManagementPage() {
                 <p className="text-lg text-gray-300 break-all">
                   <span className="font-semibold">Definition:</span>{" "}
                   {ku.data.definition}
-                </p>
-              )}
-              {ku.personalNotes && (
-                <p className="mt-2 p-3 bg-gray-600 rounded text-gray-200 italic break-words">
-                  {ku.personalNotes}
                 </p>
               )}
 
@@ -516,7 +508,7 @@ export default function KnowledgeManagementPage() {
               htmlFor="kuUserNotes"
               className="block text-sm font-medium text-gray-300 mb-1 flex items-center gap-2"
             >
-              User Notes
+              Corpus Notes
               <span className="text-[10px] bg-blue-600 text-white px-1.5 py-0.5 rounded-full font-normal normal-case">
                 AI Context
               </span>
@@ -527,23 +519,6 @@ export default function KnowledgeManagementPage() {
               onChange={(e) => setNewUserNotes(e.target.value)}
               rows={2}
               placeholder="Context instructions for Gemini (e.g., 'Focus on polite forms')..."
-              className="w-full p-3 bg-gray-700 border-gray-600 text-white rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="kuNotes"
-              className="block text-sm font-medium text-gray-300 mb-1"
-            >
-              Personal Notes
-            </label>
-            <textarea
-              id="kuNotes"
-              value={newKuNotes}
-              onChange={(e) => setNewKuNotes(e.target.value)}
-              rows={3}
-              placeholder="e.g., Mnemonic, context where I found this, related to..."
               className="w-full p-3 bg-gray-700 border-gray-600 text-white rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
             />
           </div>

--- a/frontend/src/components/EditKnowledgeUnitModal.tsx
+++ b/frontend/src/components/EditKnowledgeUnitModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { apiFetch } from "@/lib/api-client";
 import {
   KnowledgeUnit,
   GrammarClassification,
@@ -67,11 +68,12 @@ export default function EditKnowledgeUnitModal({
   const [jlptLevel, setJlptLevel] = useState("");
   const [wanikaniLevel, setWanikaniLevel] = useState<number | "">("");
   const [grammarTitle, setGrammarTitle] = useState("");
+  const [grammarNotes, setGrammarNotes] = useState("");
+  const [initialGrammarNotes, setInitialGrammarNotes] = useState("");
   const [grammarCorpusNotes, setGrammarCorpusNotes] = useState("");
   const [classification, setClassification] = useState<GrammarClassification>(emptyClassification());
   const [hasClassification, setHasClassification] = useState(false);
-  const [userNotes, setUserNotes] = useState("");
-  const [personalNotes, setPersonalNotes] = useState("");
+  const [corpusNotes, setCorpusNotes] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
@@ -88,8 +90,10 @@ export default function EditKnowledgeUnitModal({
         setHasClassification(false);
       } else if (knowledgeUnit.type === "Grammar") {
         setGrammarTitle(knowledgeUnit.data?.title || "");
+        setGrammarNotes("");
+        setInitialGrammarNotes("");
         setGrammarCorpusNotes(knowledgeUnit.data?.corpusNotes || "");
-        setJlptLevel((knowledgeUnit.data as any)?.jlptLevel || "");
+        setJlptLevel(knowledgeUnit.data?.jlptLevel || "");
         const existing = knowledgeUnit.data?.classification;
         if (existing) {
           setClassification(existing);
@@ -101,18 +105,31 @@ export default function EditKnowledgeUnitModal({
         setReading("");
         setDefinition("");
         setWanikaniLevel("");
+
+        // Fetch the cached lesson to pre-populate notes (cache hit only — no AI generation triggered if already cached)
+        apiFetch("/api/lessons/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kuId: knowledgeUnit.id }),
+        }).then(res => res.ok ? res.json() : null).then(lesson => {
+          if (lesson?.notes) {
+            setGrammarNotes(lesson.notes);
+            setInitialGrammarNotes(lesson.notes);
+          }
+        }).catch(() => {});
       } else {
         setReading("");
         setDefinition("");
         setJlptLevel("");
         setWanikaniLevel("");
         setGrammarTitle("");
+        setGrammarNotes("");
+        setInitialGrammarNotes("");
         setGrammarCorpusNotes("");
         setClassification(emptyClassification());
         setHasClassification(false);
       }
-      setUserNotes(knowledgeUnit.userNotes || "");
-      setPersonalNotes(knowledgeUnit.personalNotes || "");
+      setCorpusNotes(knowledgeUnit.data?.corpusNotes || "");
     }
   }, [knowledgeUnit]);
 
@@ -137,8 +154,7 @@ export default function EditKnowledgeUnitModal({
         definition !== (knowledgeUnit.data?.definition || "") ||
         jlptLevel !== (knowledgeUnit.data?.jlptLevel || "") ||
         wanikaniLevel !== (knowledgeUnit.data?.wanikaniLevel || "") ||
-        userNotes !== (knowledgeUnit.userNotes || "") ||
-        personalNotes !== (knowledgeUnit.personalNotes || "")
+        corpusNotes !== (knowledgeUnit.data?.corpusNotes || "")
       );
     }
     if (knowledgeUnit.type === "Grammar") {
@@ -152,10 +168,9 @@ export default function EditKnowledgeUnitModal({
       return (
         content !== knowledgeUnit.content ||
         grammarTitle !== (knowledgeUnit.data?.title || "") ||
+        grammarNotes !== initialGrammarNotes ||
         grammarCorpusNotes !== (knowledgeUnit.data?.corpusNotes || "") ||
-        jlptLevel !== ((knowledgeUnit.data as any)?.jlptLevel || "") ||
-        userNotes !== (knowledgeUnit.userNotes || "") ||
-        personalNotes !== (knowledgeUnit.personalNotes || "") ||
+        jlptLevel !== (knowledgeUnit.data?.jlptLevel || "") ||
         classChanged
       );
     }
@@ -178,8 +193,6 @@ export default function EditKnowledgeUnitModal({
             jlptLevel: jlptLevel || null,
             classification: hasClassification ? classification : null,
           },
-          userNotes,
-          personalNotes,
         };
       } else {
         updates = {
@@ -190,12 +203,20 @@ export default function EditKnowledgeUnitModal({
             definition,
             jlptLevel: jlptLevel !== "" ? jlptLevel : null,
             wanikaniLevel: wanikaniLevel !== "" ? Number(wanikaniLevel) : null,
+            corpusNotes: corpusNotes || undefined,
           },
-          userNotes,
-          personalNotes,
         };
       }
       await onSave(knowledgeUnit!.id, updates);
+
+      if (knowledgeUnit!.type === "Grammar" && grammarNotes !== initialGrammarNotes) {
+        await apiFetch(`/api/lessons/${knowledgeUnit!.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ section: "notes", content: grammarNotes }),
+        });
+      }
+
       onClose();
     } catch (error) {
       console.error("Failed to save changes", error);
@@ -304,6 +325,17 @@ export default function EditKnowledgeUnitModal({
               </div>
 
               <div>
+                <label className={labelClass}>Notes</label>
+                <textarea
+                  rows={4}
+                  value={grammarNotes}
+                  onChange={(e) => setGrammarNotes(e.target.value)}
+                  className={`${inputClass} resize-none`}
+                  placeholder="Nuance, register, common mistakes, contrast with similar patterns…"
+                />
+              </div>
+
+              <div>
                 <label className={labelClass}>Corpus Notes</label>
                 <textarea
                   rows={4}
@@ -400,37 +432,28 @@ export default function EditKnowledgeUnitModal({
             </>
           )}
 
-          {/* User Notes (Context for AI) */}
-          <div>
-            <label className="block text-xs font-bold text-shodo-ink-light uppercase tracking-wide mb-1 flex items-center gap-2">
-              User Notes
-              <span className="text-[10px] bg-shodo-indigo text-white px-1.5 py-0.5 rounded-full font-normal normal-case">
-                AI Context
-              </span>
-            </label>
-            <p className="text-xs text-shodo-ink-light mb-2">
-              Provide context for the AI (e.g., "Focus on polite forms", "Medical terminology").
-            </p>
-            <textarea
-              rows={2}
-              value={userNotes}
-              onChange={(e) => setUserNotes(e.target.value)}
-              className={`${inputClass} resize-none`}
-              placeholder="Context instructions for Gemini..."
-            />
-          </div>
+          {/* Corpus Notes — Vocab/Kanji only (Grammar has its own field above) */}
+          {(knowledgeUnit.type === "Vocab" || knowledgeUnit.type === "Kanji") && (
+            <div>
+              <label className="block text-xs font-bold text-shodo-ink-light uppercase tracking-wide mb-1 flex items-center gap-2">
+                Corpus Notes
+                <span className="text-[10px] bg-shodo-indigo text-white px-1.5 py-0.5 rounded-full font-normal normal-case">
+                  AI Context
+                </span>
+              </label>
+              <p className="text-xs text-shodo-ink-light mb-2">
+                Context for the AI lesson generator (e.g., "Focus on polite forms", "Medical terminology").
+              </p>
+              <textarea
+                rows={2}
+                value={corpusNotes}
+                onChange={(e) => setCorpusNotes(e.target.value)}
+                className={`${inputClass} resize-none`}
+                placeholder="Context instructions for Gemini..."
+              />
+            </div>
+          )}
 
-          {/* Personal Notes (Private) */}
-          <div>
-            <label className={labelClass}>Personal Notes</label>
-            <textarea
-              rows={3}
-              value={personalNotes}
-              onChange={(e) => setPersonalNotes(e.target.value)}
-              className={inputClass}
-              placeholder="Your private study notes..."
-            />
-          </div>
         </div>
 
         {/* Footer */}

--- a/frontend/src/components/lessons/GrammarLessonView.tsx
+++ b/frontend/src/components/lessons/GrammarLessonView.tsx
@@ -38,46 +38,54 @@ export default function GrammarLessonView({
       )}
 
       {/* Pattern Header */}
-      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center shadow-sm">
-        <div className="text-4xl font-bold text-slate-900 mb-2">{lesson.pattern}</div>
-        <div className="text-slate-500 text-sm mb-3">{lesson.title}</div>
+      <div className="bg-shodo-paper-dark border border-shodo-ink/5 rounded-lg p-6 text-center shadow-lg">
+        <div className="text-2xl font-bold text-shodo-ink mb-2">{lesson.pattern}</div>
+        <div className="text-shodo-ink-faint text-sm mb-3">{lesson.title}</div>
         <span className="inline-block px-3 py-1 bg-indigo-100 text-indigo-800 text-xs font-bold rounded-full">
           {lesson.jlptLevel}
         </span>
       </div>
 
-      {/* Meaning */}
-      <div className="bg-slate-50 border border-slate-200 rounded-xl p-5">
-        <h2 className="text-sm font-bold text-slate-500 uppercase tracking-wide mb-2">Meaning</h2>
-        <p className="text-slate-800 text-lg">{lesson.meaning}</p>
+      {/* Meaning + Notes */}
+      <div className="bg-shodo-paper-dark border border-shodo-ink/5 rounded-lg p-6 shadow-lg space-y-4">
+        <div>
+          <h2 className="text-sm font-bold text-shodo-ink-faint uppercase tracking-wide mb-2">Meaning</h2>
+          <p className="text-shodo-ink text-lg">{lesson.meaning}</p>
+        </div>
+        {lesson.notes && (
+          <div className="border-t border-shodo-ink/10 pt-4 space-y-3">
+            {lesson.notes.replace(/\\n/g, '\n').split(/\n\n+/).map((para, i) => (
+              <p key={i} className="text-shodo-ink-light text-base leading-relaxed">{para}</p>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Formation */}
-      <div className="bg-slate-50 border border-slate-200 rounded-xl p-5">
-        <h2 className="text-sm font-bold text-slate-500 uppercase tracking-wide mb-2">Formation</h2>
-        <p className="font-mono text-slate-900 bg-white border border-slate-100 rounded px-4 py-2 inline-block">
-          {lesson.formation}
-        </p>
+      <div className="bg-shodo-paper-dark border border-shodo-ink/5 rounded-lg p-6 shadow-lg">
+        <h2 className="text-sm font-bold text-shodo-ink-faint uppercase tracking-wide mb-2">Formation</h2>
+        <ul className="space-y-2">
+          {(Array.isArray(lesson.formation) ? lesson.formation : [lesson.formation]).map((f, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <span className="mt-2 w-1.5 h-1.5 rounded-full bg-shodo-ink-faint flex-shrink-0" />
+              <span className="font-mono text-shodo-ink bg-shodo-paper-warm border border-shodo-ink/10 rounded px-4 py-2 inline-block">
+                {f}
+              </span>
+            </li>
+          ))}
+        </ul>
       </div>
 
-      {/* Notes */}
-      {lesson.notes && (
-        <div className="bg-amber-50 border-l-4 border-amber-400 p-4 rounded-r-lg">
-          <h2 className="text-sm font-bold text-amber-700 uppercase tracking-wide mb-2">Notes</h2>
-          <p className="text-amber-900 text-sm leading-relaxed">{lesson.notes}</p>
-        </div>
-      )}
-
       {/* Examples */}
-      <div>
-        <h2 className="text-xl font-bold text-slate-800 mb-4">Examples</h2>
+      <div className="bg-shodo-paper-dark border border-shodo-ink/5 rounded-lg p-6 shadow-lg">
+        <h2 className="text-2xl font-semibold mb-4 text-shodo-ink">Examples</h2>
         <div className="space-y-4">
           {lesson.examples.map((ex, idx) => {
             const isFromSource = idx === 0 && userLesson;
             return (
               <div
                 key={idx}
-                className={`border rounded-xl p-5 ${isFromSource ? "bg-indigo-50 border-indigo-200" : "bg-white border-slate-200"}`}
+                className={`rounded-md p-4 ${isFromSource ? "bg-indigo-50 border border-indigo-200" : "bg-shodo-paper-warm"}`}
               >
                 {isFromSource && (
                   <div className="text-xs font-bold text-indigo-500 uppercase mb-2">
@@ -85,9 +93,9 @@ export default function GrammarLessonView({
                   </div>
                 )}
                 {ex.context && !isFromSource && (
-                  <div className="text-xs font-bold text-slate-400 uppercase mb-2">{ex.context}</div>
+                  <div className="text-xs font-bold text-shodo-ink-faint uppercase mb-2">{ex.context}</div>
                 )}
-                <p className="text-xl font-medium text-slate-900 mb-1">{ex.japanese}</p>
+                <p className="text-xl font-medium text-shodo-ink mb-1">{ex.japanese}</p>
                 <button
                   onClick={() => toggleReveal(idx)}
                   className="text-sm text-indigo-600 hover:text-indigo-800 transition-colors"
@@ -95,7 +103,7 @@ export default function GrammarLessonView({
                   {revealedExamples[idx] ? "Hide translation" : "Show translation"}
                 </button>
                 {revealedExamples[idx] && (
-                  <p className="text-slate-500 text-sm mt-1">{ex.english}</p>
+                  <p className="text-shodo-ink-light text-sm mt-1">{ex.english}</p>
                 )}
               </div>
             );
@@ -104,16 +112,16 @@ export default function GrammarLessonView({
       </div>
 
       {/* Facet Selection */}
-      <div className="border-t border-slate-200 pt-8">
-        <h2 className="text-xl font-bold text-slate-800 mb-2">Review Methods</h2>
-        <p className="text-sm text-slate-500 mb-4">
+      <div className="bg-shodo-paper-dark border border-shodo-ink/5 rounded-lg p-6 shadow-lg">
+        <h2 className="text-2xl font-semibold mb-2 text-shodo-ink">Review Methods</h2>
+        <p className="text-sm text-shodo-ink-faint mb-4">
           Choose which review types to add to your queue.
         </p>
         <div className="space-y-3">
           {facetOptions.map(({ key, label, description }) => (
             <label
               key={key}
-              className="flex items-start gap-3 p-4 bg-white border border-slate-200 rounded-xl cursor-pointer hover:border-indigo-300 transition-colors"
+              className="flex items-start gap-3 p-4 bg-shodo-paper-warm border border-shodo-ink/10 rounded-lg cursor-pointer hover:border-indigo-300 transition-colors"
             >
               <input
                 type="checkbox"
@@ -122,8 +130,8 @@ export default function GrammarLessonView({
                 className="mt-1 w-4 h-4 accent-indigo-600"
               />
               <div>
-                <div className="font-semibold text-slate-800">{label}</div>
-                <div className="text-sm text-slate-500">{description}</div>
+                <div className="font-semibold text-shodo-ink">{label}</div>
+                <div className="text-sm text-shodo-ink-light">{description}</div>
               </div>
             </label>
           ))}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -231,9 +231,8 @@ export interface GrammarLesson {
   pattern: string;
   title: string;
   jlptLevel: string;
-  classification?: GrammarClassification;
   meaning: string;
-  formation: string;
+  formation: string | string[];
   notes: string;
   examples: {
     japanese: string;
@@ -246,7 +245,6 @@ export interface GrammarLesson {
 
 export interface UserGrammarLesson {
   id: string;
-  userId: string;
   kuId: string;
   lessonId: string;
   sourceType: "scenario" | "concept";
@@ -277,28 +275,13 @@ export type KnowledgeUnitType =
 
 // ─── KnowledgeUnit discriminated union ───────────────────────────────────────
 
-/**
- * Fields shared by every KU sub-type.
- * Deprecated fields remain here until the User state migration is complete.
- */
+/** Fields shared by every KU sub-type. */
 export interface KnowledgeUnitBase {
   id: string;
   content: string; // The main "thing" (e.g., "食べる", "家族")
   relatedUnits: string[]; // Array of other KnowledgeUnit IDs
-  /** @deprecated migrating to User state models */
-  userId: string;
-  /** @deprecated migrating to User state models */
-  personalNotes: string;
-  /** @deprecated migrating to User state models */
-  userNotes?: string;
-  /** @deprecated migrating to User state models */
   createdAt: Timestamp;
-  /** @deprecated migrating to User state models */
-  status: "learning" | "reviewing";
-  /** @deprecated migrating to User state models */
-  facet_count: number;
-  /** @deprecated migrating to User state models */
-  history?: any[];
+  data: Record<string, any>;
 }
 
 export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
@@ -309,6 +292,7 @@ export interface VocabKnowledgeUnit extends KnowledgeUnitBase {
     conjugationType?: 'godan' | 'ichidan' | 'irregular';
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
+    corpusNotes?: string;
     [key: string]: any;
   };
 }
@@ -319,6 +303,7 @@ export interface KanjiKnowledgeUnit extends KnowledgeUnitBase {
     meaning?: string;
     jlptLevel?: string | null;
     wanikaniLevel?: number | null;
+    corpusNotes?: string;
     [key: string]: any;
   };
 }
@@ -492,8 +477,6 @@ export interface UserKnowledgeUnit {
   id: string;
   userId: string;
   kuId: string; // Bridges to GlobalKnowledgeUnit.id
-  personalNotes: string;
-  userNotes?: string;
   createdAt: Timestamp;
   status: "learning" | "reviewing";
   facet_count: number;
@@ -522,7 +505,8 @@ export type FacetType =
 export interface ReviewFacet {
   id: string;
   userId: string;
-  kuId: string; // ID of the parent KnowledgeUnit
+  kuId: string;
+  sourceCollection?: 'knowledge-units' | 'concepts' | 'scenarios';
   facetType: FacetType;
   srsStage: number; // 0 (new) to 8 (mastered)
   nextReviewAt: Timestamp; // ISO string
@@ -559,6 +543,7 @@ export type LessonDifficulty =
 export interface QuestionItem {
   id: string;
   kuId: string;
+  sourceCollection?: 'knowledge-units' | 'concepts' | 'scenarios';
   data: {
     context?: string;
     question: string;
@@ -569,23 +554,10 @@ export interface QuestionItem {
   rank: number;
   rejectionCount: number;
   createdAt: string | Timestamp;
-  /** @deprecated */
-  userId?: string;
-  /** @deprecated */
-  status?: "active" | "flagged" | "inactive";
-  /** @deprecated */
-  lastUsed?: string | Timestamp;
-  /** @deprecated */
-  previousAnswers?: {
-    answer: string;
-    result: "pass" | "fail";
-    timestamp: Timestamp;
-  }[];
 }
 
 export interface UserQuestionState {
   questionId: string;
-  kuId: string;
   rejected: boolean;
   consecutiveFailures: number;
 }


### PR DESCRIPTION
Data model cleanup — type hygiene & anomaly audit
  
  Systematic pass through DATA-MODEL.md anomalies. No behaviour changes; all runtime writes are additive or stop writing
  fields that were never read.

  Types (backend/src/types/index.ts + frontend/src/types/index.ts)

  - KnowledgeUnitBase — removed deprecated fields: personalNotes, userNotes, userId, facet_count, history, status. Added
  data: Record<string, any> to the base so subtypes can narrow it without breaking unguarded call sites.
  - GrammarKnowledgeUnit.data.jlptLevel — added jlptLevel?: string | null to backend type (frontend already had it).
  Removes as any casts in EditKnowledgeUnitModal.
  - GrammarLesson.classification — removed. Classification is hand-authored KU-level data and must never be AI-generated.
   Field was never written to lesson documents.
  - VocabKnowledgeUnit.data / KanjiKnowledgeUnit.data — added corpusNotes?: string, matching the Grammar pattern. Admin
  modal now shows a "Corpus Notes" section for Vocab/Kanji (hidden for Grammar which has its own).
  - ReviewFacet — added sourceCollection?: 'knowledge-units' | 'concepts' | 'scenarios' discriminant. New
  resolveKuCollection() helper exported from reviews.service.ts infers collection from source.type on old documents
  without the field.
  - QuestionItem — added sourceCollection; removed four deprecated fields (userId, status, lastUsed, previousAnswers).
  - UserGrammarLesson.userId — removed. Document lives at users/{uid}/user-grammar-lessons/ — uid is implicit in path.
  - UserQuestionState.kuId — removed. Was denormalised from Question.kuId at write time and never read back from state.
  - GrammarNote.explanation — removed from type and tutor tool schema. Field was emitted by the AI but never consumed by
  ensureGrammarKU or any other code path.

  Services
  
  - reviews.service.ts — resolveKuCollection() added; all facet write paths now stamp sourceCollection; dead 'scenario'
  branch removed (scenarios never create facets directly).
  - questions.service.ts — sourceCollection stamped on new question documents; kuId removed from UserQuestionState
  writes.
  - lessons.service.ts — userId removed from UserGrammarLesson write.
  - knowledge-units.service.ts, user-knowledge-units.service.ts, kanji.service.ts, knowledge-units.controller.ts —
  personalNotes, userNotes, facet_count removed from create/return paths.
  - tutor-tool.registry.ts — explanation removed from grammarNotes item schema and required array.

  Frontend

  - EditKnowledgeUnitModal.tsx — personalNotes removed; userNotes renamed to corpusNotes (reads/saves to
  data.corpusNotes); Corpus Notes section gated to Vocab/Kanji only; as any casts on jlptLevel removed.
  - manage/page.tsx — personalNotes display removed; "User Notes" label → "Corpus Notes"; saves to data.corpusNotes.
  - learn/session/page.tsx (GrammarNotesSlide) — was rendering gl.notes as a raw string. Now splits on \n\n with literal
  \n normalisation so hand-authored paragraph breaks in Firestore render correctly.
  - GrammarLessonView.tsx — same \n\n split applied for consistency.

  Docs

  - DATA-MODEL.md — all 13 anomalies annotated: 9 FIXED, 2 NOT APPLICABLE (with explanation), 1 won't-fix (Concept
  migration — complexity documented), 1 by-design (dual-path collection routing via helpers).
