### PR TITLE
fix: better review ux

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,11 +19,12 @@ import { UserModule } from './users/user.module';
 import { UserKnowledgeUnitsModule } from './user-knowledge-units/user-knowledge-units.module';
 import { ConceptsModule } from './concepts/concepts.module';
 import { LearningProgressModule } from './learning-progress/learning-progress.module';
+import { ReviewProgressModule } from './review-progress/review-progress.module';
 import { TutorModule } from './tutor/tutor.module';
 import { DailyPlanModule } from './daily-plan/daily-plan.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, LearningProgressModule, TutorModule, DailyPlanModule],
+  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, LearningProgressModule, ReviewProgressModule, TutorModule, DailyPlanModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/lib/facet-sequences.ts
+++ b/backend/src/lib/facet-sequences.ts
@@ -1,0 +1,101 @@
+import { KuFacetSequence } from '../types';
+
+/**
+ * Defines the ordered unlock sequence for each KU type.
+ *
+ * unlockAtSrsStage: all facets in this stage must reach this SRS stage before
+ * the next stage's facets are created. Corresponds roughly to:
+ *   1 = ~4 h   2 = ~8 h   3 = ~1 day   4 = ~2 days   5 = ~1 week
+ *
+ * null = terminal — no further stages unlock from here.
+ *
+ * Stages with source 'kanji-components' are skipped automatically for KUs
+ * whose lesson has no component_kanji entries.
+ */
+export const FACET_SEQUENCES: KuFacetSequence[] = [
+  {
+    kuType: 'Vocab',
+    stages: [
+      {
+        stage: 1,
+        facets: [{ type: 'Kanji-Component-Meaning', source: 'kanji-components' }],
+        unlockAtSrsStage: 2,
+      },
+      {
+        stage: 2,
+        facets: [{ type: 'Content-to-Definition', source: 'primary' }],
+        unlockAtSrsStage: 3,
+      },
+      {
+        stage: 3,
+        facets: [{ type: 'Definition-to-Content', source: 'primary' }],
+        unlockAtSrsStage: 3,
+      },
+      {
+        stage: 4,
+        facets: [{ type: 'Content-to-Reading', source: 'primary' }],
+        unlockAtSrsStage: 4,
+      },
+      {
+        stage: 5,
+        facets: [{ type: 'audio', source: 'primary' }],
+        unlockAtSrsStage: 4,
+      },
+      {
+        stage: 6,
+        facets: [{ type: 'AI-Generated-Question', source: 'primary' }],
+        unlockAtSrsStage: 5,
+      },
+      {
+        stage: 7,
+        facets: [{ type: 'Kanji-Component-Reading', source: 'kanji-components' }],
+        unlockAtSrsStage: null,
+      },
+    ],
+  },
+  {
+    kuType: 'Kanji',
+    stages: [
+      {
+        stage: 1,
+        facets: [{ type: 'Kanji-Component-Meaning', source: 'primary' }],
+        unlockAtSrsStage: 2,
+      },
+      {
+        stage: 2,
+        facets: [{ type: 'Kanji-Component-Reading', source: 'primary' }],
+        unlockAtSrsStage: null,
+      },
+    ],
+  },
+  {
+    kuType: 'Grammar',
+    stages: [
+      {
+        stage: 1,
+        facets: [{ type: 'sentence-assembly', source: 'examples' }],
+        unlockAtSrsStage: 3,
+      },
+      {
+        stage: 2,
+        facets: [{ type: 'AI-Generated-Question', source: 'primary' }],
+        unlockAtSrsStage: null,
+      },
+    ],
+  },
+  {
+    kuType: 'Concept',
+    stages: [
+      {
+        stage: 1,
+        facets: [{ type: 'sentence-assembly', source: 'examples' }],
+        unlockAtSrsStage: 3,
+      },
+      {
+        stage: 2,
+        facets: [{ type: 'AI-Generated-Question', source: 'primary' }],
+        unlockAtSrsStage: null,
+      },
+    ],
+  },
+];

--- a/backend/src/review-progress/review-progress.module.ts
+++ b/backend/src/review-progress/review-progress.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { ReviewProgressService } from './review-progress.service';
+import { KnowledgeUnitsModule } from '../knowledge-units/knowledge-units.module';
+import { LessonsModule } from '../lessons/lessons.module';
+import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
+import { GeminiModule } from '../gemini/gemini.module';
+
+@Global()
+@Module({
+  imports: [KnowledgeUnitsModule, LessonsModule, UserKnowledgeUnitsModule, GeminiModule],
+  providers: [ReviewProgressService],
+  exports: [ReviewProgressService],
+})
+export class ReviewProgressModule {}

--- a/backend/src/review-progress/review-progress.service.ts
+++ b/backend/src/review-progress/review-progress.service.ts
@@ -1,0 +1,324 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { CollectionReference, FieldValue, Firestore, Timestamp } from 'firebase-admin/firestore';
+import {
+  FIRESTORE_CONNECTION,
+  REVIEW_FACETS_COLLECTION,
+} from '../firebase/firebase.module';
+import { ADMIN_USER_ID } from '../lib/constants';
+import { FACET_SEQUENCES } from '../lib/facet-sequences';
+import {
+  FacetStageDefinition,
+  FacetStageEntry,
+  GrammarLesson,
+  KanjiLesson,
+  KnowledgeUnit,
+  KuFacetSequence,
+  Lesson,
+  ReviewFacet,
+  VocabLesson,
+} from '../types';
+import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
+import { LessonsService } from '../lessons/lessons.service';
+import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledge-units.service';
+import { GeminiService } from '../gemini/gemini.service';
+import { LearningProgressService } from '../learning-progress/learning-progress.service';
+
+@Injectable()
+export class ReviewProgressService {
+  private readonly logger = new Logger(ReviewProgressService.name);
+
+  constructor(
+    @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+    private readonly knowledgeUnitsService: KnowledgeUnitsService,
+    private readonly lessonsService: LessonsService,
+    private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
+    private readonly geminiService: GeminiService,
+    private readonly learningProgressService: LearningProgressService,
+  ) {}
+
+  private facetsColRef(uid: string): CollectionReference {
+    if (uid === ADMIN_USER_ID) {
+      return this.db.collection(REVIEW_FACETS_COLLECTION);
+    }
+    return this.db.collection('users').doc(uid).collection(REVIEW_FACETS_COLLECTION);
+  }
+
+  /**
+   * Called when a user completes a lesson. Creates the first applicable stage's
+   * facets and records currentStage on the UKU.
+   */
+  async initializeSequence(
+    uid: string,
+    kuId: string,
+  ): Promise<{ stage: number; facetsCreated: number }> {
+    const ku = await this.knowledgeUnitsService.findOne(kuId);
+    if (!ku) {
+      this.logger.warn(`initializeSequence: KU not found kuId=${kuId}`);
+      return { stage: 0, facetsCreated: 0 };
+    }
+
+    const lesson = await this.lessonsService.findByKuId(uid, kuId);
+    if (!lesson) {
+      this.logger.warn(`initializeSequence: no lesson found for kuId=${kuId}`);
+      return { stage: 0, facetsCreated: 0 };
+    }
+
+    const sequence = FACET_SEQUENCES.find(s => s.kuType === ku.type);
+    if (!sequence) {
+      this.logger.warn(`initializeSequence: no sequence defined for kuType=${ku.type}`);
+      return { stage: 0, facetsCreated: 0 };
+    }
+
+    const firstStage = this.findFirstApplicableStage(sequence, lesson);
+    if (!firstStage) {
+      this.logger.warn(`initializeSequence: no applicable stage for kuId=${kuId}`);
+      return { stage: 0, facetsCreated: 0 };
+    }
+
+    await this.userKnowledgeUnitsService.create(uid, kuId);
+    const facetsCreated = await this.createFacetsForStage(uid, kuId, ku, lesson, firstStage);
+    await this.userKnowledgeUnitsService.update(uid, kuId, { currentStage: firstStage.stage });
+    await this.learningProgressService.recomputeAndCache(uid, kuId);
+
+    this.logger.log(
+      `Initialized sequence for uid=${uid} kuId=${kuId}: stage=${firstStage.stage} facets=${facetsCreated}`,
+    );
+    return { stage: firstStage.stage, facetsCreated };
+  }
+
+  /**
+   * Called after every facet SRS update. Checks whether the current stage's
+   * unlock condition is met and if so creates the next stage's facets.
+   * Non-blocking — caller should fire-and-forget.
+   */
+  async checkAndAdvanceStage(uid: string, kuId: string): Promise<void> {
+    const uku = await this.userKnowledgeUnitsService.findByKuId(uid, kuId);
+    if (!uku?.currentStage) return; // 0 or missing = sequence not initialized
+
+    const ku = await this.knowledgeUnitsService.findOne(kuId);
+    if (!ku) return;
+
+    const sequence = FACET_SEQUENCES.find(s => s.kuType === ku.type);
+    if (!sequence) return;
+
+    const currentStageDef = sequence.stages.find(s => s.stage === uku.currentStage);
+    if (!currentStageDef || currentStageDef.unlockAtSrsStage === null) return; // terminal
+
+    const stageFacets = await this.getFacetsAtStage(uid, kuId, uku.currentStage);
+    if (stageFacets.length === 0) return;
+
+    const allReady = stageFacets.every(
+      f => (f.srsStage ?? 0) >= currentStageDef.unlockAtSrsStage!,
+    );
+    if (!allReady) return;
+
+    const lesson = await this.lessonsService.findByKuId(uid, kuId);
+    if (!lesson) return;
+
+    const nextStage = this.findNextApplicableStage(sequence, lesson, uku.currentStage);
+    if (!nextStage) return;
+
+    // Guard against concurrent calls (e.g. two sentence-assembly facets reviewed in quick
+    // succession): if next-stage facets already exist, the first call already advanced us.
+    const alreadyCreated = await this.getFacetsAtStage(uid, kuId, nextStage.stage);
+    if (alreadyCreated.length > 0) {
+      this.logger.log(`Stage ${nextStage.stage} facets already exist for kuId=${kuId}, skipping duplicate advance`);
+      return;
+    }
+
+    this.logger.log(
+      `Advancing sequence uid=${uid} kuId=${kuId}: ${uku.currentStage} → ${nextStage.stage}`,
+    );
+
+    await this.createFacetsForStage(uid, kuId, ku, lesson, nextStage);
+    await this.userKnowledgeUnitsService.update(uid, kuId, { currentStage: nextStage.stage });
+    await this.learningProgressService.recomputeAndCache(uid, kuId);
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
+  /** First stage that has at least one applicable entry given the lesson data. */
+  private findFirstApplicableStage(
+    sequence: KuFacetSequence,
+    lesson: Lesson,
+  ): FacetStageDefinition | null {
+    for (const stageDef of sequence.stages) {
+      if (this.stageIsApplicable(stageDef, lesson)) return stageDef;
+    }
+    return null;
+  }
+
+  /** Next stage after currentStage that has at least one applicable entry. */
+  private findNextApplicableStage(
+    sequence: KuFacetSequence,
+    lesson: Lesson,
+    currentStage: number,
+  ): FacetStageDefinition | null {
+    const remaining = sequence.stages.filter(s => s.stage > currentStage);
+    for (const stageDef of remaining) {
+      if (this.stageIsApplicable(stageDef, lesson)) return stageDef;
+    }
+    return null;
+  }
+
+  /**
+   * A stage is applicable if at least one of its entries can produce facet data.
+   * Kanji-component entries are skipped when the lesson has no component_kanji.
+   */
+  private stageIsApplicable(stageDef: FacetStageDefinition, lesson: Lesson): boolean {
+    return stageDef.facets.some(entry => this.buildFacetData(entry, lesson).length > 0);
+  }
+
+  /** Returns all facets for a KU that belong to a given sequence stage. */
+  private async getFacetsAtStage(
+    uid: string,
+    kuId: string,
+    stage: number,
+  ): Promise<ReviewFacet[]> {
+    const snapshot = await this.facetsColRef(uid).where('kuId', '==', kuId).get();
+    return snapshot.docs
+      .map(d => ({ id: d.id, ...d.data() }) as ReviewFacet)
+      .filter(f => f.sequenceStage === stage);
+  }
+
+  /** Creates all facets for a stage and increments UKU facet_count. */
+  private async createFacetsForStage(
+    uid: string,
+    kuId: string,
+    ku: KnowledgeUnit,
+    lesson: Lesson,
+    stageDef: FacetStageDefinition,
+  ): Promise<number> {
+    const batch = this.db.batch();
+    const now = Timestamp.now();
+    let count = 0;
+
+    for (const entry of stageDef.facets) {
+      let dataItems = this.buildFacetData(entry, lesson);
+      if (dataItems.length === 0) continue;
+
+      // Audio facets: generate cloze sentences before the batch write
+      if (entry.type === 'audio') {
+        dataItems = await Promise.all(
+          dataItems.map(async d => {
+            if (d.contextExample?.sentence) {
+              try {
+                d.clozeSentence = await this.geminiService.generateClozeSentence(
+                  ku.content,
+                  d.contextExample.sentence,
+                );
+              } catch (e) {
+                this.logger.error(`Cloze generation failed for kuId=${kuId}`, e);
+              }
+            }
+            return d;
+          }),
+        );
+      }
+
+      for (const data of dataItems) {
+        batch.set(this.facetsColRef(uid).doc(), {
+          kuId,
+          sourceCollection: ku.type === 'Concept' ? 'concepts' : 'knowledge-units',
+          facetType: entry.type,
+          srsStage: 0,
+          nextReviewAt: now,
+          createdAt: now,
+          history: [],
+          sequenceStage: stageDef.stage,
+          source: { type: 'lesson', id: kuId },
+          ...(uid === ADMIN_USER_ID ? { userId: uid } : {}),
+          data,
+        });
+        count++;
+      }
+    }
+
+    if (count === 0) return 0;
+
+    await batch.commit();
+    await this.userKnowledgeUnitsService.update(uid, kuId, {
+      facet_count: FieldValue.increment(count),
+    });
+
+    return count;
+  }
+
+  /**
+   * Builds the data payload(s) for a single facet entry.
+   * Returns an array: 'kanji-components' and 'examples' produce one item per component/example;
+   * 'primary' produces a single item (or empty array when data is unavailable).
+   */
+  private buildFacetData(entry: FacetStageEntry, lesson: Lesson): Record<string, any>[] {
+    if (entry.source === 'kanji-components') {
+      if (lesson.type !== 'Vocab') return [];
+      const vl = lesson as VocabLesson;
+      const components = vl.component_kanji ?? [];
+      if (components.length === 0) return [];
+
+      return components.map(k => {
+        if (entry.type === 'Kanji-Component-Meaning') {
+          return { content: k.kanji, meaning: k.meaning };
+        }
+        // Kanji-Component-Reading — include vocabReading so the card can flag mismatches
+        return {
+          content: k.kanji,
+          vocabReading: k.reading,
+          onyomi: k.onyomi ?? [],
+          kunyomi: k.kunyomi ?? [],
+        };
+      });
+    }
+
+    if (entry.source === 'examples') {
+      if (lesson.type === 'Grammar') {
+        const gl = lesson as GrammarLesson;
+        return (gl.examples ?? []).map(ex => ({
+          goalTitle: gl.pattern,
+          fragments: ex.fragments,
+          answer: ex.japanese,
+          english: ex.english,
+          accepted_alternatives: ex.accepted_alternatives ?? [],
+        }));
+      }
+      return [];
+    }
+
+    // source === 'primary'
+    if (lesson.type === 'Vocab') {
+      const vl = lesson as VocabLesson;
+
+      if (entry.type === 'audio') {
+        const examples = vl.context_examples ?? [];
+        if (examples.length === 0) return [];
+        const contextExample = examples[Math.floor(Math.random() * examples.length)];
+        return [{ content: vl.vocab, reading: vl.reading, definitions: vl.definitions ?? [], contextExample }];
+      }
+
+      // Skip reading review for kana-only vocab — content IS the reading
+      if (entry.type === 'Content-to-Reading' && vl.vocab === vl.reading) return [];
+
+      // Content-to-Definition, Definition-to-Content, Content-to-Reading, AI-Generated-Question
+      return [{ content: vl.vocab, reading: vl.reading, definitions: vl.definitions ?? [] }];
+    }
+
+    if (lesson.type === 'Kanji') {
+      const kl = lesson as KanjiLesson;
+      if (entry.type === 'Kanji-Component-Meaning') {
+        return [{ content: kl.kanji, meaning: kl.meaning, onyomi: kl.onyomi, kunyomi: kl.kunyomi }];
+      }
+      if (entry.type === 'Kanji-Component-Reading') {
+        return [{ content: kl.kanji, onyomi: kl.onyomi, kunyomi: kl.kunyomi }];
+      }
+    }
+
+    if (lesson.type === 'Grammar') {
+      const gl = lesson as GrammarLesson;
+      if (entry.type === 'AI-Generated-Question') {
+        return [{ content: gl.pattern, pattern: gl.pattern, title: gl.title }];
+      }
+    }
+
+    return [];
+  }
+}

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post, Body, BadRequestException, Put, Param, Get, Query, Logger, UseGuards } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
+import { ReviewProgressService } from '../review-progress/review-progress.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { UserId } from '../auth/user-id.decorator';
 
@@ -8,7 +9,10 @@ import { UserId } from '../auth/user-id.decorator';
 export class ReviewsController {
   private readonly logger = new Logger(ReviewsController.name);
 
-  constructor(private readonly reviewsService: ReviewsService) { }
+  constructor(
+    private readonly reviewsService: ReviewsService,
+    private readonly reviewProgressService: ReviewProgressService,
+  ) { }
 
   @Post('evaluate')
   async evaluate(@UserId() uid: string, @Body() body: { userAnswer: string; expectedAnswers: string[]; question: string; topic: string; questionId: string; kuId: string; facetType?: string }) {
@@ -55,6 +59,15 @@ export class ReviewsController {
     }
 
     return this.reviewsService.generateReviewFacets(uid, body.kuId, body.facetsToCreate, body.selfCertifiedFacets ?? []);
+  }
+
+  @Post('initialize-sequence')
+  async initializeSequence(
+    @UserId() uid: string,
+    @Body() body: { kuId: string },
+  ) {
+    if (!body.kuId) throw new BadRequestException('Missing kuId');
+    return this.reviewProgressService.initializeSequence(uid, body.kuId);
   }
 
   @Get('facets')

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -9,6 +9,7 @@ import { StatsModule } from '../stats/stats.module';
 import { UserKnowledgeUnitsModule } from '../user-knowledge-units/user-knowledge-units.module';
 import { ScenariosModule } from '../scenarios/scenarios.module';
 import { LearningProgressModule } from '../learning-progress/learning-progress.module';
+import { ReviewProgressModule } from '../review-progress/review-progress.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { LearningProgressModule } from '../learning-progress/learning-progress.m
     UserKnowledgeUnitsModule,
     ScenariosModule,
     LearningProgressModule,
+    ReviewProgressModule,
   ],
   controllers: [ReviewsController],
   providers: [ReviewsService],

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -20,6 +20,7 @@ import { UserKnowledgeUnitsService } from '../user-knowledge-units/user-knowledg
 import { StatsService } from '../stats/stats.service';
 import { ScenariosService } from '../scenarios/scenarios.service';
 import { LearningProgressService } from '../learning-progress/learning-progress.service';
+import { ReviewProgressService } from '../review-progress/review-progress.service';
 import { buildAnswerEvaluatorPrompt } from '../prompts/evaluation.prompts';
 
 /**
@@ -37,18 +38,31 @@ export function resolveKuCollection(facet: Pick<ReviewFacet, 'sourceCollection' 
 export class ReviewsService {
     private readonly logger = new Logger(ReviewsService.name);
 
-    // SRS intervals in hours (maps to srsStage)
-    private readonly INTERVALS = {
-        0: 10 / 60, // 10 minutes
-        1: 8, // 8 hours
-        2: 24, // 1 day
-        3: 72, // 3 days
-        4: 168, // 1 week
-        5: 336, // 2 weeks
-        6: 730, // 1 month (approx)
-        7: 2920, // 4 months
-        8: 8760, // 1 year
-    };
+    // SRS intervals in hours (maps to srsStage).
+    // Set SRS_TEST_MODE=true in backend/.env to use the compressed testing schedule.
+    private readonly INTERVALS = process.env.SRS_TEST_MODE === 'true'
+        ? {
+            0: 10 / 60,   // 10 min
+            1: 10 / 60,   // 10 min
+            2: 10 / 60,   // 10 min
+            3: 10 / 60,   // 10 min
+            4: 10 / 60,   // 10 min
+            5: 10 / 60,   // 10 min
+            6: 730,
+            7: 2920,
+            8: 8760,
+        }
+        : {
+            0: 10 / 60,   // 10 min
+            1: 8,         // 8 h
+            2: 24,        // 1 day
+            3: 72,        // 3 days
+            4: 168,       // 1 week
+            5: 336,       // 2 weeks
+            6: 730,       // ~1 month
+            7: 2920,      // 4 months
+            8: 8760,      // 1 year
+        };
 
     constructor(
         @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
@@ -60,6 +74,7 @@ export class ReviewsService {
         private readonly statsService: StatsService,
         private readonly scenariosService: ScenariosService,
         private readonly learningProgressService: LearningProgressService,
+        private readonly reviewProgressService: ReviewProgressService,
     ) { }
 
     private facetsColRef(uid: string): CollectionReference {
@@ -160,6 +175,17 @@ export class ReviewsService {
         // Post-transaction: recompute and cache UKU status from facet SRS data
         if (txResult.kuId) {
             await this.learningProgressService.recomputeAndCache(uid, txResult.kuId);
+        }
+
+        // Post-transaction: check if this SRS update unlocks the next facet stage
+        if (txResult.kuId && txResult.newStage > txResult.prevStage) {
+            void (async () => {
+                try {
+                    await this.reviewProgressService.checkAndAdvanceStage(uid, txResult.kuId);
+                } catch (e) {
+                    this.logger.error(`checkAndAdvanceStage failed uid=${uid} kuId=${txResult.kuId}`, e);
+                }
+            })();
         }
 
         // Post-transaction: check if a linked scenario's vocab is now all drill-ready

--- a/backend/src/stats/stats.service.ts
+++ b/backend/src/stats/stats.service.ts
@@ -44,6 +44,20 @@ export class StatsService {
             .count()
             .get();
 
+        const next24HoursQuery = facetsCol
+            .where("nextReviewAt", ">", Timestamp.now())
+            .where("nextReviewAt", "<=", Timestamp.fromDate(new Date(Date.now() + 24 * 60 * 60 * 1000)))
+            .count()
+            .get();
+
+        const endOfToday = new Date();
+        endOfToday.setHours(23, 59, 59, 999);
+        const restOfTodayQuery = facetsCol
+            .where("nextReviewAt", ">", Timestamp.now())
+            .where("nextReviewAt", "<=", Timestamp.fromMillis(endOfToday.getTime()))
+            .count()
+            .get();
+
         const userStatsQuery = this.db.collection('users').doc(uid).get();
 
         const scenariosCol = uid === ADMIN_USER_ID
@@ -54,11 +68,13 @@ export class StatsService {
             .count()
             .get();
 
-        const [ukuLearnSnapshot, reviewingSnapshot, masteredSnapshot, reviewsSnapshot, userStatsDoc, simulateScenariosSnapshot] = await Promise.all([
+        const [ukuLearnSnapshot, reviewingSnapshot, masteredSnapshot, reviewsSnapshot, next24HoursSnapshot, restOfTodaySnapshot, userStatsDoc, simulateScenariosSnapshot] = await Promise.all([
             ukuLearnQuery,
             reviewQuery,
             masteredQuery,
             reviewsDueQuery,
+            next24HoursQuery,
+            restOfTodayQuery,
             userStatsQuery,
             simulateScenariosQuery,
         ]);
@@ -77,14 +93,9 @@ export class StatsService {
 
         // --- CALCULATION LOGIC ---
 
-        // 1. Next 24 Hours
-        // Sum hourly buckets from (now + 1h) to (now + 24h)
-        let next24HoursCount = 0;
-        for (let i = 1; i <= 24; i++) {
-            const futureHour = new Date(now.getTime() + i * 60 * 60 * 1000);
-            const key = this.getDateBuckets(futureHour).hourKey;
-            next24HoursCount += (rawHourlyForecast[key] || 0);
-        }
+        // 1. Next 24 Hours — direct range query so past-due items (nextReviewAt <= now) are
+        // never double-counted with reviewsDue, regardless of SRS interval length.
+        const next24HoursCount = next24HoursSnapshot.data().count;
 
         // 2. 5-Day Schedule
         // Day 0: Rest of Today (remaining hours)
@@ -93,20 +104,8 @@ export class StatsService {
         const schedule: { date: string; isToday: boolean; count: number; runningTotal: number; label: string; }[] = [];
         let runningTotal = reviewsDueCount;
 
-        // Day 0 (Today)
-        let todayRemainingCount = 0;
-        const startHour = now.getHours() + 1; // start from next hour
-        if (startHour < 24) {
-            const todayBuckets = this.getDateBuckets(now);
-            // Reconstruct the hour keys for the rest of today
-            // Note: simple string manipulation is safe here as yyyy-mm-dd is stable for the loop
-            const prefix = todayBuckets.dayKey;
-            for (let h = startHour; h < 24; h++) {
-                const hh = String(h).padStart(2, '0');
-                const key = `${prefix}-${hh}`;
-                todayRemainingCount += (rawHourlyForecast[key] || 0);
-            }
-        }
+        // Day 0 (Today) — direct range query avoids hourly-bucket blind spots (e.g. same-hour reschedules)
+        const todayRemainingCount = restOfTodaySnapshot.data().count;
 
         runningTotal += todayRemainingCount;
         schedule.push({

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -376,6 +376,28 @@ export interface UserKnowledgeUnit {
     type: 'scenario' | 'lesson';
     id: string;
   };
+  /** Current position in the facet unlock sequence. 0 = not yet initialized. */
+  currentStage?: number;
+}
+
+// ─── Facet sequence types ────────────────────────────────────────────────────
+
+export interface FacetStageEntry {
+  type: FacetType;
+  /** Where the facet data comes from. 'kanji-components' produces one facet per component. */
+  source: 'primary' | 'kanji-components' | 'examples';
+}
+
+export interface FacetStageDefinition {
+  stage: number;
+  facets: FacetStageEntry[];
+  /** All facets in this stage must reach this SRS stage before the next stage unlocks. null = terminal. */
+  unlockAtSrsStage: number | null;
+}
+
+export interface KuFacetSequence {
+  kuType: string;
+  stages: FacetStageDefinition[];
 }
 
 export interface UserConcept {
@@ -424,6 +446,8 @@ export interface ReviewFacet {
   consecutiveFailures?: number;
   /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
+  /** Which stage in the KU's facet unlock sequence this facet belongs to. */
+  sequenceStage?: number;
   data?: any;
   source?: {
     type: 'lesson' | 'concept';

--- a/frontend/src/app/learn/session/page.tsx
+++ b/frontend/src/app/learn/session/page.tsx
@@ -64,46 +64,11 @@ async function fetchLessonWithRetry(item: QueueItem): Promise<Lesson> {
   }
 }
 
-async function enrollItem(item: QueueItem, lesson: Lesson): Promise<void> {
-  const facetsToCreate: { key: string; data: Record<string, unknown> }[] = [];
-
-  if (lesson.type === "Vocab") {
-    const vl = lesson as VocabLesson;
-    const base = { content: item.content, reading: vl.reading, definitions: vl.definitions ?? [], topic: item.content };
-    const hasReading = vl.reading && vl.reading !== item.content;
-    const examples = vl.context_examples ?? [];
-    facetsToCreate.push({ key: "Definition-to-Content", data: base });
-    facetsToCreate.push({ key: "Content-to-Definition", data: base });
-    if (hasReading) facetsToCreate.push({ key: "Content-to-Reading", data: base });
-    if (examples.length > 0) {
-      facetsToCreate.push({ key: "audio", data: { ...base, contextExample: examples[Math.floor(Math.random() * examples.length)] } });
-    }
-    facetsToCreate.push({ key: "AI-Generated-Question", data: base });
-    for (const k of vl.component_kanji ?? []) {
-      facetsToCreate.push({ key: `Kanji-Component-${k.kanji}`, data: { meaning: k.meaning, onyomi: k.onyomi ?? [], kunyomi: k.kunyomi ?? [] } });
-    }
-  } else if (lesson.type === "Kanji") {
-    const kl = lesson as KanjiLesson;
-    const base = { content: item.content, meaning: kl.meaning, onyomi: kl.onyomi, kunyomi: kl.kunyomi };
-    facetsToCreate.push({ key: "Kanji-Component-Meaning", data: base });
-    facetsToCreate.push({ key: "Kanji-Component-Reading", data: base });
-  } else if (lesson.type === "Grammar") {
-    const gl = lesson as GrammarLesson;
-    for (const ex of gl.examples) {
-      facetsToCreate.push({
-        key: "sentence-assembly",
-        data: { goalTitle: gl.pattern, fragments: ex.fragments, answer: ex.japanese, english: ex.english, accepted_alternatives: ex.accepted_alternatives ?? [], sourceId: item.kuId, sourceTitle: gl.title },
-      });
-    }
-    facetsToCreate.push({ key: "AI-Generated-Question", data: { content: gl.pattern, topic: gl.title, sourceId: item.kuId, sourceTitle: gl.title } });
-    facetsToCreate.push({ key: "Content-to-Definition", data: { content: gl.pattern, definitions: [gl.meaning], topic: gl.title, kuType: "Grammar" } });
-  }
-
-  if (facetsToCreate.length === 0) return;
-  await apiFetch("/api/reviews/generate", {
+async function enrollItem(item: QueueItem): Promise<void> {
+  await apiFetch("/api/reviews/initialize-sequence", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ kuId: item.kuId, facetsToCreate, selfCertifiedFacets: [] }),
+    body: JSON.stringify({ kuId: item.kuId }),
   });
 }
 
@@ -465,8 +430,8 @@ export default function LessonSessionPage() {
     })();
   }, []);
 
-  const triggerEnrollment = useCallback((loaded: LoadedItem) => {
-    enrollmentPromises.current.push(enrollItem(loaded.item, loaded.lesson));
+  const triggerEnrollment = useCallback((item: QueueItem) => {
+    enrollmentPromises.current.push(enrollItem(item));
   }, []);
 
   const advance = useCallback(async () => {
@@ -480,7 +445,7 @@ export default function LessonSessionPage() {
       return;
     }
     // Finished this item — enroll it
-    triggerEnrollment(loaded);
+    triggerEnrollment(loaded.item);
 
     if (!isLastItem) {
       setCurrentItemIdx(i => i + 1);

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, FormEvent } from "react";
+import React, { useState, useEffect, useRef, useCallback, FormEvent } from "react";
 import Link from "next/link";
 import { ReviewItem, ReviewFacet, KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson } from "@/types";
 import * as wanakana from "wanakana";
@@ -99,6 +99,17 @@ export default function ReviewPage() {
   const currentItem = reviewQueue[currentIndex];
 
   const reviewCount = reviewQueue.length;
+  const isSessionComplete = reviewQueue.length > 0 && currentIndex >= reviewQueue.length;
+
+  // Refresh header stats when session ends, with a delay to let fire-and-forget
+  // stage advancement (checkAndAdvanceStage) finish updating UKU status.
+  useEffect(() => {
+    if (!isSessionComplete) return;
+    const timer = setTimeout(() => {
+      window.dispatchEvent(new CustomEvent("refreshStats"));
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [isSessionComplete]);
 
   const lastFetchedIndex = useRef<number | null>(null);
   const nextButtonRef = useRef<HTMLButtonElement>(null);
@@ -175,27 +186,42 @@ export default function ReviewPage() {
   };
 
   // --- Data Fetching ---
-  useEffect(() => {
-    const fetchDueItems = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        // TODO usenestjs backend service instead
-        const response = await apiFetch("/api/reviews/facets?due=true");
-        if (!response.ok) {
-          throw new Error("Failed to fetch due review items");
-        }
-        const data: ReviewItem[] = await response.json();
-        setReviewQueue(shuffleArray(data));
-      } catch (err) {
-        if (err instanceof Error) setError(err.message);
-        else setError("An unknown error occurred");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchDueItems();
+  const fetchDueItems = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await apiFetch("/api/reviews/facets?due=true");
+      if (!response.ok) throw new Error("Failed to fetch due review items");
+      const data: ReviewItem[] = await response.json();
+      setReviewQueue(shuffleArray(data));
+    } catch (err) {
+      if (err instanceof Error) setError(err.message);
+      else setError("An unknown error occurred");
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  useEffect(() => { fetchDueItems(); }, [fetchDueItems]);
+
+  // Reload queue when the header Review tab is clicked while already on this page
+  useEffect(() => {
+    const handleReload = () => {
+      setCurrentIndex(0);
+      setUserAnswer("");
+      setAnswerState("unanswered");
+      setAiExplanation("");
+      setSessionFailureCounts({});
+      setPendingSrsResult(null);
+      setLevelStatus(null);
+      setShowLesson(false);
+      setLessonForReview(null);
+      setShowFeedbackModal(false);
+      fetchDueItems();
+    };
+    window.addEventListener("reloadReviews", handleReload);
+    return () => window.removeEventListener("reloadReviews", handleReload);
+  }, [fetchDueItems]);
 
   // --- Effect to handle current item changes ---
   useEffect(() => {
@@ -696,7 +722,7 @@ export default function ReviewPage() {
           href="/"
           className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700"
         >
-          Back to Manage
+          Finish
         </Link>
       </main>
     );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "@/lib/api-client";
 import { useAuth } from "@/providers/AuthProvider";
@@ -13,6 +14,7 @@ import { applyFurigana, loadFurigana } from "@/lib/furigana";
  */
 export default function Header() {
   const { user } = useAuth();
+  const pathname = usePathname();
   const [stats, setStats] = useState({ learnCount: 0, reviewingCount: 0, reviewsDue: 0, simulateCount: 0 });
   const [showDailyNudge, setShowDailyNudge] = useState(false);
 
@@ -120,12 +122,21 @@ export default function Header() {
           >
             Learn ({stats.learnCount}/{stats.reviewingCount})
           </Link>
-          <Link
-            href="/review"
-            className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
-          >
-            Review ({stats.reviewsDue})
-          </Link>
+          {pathname === "/review" ? (
+            <button
+              onClick={() => window.dispatchEvent(new CustomEvent("reloadReviews"))}
+              className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
+            >
+              Review ({stats.reviewsDue})
+            </button>
+          ) : (
+            <Link
+              href="/review"
+              className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"
+            >
+              Review ({stats.reviewsDue})
+            </Link>
+          )}
           <Link
             href="/scenarios"
             className="whitespace-nowrap px-4 py-2 rounded-md text-shodo-ink font-medium hover:bg-shodo-ink/5 transition-colors duration-200"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -481,6 +481,23 @@ export interface UserKnowledgeUnit {
   status: "learning" | "reviewing";
   facet_count: number;
   history?: any[];
+  currentStage?: number;
+}
+
+export interface FacetStageEntry {
+  type: FacetType;
+  source: 'primary' | 'kanji-components' | 'examples';
+}
+
+export interface FacetStageDefinition {
+  stage: number;
+  facets: FacetStageEntry[];
+  unlockAtSrsStage: number | null;
+}
+
+export interface KuFacetSequence {
+  kuType: string;
+  stages: FacetStageDefinition[];
 }
 
 /** Distributes Omit across union members, preserving the discriminated union. */
@@ -519,6 +536,7 @@ export interface ReviewFacet {
   currentQuestionId?: string;
   /** @deprecated - failure tracking moved to UserQuestionState.consecutiveFailures */
   questionAttempts?: number;
+  sequenceStage?: number;
   data?: any;
 }
 


### PR DESCRIPTION
## Summary
  
  - **Fix: Today bar empty in Next 24 Hours widget** — The schedule bar chart calculated
    today's upcoming count by summing hourly forecast buckets, skipping the current hour.
    With short SRS intervals, reviews rescheduled to later in the same hour were counted
    by the top-line direct query but invisible to the bar. Replaced the hourly-bucket loop
    with a direct Firestore range query (`nextReviewAt > now AND <= end_of_today`),
    matching the approach already used for the top-line count.

  - **Fix: Review tab does nothing when already on /review** — `Link href="/review"` is a
    no-op in Next.js when already on that route. When new reviews become available mid-session
    the user had no way to load them without a full page reload. The Review tab now renders
    as a button on `/review` that dispatches a `reloadReviews` event; the review page listens
    for this event, resets per-session state, and re-fetches the queue.

  - **Fix: Header stats stale after session ends** — Added a 2-second delayed `refreshStats`
    dispatch when the review queue is exhausted. The delay allows fire-and-forget
    `checkAndAdvanceStage` calls to finish committing UKU status updates before the
    header re-fetches.

  - **Fix: Session complete button labelled "Back to Manage"** — Renamed to "Finish".

  - **Fix: Content-to-Reading facets created for kana-only vocab** — Words like どんな have
    `vocab === reading`; reviewing their reading is a no-op. Added a guard in
    `buildFacetData` to return an empty array for `Content-to-Reading` entries when the
    vocab is kana-only, consistent with how kanji-component stages are skipped when no
    component kanji exist.

