### PR TITLE
feat: implement automated content quality flagging and admin

### DIFF
--- a/CONTENT-QUALITY-GUIDE.md
+++ b/CONTENT-QUALITY-GUIDE.md
@@ -1,0 +1,136 @@
+# Content Quality Guide
+
+This document explains how AIGENKI enforces level-appropriate content and how to investigate and correct violations.
+
+---
+
+## Core Principle: JLPT as Curated Learning Paths
+
+JLPT levels are not abstract difficulty buckets — they are curated learning paths that expose learners to a consistent, well-defined vocabulary and grammar set. An N5 learner should encounter the same set of N5 vocabulary across all generated content, not vocabulary that happens to feel "easy enough."
+
+**The constraint is always: `ku.data.jlptLevel ≤ user.preferences.jlptLevel`.**
+
+Content generated for a user must use vocabulary and grammar at or below that user's declared JLPT level in all surrounding sentences, context examples, and scenario dialogue. The target word or pattern being taught is the sole exception — it can be at any level, since that is the point of the lesson.
+
+---
+
+## Above-Level Items: Separate Path
+
+Users may elect to enroll in vocabulary or grammar above their declared level (e.g., a word they've encountered and want to learn). These items are marked `aboveLevel: true` on their `UserKnowledgeUnit` document at enrollment time.
+
+Above-level items are learned in isolation. They are:
+- **Excluded** from `tutorContext.allowedGrammar` — they do not become part of the ambient generation context
+- **Excluded** from the `get_user_level` and `get_grammar_patterns` tool responses
+- **Not** injected into scenario dialogue, sentence-assembly fragments, or audio facets
+
+This ensures that voluntarily learning an advanced item doesn't contaminate every other generated piece of content.
+
+---
+
+## How Level Constraints Are Applied
+
+Every prompt that generates user-facing Japanese content calls the `get_user_level` Gemini function tool before generating anything. This tool returns:
+
+```json
+{
+  "jlptLevel": "N4",
+  "allowedGrammar": ["〜ている", "〜たことがある", "〜たら", ...]
+}
+```
+
+`allowedGrammar` is the user's actual enrolled grammar patterns, filtered to in-level items only (i.e., `aboveLevel != true`). Prompts must use **only** patterns from this list for surrounding sentences — not the full static JLPT grammar schema.
+
+The user's `jlptLevel` also drives a `levelConstraint` injected into every lesson generation prompt: *"Keep all example sentences at or below JLPT [level], even if the target vocabulary or pattern is more advanced."*
+
+---
+
+## What Counts as a Violation
+
+The `ValidationService` checks generated content post-generation using a Gemini flash model with structured output. It flags:
+
+- **vocab**: A vocabulary item that belongs to a JLPT level above the user's declared level
+- **grammar**: A grammar pattern that belongs to a JLPT level above the user's declared level
+
+The validator checks:
+- `context_examples[].sentence` for Vocab lessons
+- `examples[].japanese` for Grammar lessons
+
+Violations are stored in `content-flags` (Firestore collection) and also written to `lessons/{kuId}.validation`.
+
+---
+
+## Content Flags
+
+Each flag record (`ContentFlag`) contains:
+
+| Field | Description |
+|---|---|
+| `kuId` | The Knowledge Unit whose lesson triggered the flag |
+| `kuContent` | The Japanese word or pattern being taught (e.g. 食べる) |
+| `userLevel` | The user's JLPT level at generation time |
+| `violations` | Array of `{ segment, detectedLevel, type }` |
+| `status` | `open` → `resolved` or `dismissed` |
+| `dismissNote` | Free-text reason if dismissed |
+
+Flags are global (not per-user) because lesson content is global — one lesson document shared by all users at a given level.
+
+---
+
+## Resolving Flags
+
+### Via Admin UI (`/admin/content-quality`)
+
+The admin UI shows all open flags with the offending segments highlighted. Each flag has three actions:
+
+- **Regenerate**: Clears the lesson document and re-triggers generation. The lesson will be re-validated automatically. If it passes, the flag is resolved automatically. If it fails again, a new flag is created.
+- **Resolve**: Marks the flag as `resolved` manually (e.g., after editing the lesson directly via the Lesson editor).
+- **Dismiss**: Marks the flag as `dismissed` with an optional note explaining why the content is acceptable despite the violation.
+
+### Via Claude Code Skill (`/review-content-flags`)
+
+The skill fetches open flags and applies contextual reasoning for each:
+
+1. **Is the violation real?** The validator is conservative but not perfect. An N4 word used as an example in an N4 lesson is not a violation even if it's technically N4. Context matters.
+2. **Is the violation severe?** A single N3 grammar particle in an N5 lesson is more severe than a borderline N4 vocabulary item in an N3 lesson.
+3. **What is the fix?** Options in order of preference:
+   - Dismiss with a note if the content is borderline or the validator is being over-cautious
+   - Edit the specific sentence directly in the lesson (using the Lesson editor or Firestore) if the fix is a targeted substitution
+   - Regenerate if the lesson content is broadly above-level
+
+---
+
+## Validation Service Details
+
+**Model**: `MODEL_GEMINI_FLASH` (env var, defaults to `gemini-2.0-flash`)
+
+**Prompt structure**: System prompt instructs the model to identify vocabulary and grammar above the target JLPT level. User message is the joined set of example sentences.
+
+**Output schema**:
+```typescript
+{
+  valid: boolean;
+  violations: Array<{
+    segment: string;        // exact Japanese segment
+    detectedLevel: string;  // e.g. "N3"
+    type: 'vocab' | 'grammar';
+  }>;
+}
+```
+
+All validation calls are logged to the `api-logs` Firestore collection under route `/validation/content`.
+
+---
+
+## Lesson `validation` Field
+
+Every lesson document can carry a `validation` field:
+
+```typescript
+{
+  status: 'pending' | 'pass' | 'fail';
+  checkedAt?: Timestamp;
+  violations?: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+}
+```
+
+This is written non-blockingly after every new lesson generation. Existing lessons that predate the validation system will have no `validation` field (treat as `pending`).

--- a/DATA-MODEL.md
+++ b/DATA-MODEL.md
@@ -52,7 +52,22 @@ erDiagram
         array  definitions   "Vocab"
         array  context_examples "Vocab"
         array  component_kanji  "Vocab"
-        string classification "Grammar — should NOT be here; classification is KU-level only"
+        object validation    "status: pending|pass|fail, checkedAt, violations[]"
+    }
+
+    ContentFlag {
+        string id PK
+        string sourceType    "lesson | facet | scenario"
+        string sourceId      "FK → lesson kuId OR scenario id"
+        string kuId          "FK → KnowledgeUnit.id (optional — absent for scenario flags)"
+        string kuContent     "human-readable label (word, pattern, or scenario title)"
+        string userLevel     "user's jlptLevel at generation time"
+        array  violations    "segment, detectedLevel, type (vocab|grammar)"
+        string status        "open | resolved | dismissed"
+        string manualNote    "set when created manually (no AI call)"
+        string dismissNote   "set when dismissed"
+        timestamp resolvedAt
+        timestamp createdAt
     }
 
     Question {
@@ -80,6 +95,8 @@ erDiagram
         string kuId PK       "= KnowledgeUnit.id"
         string status        "learning | reviewing | mastered — owned by LearningProgressService"
         number facet_count
+        number currentStage  "current facet sequence stage — owned by ReviewProgressService"
+        boolean aboveLevel   "true if ku.data.jlptLevel > user.preferences.jlptLevel at enrollment time"
         string source_type   "scenario | lesson"
         string source_id     "FK → Scenario.id OR Lesson.kuId"
     }
@@ -153,6 +170,8 @@ erDiagram
     %% ═══════════════════════════════════════════════════════
 
     KnowledgeUnit ||--o| Lesson : "generates (keyed by kuId)"
+    Lesson o|--o{ ContentFlag : "flagged by validation"
+    Scenario o|--o{ ContentFlag : "flagged by validation"
     KnowledgeUnit ||--o| UserLessonOverlay : "overlay (keyed by kuId)"
     KnowledgeUnit ||--o{ UserKnowledgeUnit : "enrolled as"
     KnowledgeUnit ||--o{ ReviewFacet : "drilled by (Vocab/Kanji/Grammar facets)"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,9 +22,10 @@ import { LearningProgressModule } from './learning-progress/learning-progress.mo
 import { ReviewProgressModule } from './review-progress/review-progress.module';
 import { TutorModule } from './tutor/tutor.module';
 import { DailyPlanModule } from './daily-plan/daily-plan.module';
+import { ValidationModule } from './validation/validation.module';
 
 @Module({
-  imports: [ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, LearningProgressModule, ReviewProgressModule, TutorModule, DailyPlanModule],
+  imports: [ValidationModule, ReviewsModule, FirebaseModule, GeminiModule, ConfigModule.forRoot(), QuestionsModule, ApilogModule, LessonsModule, KnowledgeUnitsModule, StatsModule, KanjiModule, ScenariosModule, AudioModule, AuthModule, UserModule, UserKnowledgeUnitsModule, ConceptsModule, LearningProgressModule, ReviewProgressModule, TutorModule, DailyPlanModule],
   controllers: [AppController],
   providers: [AppService, QuestionsService],
 })

--- a/backend/src/concepts/concepts.service.ts
+++ b/backend/src/concepts/concepts.service.ts
@@ -140,7 +140,10 @@ export class ConceptsService {
   async generate(uid: string, topic: string, notes?: string): Promise<ConceptKnowledgeUnit & { id: string }> {
     this.logger.log(`Generating concept for topic="${topic}" uid=${uid}`);
 
-    const prompt = buildConceptPrompt(topic, notes);
+    const userDoc = await this.db.collection('users').doc(uid).get();
+    const jlptLevel: string = (userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5';
+
+    const prompt = buildConceptPrompt(topic, jlptLevel, notes);
     this.logger.log(`Prompt length: ${prompt.length} chars`);
 
     const jsonString = await this.geminiService.generateConcept(prompt, { topic });

--- a/backend/src/firebase/firebase.module.ts
+++ b/backend/src/firebase/firebase.module.ts
@@ -17,6 +17,7 @@ export const USER_CONCEPTS_SUBCOLLECTION = 'user-concepts';
 export const QUESTION_STATES_SUBCOLLECTION = 'question-states';
 export const USER_GRAMMAR_LESSONS_SUBCOLLECTION = 'user-grammar-lessons';
 export const USER_LESSONS_SUBCOLLECTION = 'user-lessons';
+export const CONTENT_FLAGS_COLLECTION = 'content-flags';
 export const Timestamp = admin.firestore.Timestamp;
 export const FieldValue = admin.firestore.FieldValue;
 

--- a/backend/src/lessons/lessons.controller.ts
+++ b/backend/src/lessons/lessons.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, BadRequestException, NotFoundException, Param, Put, Get, Query, Logger, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, BadRequestException, NotFoundException, Param, Put, Get, Query, Logger, UseGuards, HttpCode } from '@nestjs/common';
 import { LessonsService } from './lessons.service';
 import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
@@ -107,13 +107,20 @@ export class LessonsController {
     return this.lessonsService.getUserGrammarLessons(uid, kuId);
   }
 
+  @Post('regenerate/:kuId')
+  @UseGuards(AdminGuard)
+  async regenerate(@UserId() uid: string, @Param('kuId') kuId: string) {
+    if (!kuId) throw new BadRequestException('kuId is required');
+    return this.lessonsService.regenerateLesson(uid, kuId);
+  }
+
   @Get('grammar-lesson-prompt')
   @UseGuards(AdminGuard)
   async getGrammarLessonPrompt(@Query('kuId') kuId: string) {
     if (!kuId) throw new BadRequestException('kuId is required');
     const ku = await this.knowledgeUnitsService.findOneById(kuId);
     if (!ku || ku.type !== 'Grammar') throw new NotFoundException(`Grammar KU ${kuId} not found`);
-    const userMessage = buildGrammarLessonMessage(ku as GrammarKnowledgeUnit);
+    const userMessage = buildGrammarLessonMessage(ku as GrammarKnowledgeUnit, 'N4');
     return { kuId, content: ku.content, userMessage };
   }
 }

--- a/backend/src/lessons/lessons.service.ts
+++ b/backend/src/lessons/lessons.service.ts
@@ -6,8 +6,9 @@ import { QuestionsService } from '../questions/questions.service';
 import { KnowledgeUnit, Lesson, VocabLesson, KanjiLesson, GrammarLesson, GrammarKnowledgeUnit, UserGrammarLesson, UserRoot } from '../types';
 import { performance } from 'perf_hooks';
 import { KnowledgeUnitsService } from '../knowledge-units/knowledge-units.service';
+import { ValidationService } from '../validation/validation.service';
 import { buildVocabLessonMessage, buildVocabCacheContext, buildKanjiLessonPrompt } from '../prompts/vocab.prompts';
-import { GRAMMAR_INSTRUCTIONS, buildGrammarLessonMessage } from '../prompts/grammar.prompts';
+import { buildGrammarLessonMessage } from '../prompts/grammar.prompts';
 import { ADMIN_USER_ID } from '../lib/constants';
 
 function applyKuOverrides(lesson: Lesson, ku: KnowledgeUnit): Lesson {
@@ -25,6 +26,7 @@ export class LessonsService {
     @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
     private readonly geminiService: GeminiService,
     private readonly knowledgeUnitsService: KnowledgeUnitsService,
+    private readonly validationService: ValidationService,
   ) { }
 
   async generateLesson(uid: string, kuId: string, cachedContentName?: string) {
@@ -38,6 +40,9 @@ export class LessonsService {
     }
 
     const ku = kuDoc.data() as KnowledgeUnit;
+
+    const userDoc = await this.db.collection('users').doc(uid).get();
+    const jlptLevel: string = (userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5';
 
     const content = ku.content;
 
@@ -64,7 +69,7 @@ export class LessonsService {
 
     if (ku.type === "Grammar") {
       const grammarKu = ku as GrammarKnowledgeUnit;
-      userMessage = buildGrammarLessonMessage(grammarKu);
+      userMessage = buildGrammarLessonMessage(grammarKu, jlptLevel);
 
       const lessonString = await this.geminiService.generateLesson(userMessage, { content: grammarKu.content, kuId }, undefined);
       if (!lessonString) throw new Error('AI response was empty.');
@@ -79,6 +84,9 @@ export class LessonsService {
       }
 
       await lessonDbRef.set(lessonJson);
+
+      void this.validateAndFlagLesson(uid, kuId, 'Grammar', ku.content, lessonJson, jlptLevel);
+
       return applyKuOverrides(lessonJson, ku);
     }
 
@@ -87,7 +95,7 @@ export class LessonsService {
     } else {
       // TODO: pass ku.data.corpusNotes into buildVocabLessonMessage so Vocab/Kanji corpus
       // notes are injected into the prompt, mirroring how Grammar uses corpusNotes.
-      userMessage = buildVocabLessonMessage(ku.content, !!cachedContentName);
+      userMessage = buildVocabLessonMessage(ku.content, !!cachedContentName, jlptLevel);
     }
 
     const lessonString = await this.geminiService.generateLesson(
@@ -148,6 +156,8 @@ export class LessonsService {
 
     // --- SAVE TO 'lessons' collection ---
     await lessonDbRef.set(lessonJson);
+
+    void this.validateAndFlagLesson(uid, kuId, ku.type, ku.content, lessonJson, jlptLevel);
 
     // --- UPDATE KU WITH LESSON DATA ---
     if (ku.type === 'Vocab') {
@@ -332,8 +342,11 @@ export class LessonsService {
   }
 
   async processBatch(uid: string, vocabValues: { id: string; content: string }[]) {
+    const userDoc = await this.db.collection('users').doc(uid).get();
+    const batchJlptLevel: string = (userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5';
+
     const cacheName = await this.geminiService.createContextCache(
-      buildVocabCacheContext(),
+      buildVocabCacheContext(batchJlptLevel),
       3600
     );
 
@@ -411,6 +424,41 @@ export class LessonsService {
       } catch (cacheError) {
         this.logger.error(`Failed to delete Context Cache: ${cacheName}`, cacheError);
       }
+    }
+  }
+
+  async regenerateLesson(uid: string, kuId: string): Promise<Lesson> {
+    const lessonRef = this.db.collection(LESSONS_COLLECTION).doc(kuId);
+    await lessonRef.set({ status: 'failed' }, { merge: true });
+    return this.generateLesson(uid, kuId) as Promise<Lesson>;
+  }
+
+  private async validateAndFlagLesson(
+    uid: string,
+    kuId: string,
+    kuType: string,
+    kuContent: string,
+    lesson: Lesson,
+    jlptLevel: string,
+  ): Promise<void> {
+    try {
+      let segments: string[] = [];
+      if (kuType === 'Vocab') {
+        segments = ((lesson as VocabLesson).context_examples ?? [])
+          .map(e => e.sentence)
+          .filter(Boolean);
+      } else if (kuType === 'Grammar') {
+        segments = ((lesson as GrammarLesson).examples ?? [])
+          .map(e => e.japanese)
+          .filter(Boolean);
+      }
+
+      if (segments.length === 0) return;
+
+      const result = await this.validationService.validateContent(segments, jlptLevel, uid);
+      await this.validationService.flagLesson(kuId, kuContent, jlptLevel, result);
+    } catch (err) {
+      this.logger.error(`Lesson validation failed for kuId=${kuId}`, err);
     }
   }
 }

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -3,13 +3,13 @@
  * Source: backend/src/concepts/concepts.service.ts
  */
 
-import { NO_ROMAJI, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
+import { NO_ROMAJI, levelConstraint, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
 
 /**
  * Builds the full prompt for generating a ConceptKnowledgeUnit page.
  * Source: concepts.service.ts CONCEPT_PROMPT function
  */
-export function buildConceptPrompt(topic: string, notes?: string): string {
+export function buildConceptPrompt(topic: string, jlptLevel: string, notes?: string): string {
   return `You are a kind and thoughtful Japanese language teacher with decades of experience. Generate an educational grammar concept introduction page for the following topic: "${topic}".
 
 Write for an English-speaking learner at any level. Use Japanese text for all examples — do not include Romaji anywhere.
@@ -35,7 +35,7 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
 5. 'targetGrammar': The specific Japanese substring that represents the grammar concept, written as plain Japanese text (no furigana brackets). It must appear verbatim in the plain text of 'japanese' after stripping all bracket annotations.
 
 **Constraints:**
-- Keep all example sentences at or below JLPT N4, even if the target vocabulary or pattern is more advanced.
+- ${levelConstraint(jlptLevel)}
 - Do not explain meta-linguistic terms (e.g. do not define what a "particle" is).
 - ${NO_ROMAJI}
 

--- a/backend/src/prompts/concept.prompts.ts
+++ b/backend/src/prompts/concept.prompts.ts
@@ -3,7 +3,7 @@
  * Source: backend/src/concepts/concepts.service.ts
  */
 
-import { NO_ROMAJI, USER_TARGET_LEVEL, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
+import { NO_ROMAJI, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
 
 /**
  * Builds the full prompt for generating a ConceptKnowledgeUnit page.
@@ -35,7 +35,7 @@ Write for an English-speaking learner at any level. Use Japanese text for all ex
 5. 'targetGrammar': The specific Japanese substring that represents the grammar concept, written as plain Japanese text (no furigana brackets). It must appear verbatim in the plain text of 'japanese' after stripping all bracket annotations.
 
 **Constraints:**
-- ${USER_TARGET_LEVEL}
+- Keep all example sentences at or below JLPT N4, even if the target vocabulary or pattern is more advanced.
 - Do not explain meta-linguistic terms (e.g. do not define what a "particle" is).
 - ${NO_ROMAJI}
 

--- a/backend/src/prompts/curriculum.ts
+++ b/backend/src/prompts/curriculum.ts
@@ -105,10 +105,10 @@ export function getCumulativeGrammar(upToLevel: JlptLevel): CurriculumLevelEntry
 export const GET_USER_LEVEL_DECLARATION: FunctionDeclaration = {
   name: 'get_user_level',
   description:
-    'Returns the learner\'s current JLPT level and the complete cumulative grammar schema ' +
-    'covering everything they have studied up to that level. ' +
+    'Returns the learner\'s current JLPT level and the exact grammar patterns they have enrolled in. ' +
     'Call this before writing any question so that surrounding sentence grammar and vocabulary ' +
-    'stays within what the learner already knows.',
+    'stays within what the learner has actually studied. ' +
+    'Use allowedGrammar (not any assumed JLPT schema) as the constraint for surrounding sentences.',
   parameters: {
     type: Type.OBJECT,
     properties: {},

--- a/backend/src/prompts/fragments.ts
+++ b/backend/src/prompts/fragments.ts
@@ -8,8 +8,9 @@
 export const NO_ROMAJI =
   `Do not include Romaji anywhere in your response.`;
 
-export const USER_TARGET_LEVEL =
-  `Keep all example sentences at or below JLPT N4 complexity, even if the target vocabulary or pattern is more advanced.`;
+export function levelConstraint(jlptLevel: string): string {
+  return `Keep all example sentences at or below JLPT ${jlptLevel}, even if the target vocabulary or pattern is more advanced.`;
+}
 
 export const JSON_ONLY_OUTPUT =
   `Return ONLY a valid JSON object. Do NOT output any text before or after it. Do NOT use markdown code blocks or backticks.`;

--- a/backend/src/prompts/grammar.prompts.ts
+++ b/backend/src/prompts/grammar.prompts.ts
@@ -4,18 +4,19 @@
  */
 
 import { GrammarKnowledgeUnit } from '../types';
-import { USER_TARGET_LEVEL, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
+import { levelConstraint, FRAGMENT_CONTRACT, ACCEPTED_ALTERNATIVES_DEF } from './fragments';
 
 // ---------------------------------------------------------------------------
 // Grammar lesson instructions (static)
 // ---------------------------------------------------------------------------
 
-/** Static schema and rules appended to every grammar lesson user message. */
-export const GRAMMAR_INSTRUCTIONS = `
+/** Builds schema and rules for grammar lesson generation, scoped to the user's JLPT level. */
+export function buildGrammarInstructions(jlptLevel: string): string {
+  return `
 Instructions:
  - The lesson should be in English. The use of Romaji anywhere in the lesson is forbidden.
  - Avoid using the following terminology: "copula", "predicate". Use of "particle" and "modifier" is acceptable.
- 
+
 Generate a complete grammar lesson matching this JSON schema exactly:
 {
   "type": "Grammar",
@@ -43,8 +44,9 @@ Rules:
 - ${FRAGMENT_CONTRACT} The final fragment MUST include the sentence-ending punctuation (。). Each example must have different fragments matching its own sentence.
 - ${ACCEPTED_ALTERNATIVES_DEF}
 - NEVER copy fragments from one example to another
-- Keep all example sentences at or below JLPT ${USER_TARGET_LEVEL}, even if the target grammar pattern is at a higher level
+- ${levelConstraint(jlptLevel)}
 `;
+}
 
 // ---------------------------------------------------------------------------
 // Grammar lesson user message (parameterized)
@@ -55,10 +57,10 @@ Rules:
  * Embeds the KU data and verbatim context example, then appends GRAMMAR_INSTRUCTIONS.
  * Source: lessons.service.ts:generateLesson (Grammar branch)
  */
-export function buildGrammarLessonMessage(ku: GrammarKnowledgeUnit): string {
+export function buildGrammarLessonMessage(ku: GrammarKnowledgeUnit, jlptLevel: string): string {
   const ctxExample = ku.data.exampleInContext;
-  return `You are an expert Japanese grammar tutor for the Japanese Language learning app: AIGENKI. AIGENKI uses AI generate lessons for Japanese Grammar, Vocab and Concepts along with SRS based reviews with a mix of questions types designed to advance users through their Japanese learning experience. The "Corpus context" section provides additional information about the Grammar pattern being taught and how it exists within the context of the knowledge corpus within AIGENKI 
-  
+  return `You are an expert Japanese grammar tutor for the Japanese Language learning app: AIGENKI. AIGENKI uses AI generate lessons for Japanese Grammar, Vocab and Concepts along with SRS based reviews with a mix of questions types designed to advance users through their Japanese learning experience. The "Corpus context" section provides additional information about the Grammar pattern being taught and how it exists within the context of the knowledge corpus within AIGENKI
+
 Your Task: Generate a complete AIGENKI lesson at the user's current level, for the grammar pattern: ${ku.content}
 
 Grammar title: ${ku.data.title}
@@ -69,5 +71,5 @@ Example from context (USE AS examples[0] VERBATIM):
   fragments: ${JSON.stringify(ctxExample?.fragments ?? [])}
   accepted_alternatives: ${JSON.stringify(ctxExample?.accepted_alternatives ?? [])}
 
-${GRAMMAR_INSTRUCTIONS}`;
+${buildGrammarInstructions(jlptLevel)}`;
 }

--- a/backend/src/prompts/quiz.prompts.ts
+++ b/backend/src/prompts/quiz.prompts.ts
@@ -127,6 +127,46 @@ export const NOUN_PARTICLE_FEW_SHOT_TURNS: Array<{ user: string; model: string }
 ];
 
 // ---------------------------------------------------------------------------
+// Grammar pattern questions
+// ---------------------------------------------------------------------------
+
+export const GRAMMAR_QUESTION_OPTIONS: Record<string, string> = {
+  'novel-translation': 'Create a completely new English sentence that naturally forces the use of the target grammar pattern. Ask the user to translate it into Japanese.',
+  'error-correction': 'Present a complete Japanese sentence that attempts to use the target grammar pattern but contains a specific error in its construction. Ask the user to correct the error and provide the fully corrected Japanese sentence. Provide the intended English meaning as context.',
+};
+
+export type GrammarQuestionType = keyof typeof GRAMMAR_QUESTION_OPTIONS;
+
+/**
+ * Builds the system prompt for Grammar KU AI-Generated-Question generation.
+ * The question must be in English; Japanese sentences are quoted inline.
+ * Surrounding sentence content is constrained to the user's enrolled grammar from get_user_level.
+ */
+export function buildGrammarQuestionPrompt(
+  pattern: string,
+  title: string,
+  questionType: GrammarQuestionType,
+): string {
+  return `You are an expert Japanese language tutor.
+You are testing the user on the following Japanese grammar pattern.
+Pattern: ${pattern}
+Title: ${title}
+
+FIRST: Call get_user_level to retrieve the learner's JLPT level and the grammar patterns they have enrolled in.
+
+THEN generate a question using this format:
+${GRAMMAR_QUESTION_OPTIONS[questionType]}
+
+Rules:
+1. The answer MUST require the user to correctly apply the pattern: ${pattern}
+2. The 'question' field MUST be written entirely in English. Any Japanese sentence shown to the user must be embedded inline as a quoted string — never write the question instruction itself in Japanese.
+3. ${NO_ROMAJI}
+4. LEVEL CONSTRAINT (critical): Use ONLY grammar patterns from the allowedGrammar list returned by get_user_level for any surrounding sentence. The pattern being tested (${pattern}) is the exception — everything else must come from that list.
+5. Keep vocabulary simple and concrete. The user is being tested on grammar, not vocabulary.
+6. ${JSON_ONLY_OUTPUT}`;
+}
+
+// ---------------------------------------------------------------------------
 // Concept mechanic questions
 // ---------------------------------------------------------------------------
 

--- a/backend/src/prompts/validation.prompts.ts
+++ b/backend/src/prompts/validation.prompts.ts
@@ -1,0 +1,24 @@
+/**
+ * Prompt for post-generation content validation.
+ * Used by ValidationService to detect above-level vocabulary and grammar.
+ */
+
+/**
+ * Builds the system prompt for content-level validation.
+ * The model returns structured JSON listing any violations found.
+ */
+export function buildValidationPrompt(jlptLevel: string): string {
+  return `You are a Japanese language level checker for a JLPT learning app.
+
+You will receive a list of Japanese sentences or phrases generated for a JLPT ${jlptLevel} learner. Your job is to identify any vocabulary items or grammar patterns in the content that are above JLPT ${jlptLevel}.
+
+For each violation, return:
+- "segment": the exact Japanese word, phrase, or grammatical construction that is above level
+- "detectedLevel": the JLPT level it actually belongs to (N4, N3, N2, or N1)
+- "type": "vocab" if it is a vocabulary item, "grammar" if it is a grammar pattern
+
+If all content is appropriate for JLPT ${jlptLevel}, return an empty violations array and set valid to true.
+If any violations are found, set valid to false.
+
+Be precise: only flag items that are clearly above the target level. Do not flag items that are ambiguous or borderline.`;
+}

--- a/backend/src/prompts/vocab.prompts.ts
+++ b/backend/src/prompts/vocab.prompts.ts
@@ -3,6 +3,8 @@
  * Sources: backend/src/lessons/lessons.service.ts, backend/src/gemini/gemini.service.ts
  */
 
+import { levelConstraint } from './fragments';
+
 // ---------------------------------------------------------------------------
 // Vocab lesson
 // ---------------------------------------------------------------------------
@@ -20,7 +22,7 @@ The lesson should be in English. Where you want to use Japanese text for example
 **Task 2: Lesson Generation**
 * Generate detailed explanations for meaning and reading.
 * If a word is a "suru noun", include explanations of the meaning of the suru form.
-* Generate context examples that are no more complex that JLPT N4 even if the vocabulary itself is more advanced.
+* Generate context examples appropriate for the user's current JLPT level even if the vocabulary itself is more advanced. (Level constraint is injected at call time.)
 * Analyze component Kanji. If the word is normally or almost always written in kana alone in modern Japanese (e.g. もらう, くれる, いる, ある, すごい, かわいい), set \`component_kanji\` to an empty array — do not include the kanji breakdown even if kanji exist for it.
 * Do not explain what "rendaku" means.
 
@@ -234,12 +236,13 @@ Output:
  * VOCAB_INSTRUCTIONS is already loaded into the cache as the system instruction.
  * Source: lessons.service.ts:generateLesson (Vocab branch)
  */
-export function buildVocabLessonMessage(content: string, useCached: boolean): string {
+export function buildVocabLessonMessage(content: string, useCached: boolean, jlptLevel: string): string {
   if (useCached) {
     return `Generate a lesson for the Japanese word: ${content}`;
   }
   return `You are an expert Japanese tutor. You will be asked to generate a lesson for the Japanese word: ${content}.
-${VOCAB_INSTRUCTIONS}`;
+${VOCAB_INSTRUCTIONS}
+${levelConstraint(jlptLevel)}`;
 }
 
 /**
@@ -247,8 +250,8 @@ ${VOCAB_INSTRUCTIONS}`;
  * Combines VOCAB_INSTRUCTIONS and VOCAB_EXAMPLES so individual batch requests can be short.
  * Source: lessons.service.ts:processBatch
  */
-export function buildVocabCacheContext(): string {
-  return `You are an expert Japanese tutor. You will be asked to generate a lesson for a Japanese word.\n${VOCAB_INSTRUCTIONS}\n\n${VOCAB_EXAMPLES}`;
+export function buildVocabCacheContext(jlptLevel: string): string {
+  return `You are an expert Japanese tutor. You will be asked to generate a lesson for a Japanese word.\n${VOCAB_INSTRUCTIONS}\n${levelConstraint(jlptLevel)}\n\n${VOCAB_EXAMPLES}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/questions/questions.service.ts
+++ b/backend/src/questions/questions.service.ts
@@ -23,8 +23,11 @@ import {
   CONCEPT_QUESTION_OPTIONS,
   buildConceptQuestionPrompt,
   ConceptMechanic,
+  GRAMMAR_QUESTION_OPTIONS,
+  buildGrammarQuestionPrompt,
+  GrammarQuestionType,
 } from '../prompts/quiz.prompts';
-import { GET_USER_LEVEL_DECLARATION, getCumulativeGrammar, JlptLevel } from '../prompts/curriculum';
+import { GET_USER_LEVEL_DECLARATION, JlptLevel } from '../prompts/curriculum';
 
 const SUITABLE_RANK_THRESHOLD = 30;
 const RANK_CORRECT_DELTA = 5;
@@ -165,6 +168,10 @@ export class QuestionsService {
       // Check knowledge-units collection first
       try {
         const kuData = await this.knowledgeUnitsService.findOne(kuId);
+        if (kuData.type === 'Grammar') {
+          this.logger.log(`Routing Grammar KU ${kuId} to grammar question path`);
+          return this.generateGrammarQuestion(uid, kuData.content, kuData.data.title ?? kuData.content, kuId, facetId);
+        }
         if (kuData.type === 'Concept' && kuData.data.mechanics?.length > 0) {
           const mechanic = kuData.data.mechanics[Math.floor(Math.random() * kuData.data.mechanics.length)];
           this.logger.log(`Routing concept KU ${kuId} to concept question path (mechanic: "${mechanic.goalTitle}")`);
@@ -193,11 +200,10 @@ export class QuestionsService {
     return {
       get_user_level: async () => {
         const userDoc = await this.db.collection('users').doc(uid).get();
-        const level = ((userDoc.data() as any)?.preferences?.jlptLevel ?? 'N5') as JlptLevel;
-        return {
-          jlptLevel: level,
-          cumulativeGrammar: getCumulativeGrammar(level),
-        };
+        const userData = userDoc.data() as any;
+        const level = (userData?.preferences?.jlptLevel ?? 'N5') as JlptLevel;
+        const allowedGrammar: string[] = userData?.tutorContext?.allowedGrammar ?? [];
+        return { jlptLevel: level, allowedGrammar };
       },
     };
   }
@@ -292,6 +298,60 @@ export class QuestionsService {
 
     await ref.set(newQuestion);
     this.logger.log(`Saved new question ${ref.id} for KU ${kuId} (level: ${capturedLevel})`);
+
+    if (facetId) {
+      await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);
+    }
+
+    return this.toResponse(newQuestion, true);
+  }
+
+  private async generateGrammarQuestion(uid: string, pattern: string, title: string, kuId: string, facetId?: string): Promise<QuestionResponse> {
+    const questionType = pickRandomQuestionType(GRAMMAR_QUESTION_OPTIONS) as GrammarQuestionType;
+    const systemPrompt = buildGrammarQuestionPrompt(pattern, title, questionType);
+
+    let capturedLevel = 'N5';
+    const toolHandlers = {
+      get_user_level: async (args: Record<string, unknown>) => {
+        const result = await this.buildLevelToolHandler(uid).get_user_level(args);
+        capturedLevel = result.jlptLevel as string;
+        return result;
+      },
+    };
+
+    const parsed = await this.geminiService.generateWithTools<{
+      question: string;
+      answer: string;
+      context?: string;
+      accepted_alternatives?: string[];
+    }>(
+      '',
+      systemPrompt,
+      [GET_USER_LEVEL_DECLARATION],
+      toolHandlers,
+      this.questionResponseSchema,
+      { route: '/questions/generate', topic: pattern, kuId },
+    );
+
+    const ref = this.db.collection(QUESTIONS_COLLECTION).doc();
+    const newQuestion: QuestionItem = {
+      id: ref.id,
+      kuId,
+      sourceCollection: 'knowledge-units',
+      data: {
+        question: parsed.question,
+        context: parsed.context,
+        answer: parsed.answer,
+        acceptedAlternatives: parsed.accepted_alternatives,
+        difficulty: `JLPT-${capturedLevel}` as import('@/types').LessonDifficulty,
+      },
+      rank: 50,
+      rejectionCount: 0,
+      createdAt: Timestamp.now(),
+    };
+
+    await ref.set(newQuestion);
+    this.logger.log(`Saved new grammar question ${ref.id} for KU ${kuId} (pattern: ${pattern}, level: ${capturedLevel})`);
 
     if (facetId) {
       await this.reviewsService.updateFacetQuestion(uid, facetId, ref.id);

--- a/backend/src/scenarios/scenarios.service.ts
+++ b/backend/src/scenarios/scenarios.service.ts
@@ -14,6 +14,7 @@ import { UserService } from '../users/user.service';
 import { FIRESTORE_CONNECTION, SCENARIOS_COLLECTION, REVIEW_FACETS_COLLECTION } from '../firebase/firebase.module';
 import { ADMIN_USER_ID } from '../lib/constants';
 import { GeminiService } from '../gemini/gemini.service';
+import { ValidationService } from '../validation/validation.service';
 import { ALLOWED_USER_ROLES, ALLOWED_AI_ROLES, buildArchitectPrompt, buildImportPrompt, buildChatSystemPrompt } from '../prompts/scenario.prompts';
 import { GET_GRAMMAR_PATTERNS_DECLARATION } from '../prompts/curriculum';
 import { GrammarMatch } from '../types/scenario';
@@ -33,6 +34,7 @@ export class ScenariosService {
     private readonly userKnowledgeUnitsService: UserKnowledgeUnitsService,
     private readonly lessonsService: LessonsService,
     private readonly userService: UserService,
+    private readonly validationService: ValidationService,
   ) {}
 
   private scenariosColRef(uid: string): CollectionReference {
@@ -42,28 +44,45 @@ export class ScenariosService {
     return this.db.collection('users').doc(uid).collection(SCENARIOS_COLLECTION);
   }
 
-  private buildGrammarToolHandlers() {
+  private buildGrammarToolHandlers(uid: string) {
     return {
       get_grammar_patterns: async (args: Record<string, unknown>) => {
         const jlptLevel = (args.jlptLevel as string) || 'N4';
-        const snap = await this.db
-          .collection('knowledge-units')
-          .where('type', '==', 'Grammar')
-          .where('data.jlptLevel', '==', jlptLevel)
-          .limit(60)
+
+        // Fetch only grammar KUs the user has enrolled (and are not above their level)
+        const ukuSnap = await this.db
+          .collection('users').doc(uid)
+          .collection('user-kus')
+          .where('aboveLevel', '!=', true)
           .get();
 
-        const patterns = snap.docs.map(doc => {
-          const d = doc.data();
-          return {
-            kuId: doc.id,
-            content: d.content as string,
-            title: (d.data as any)?.title ?? '',
-            corpusNotes: (d.data as any)?.corpusNotes ?? '',
-          };
-        });
+        const enrolledKuIds = ukuSnap.docs.map(d => d.data().kuId as string);
+        if (enrolledKuIds.length === 0) {
+          this.logger.log(`get_grammar_patterns(${jlptLevel}) → 0 enrolled patterns for uid=${uid}`);
+          return { patterns: [] };
+        }
 
-        this.logger.log(`get_grammar_patterns(${jlptLevel}) → ${patterns.length} patterns`);
+        // Batch-fetch global KUs for enrolled IDs, filter to Grammar at the requested level
+        const kuRefs = enrolledKuIds.map(id => this.db.collection('knowledge-units').doc(id));
+        const kuDocs = await this.db.getAll(...kuRefs);
+
+        const patterns = kuDocs
+          .filter(doc => {
+            if (!doc.exists) return false;
+            const d = doc.data()!;
+            return d.type === 'Grammar' && (d.data as any)?.jlptLevel === jlptLevel;
+          })
+          .map(doc => {
+            const d = doc.data()!;
+            return {
+              kuId: doc.id,
+              content: d.content as string,
+              title: (d.data as any)?.title ?? '',
+              corpusNotes: (d.data as any)?.corpusNotes ?? '',
+            };
+          });
+
+        this.logger.log(`get_grammar_patterns(${jlptLevel}) → ${patterns.length} enrolled patterns for uid=${uid}`);
         return { patterns };
       },
     };
@@ -127,7 +146,7 @@ export class ScenariosService {
       const data = await this.geminiService.generateScenario(
         prompt,
         [GET_GRAMMAR_PATTERNS_DECLARATION],
-        this.buildGrammarToolHandlers(),
+        this.buildGrammarToolHandlers(userId),
       );
 
       const docRef = this.scenariosColRef(userId).doc();
@@ -177,6 +196,7 @@ export class ScenariosService {
       );
 
       await docRef.set(cleanData);
+      void this.validateScenario(newScenario, resolvedDto.difficulty!);
       return id;
 
     } catch (error) {
@@ -230,6 +250,7 @@ export class ScenariosService {
 
     await docRef.set(cleanData);
     this.logger.log(`saveFromTutor: created scenario ${id} for uid=${uid}`);
+    void this.validateScenario(newScenario, newScenario.difficultyLevel);
     return { id, success: true };
   }
 
@@ -249,7 +270,7 @@ export class ScenariosService {
       const data = await this.geminiService.generateScenario(
         prompt,
         [GET_GRAMMAR_PATTERNS_DECLARATION],
-        this.buildGrammarToolHandlers(),
+        this.buildGrammarToolHandlers(uid),
       );
 
       const docRef = this.scenariosColRef(uid).doc();
@@ -749,5 +770,19 @@ export class ScenariosService {
     }));
 
     return result;
+  }
+
+  private async validateScenario(scenario: Scenario, jlptLevel: string): Promise<void> {
+    try {
+      const segments = scenario.dialogue
+        .map(line => line.text)
+        .filter(Boolean);
+      if (segments.length === 0) return;
+
+      const result = await this.validationService.validateContent(segments, jlptLevel, scenario.userId);
+      await this.validationService.flagScenario(scenario.id, scenario.title, jlptLevel, result);
+    } catch (err) {
+      this.logger.error(`Scenario validation failed for id=${scenario.id}`, err);
+    }
   }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -135,6 +135,12 @@ export interface UserRoot {
   };
 }
 
+export interface LessonValidation {
+  status: 'pending' | 'pass' | 'fail';
+  checkedAt?: Timestamp;
+  violations?: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+}
+
 export interface VocabLesson {
   kuId?: string;
   type: "Vocab";
@@ -147,6 +153,7 @@ export interface VocabLesson {
   meaning_explanation: string;
   reading_explanation: string;
   context_examples?: { sentence: string; translation: string }[];
+  validation?: LessonValidation;
   component_kanji?: {
     kanji: string;
     reading: string;
@@ -217,6 +224,7 @@ export interface GrammarLesson {
   meaning: string;       // one-line summary
   formation: string | string[];
   notes: string;         // nuance, pitfalls
+  validation?: LessonValidation;
   examples: {
     japanese: string;
     english: string;
@@ -378,6 +386,8 @@ export interface UserKnowledgeUnit {
   };
   /** Current position in the facet unlock sequence. 0 = not yet initialized. */
   currentStage?: number;
+  /** True if ku.data.jlptLevel > user.preferences.jlptLevel at enrollment time. Above-level items are excluded from ambient generation context. */
+  aboveLevel?: boolean;
 }
 
 // ─── Facet sequence types ────────────────────────────────────────────────────
@@ -664,6 +674,29 @@ export interface GrammarClassification {
    * questions and by SRS to schedule contrasting reviews.
    */
   confusableWith?: string[];
+}
+
+// ─── Content validation ───────────────────────────────────────────────────────
+
+export interface ValidationResult {
+  valid: boolean;
+  violations: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+}
+
+export interface ContentFlag {
+  id?: string;
+  kuId?: string;
+  sourceType: 'lesson' | 'facet' | 'scenario';
+  sourceId: string;
+  kuContent: string;
+  userLevel: string;
+  violations: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+  status: 'open' | 'resolved' | 'dismissed';
+  /** Set when the flag was created manually rather than by the automated validator. */
+  manualNote?: string;
+  dismissNote?: string;
+  resolvedAt?: Timestamp;
+  createdAt: Timestamp;
 }
 
 export * from './scenario';

--- a/backend/src/user-knowledge-units/user-knowledge-units.service.ts
+++ b/backend/src/user-knowledge-units/user-knowledge-units.service.ts
@@ -4,6 +4,16 @@ import { FIRESTORE_CONNECTION, KNOWLEDGE_UNITS_COLLECTION, USER_KUS_SUBCOLLECTIO
 import { KnowledgeUnit, UserKnowledgeUnit } from '../types';
 import { StatsService } from '../stats/stats.service';
 
+const JLPT_DIFFICULTY: Record<string, number> = { N5: 5, N4: 4, N3: 3, N2: 2, N1: 1 };
+
+function isAboveLevel(kuJlptLevel: string | undefined | null, userJlptLevel: string | undefined | null): boolean {
+  if (!kuJlptLevel || !userJlptLevel) return false;
+  const kuDiff = JLPT_DIFFICULTY[kuJlptLevel];
+  const userDiff = JLPT_DIFFICULTY[userJlptLevel];
+  if (kuDiff === undefined || userDiff === undefined) return false;
+  return kuDiff < userDiff; // lower number = harder level
+}
+
 @Injectable()
 export class UserKnowledgeUnitsService {
   private readonly logger = new Logger(UserKnowledgeUnitsService.name);
@@ -112,17 +122,25 @@ export class UserKnowledgeUnitsService {
     const ref = await this.userKusRef(uid).add(payload);
     this.logger.log(`Created UKU id=${ref.id} for uid=${uid} kuId=${kuId} source=${source?.type ?? 'none'}`);
 
-    // Non-blocking: update stats and tutorContext on enrollment
+    // Non-blocking: update stats, tutorContext, and aboveLevel flag on enrollment
     void (async () => {
       try {
-        const kuDoc = await this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(kuId).get();
+        const [kuDoc, userDoc] = await Promise.all([
+          this.db.collection(KNOWLEDGE_UNITS_COLLECTION).doc(kuId).get(),
+          this.db.collection('users').doc(uid).get(),
+        ]);
         const kuData = kuDoc.data();
+        const userPrefs = userDoc.data()?.preferences;
         const jlptLevel = kuData?.data?.jlptLevel;
-        if (jlptLevel) {
+
+        const aboveLevel = isAboveLevel(jlptLevel, userPrefs?.jlptLevel);
+        await this.userKusRef(uid).doc(ref.id).update({ aboveLevel });
+
+        if (jlptLevel && !aboveLevel) {
           await this.statsService.recordKuEnrolled(uid, jlptLevel);
           await this.statsService.updateCurriculumNode(uid, jlptLevel);
         }
-        if (kuData?.type === 'Grammar' && kuData?.content) {
+        if (kuData?.type === 'Grammar' && kuData?.content && !aboveLevel) {
           await this.statsService.addToAllowedGrammar(uid, kuData.content);
         }
       } catch (e) {

--- a/backend/src/validation/content-flags.controller.ts
+++ b/backend/src/validation/content-flags.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards, BadRequestException } from '@nestjs/common';
+import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+import { ValidationService } from './validation.service';
+
+@Controller('content-flags')
+@UseGuards(FirebaseAuthGuard, AdminGuard)
+export class ContentFlagsController {
+  constructor(private readonly validationService: ValidationService) {}
+
+  @Get()
+  async list(@Query('status') status?: string) {
+    return this.validationService.getFlags(status ?? 'open');
+  }
+
+  @Post()
+  async create(
+    @Body() body: {
+      sourceType: 'lesson' | 'scenario';
+      sourceId: string;
+      kuContent: string;
+      userLevel: string;
+      manualNote: string;
+    },
+  ) {
+    if (!body.sourceType || !body.sourceId || !body.kuContent || !body.manualNote) {
+      throw new BadRequestException('sourceType, sourceId, kuContent, and manualNote are required');
+    }
+    const id = await this.validationService.createManualFlag(body);
+    return { id };
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() body: { status: 'resolved' | 'dismissed'; dismissNote?: string },
+  ) {
+    if (!body.status || !['resolved', 'dismissed'].includes(body.status)) {
+      throw new BadRequestException('status must be "resolved" or "dismissed"');
+    }
+    await this.validationService.updateFlag(id, body);
+    return { success: true };
+  }
+}

--- a/backend/src/validation/validation.module.ts
+++ b/backend/src/validation/validation.module.ts
@@ -1,0 +1,15 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ValidationService } from './validation.service';
+import { ContentFlagsController } from './content-flags.controller';
+import { ApilogModule } from '../apilog/apilog.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Global()
+@Module({
+  imports: [ConfigModule, ApilogModule, AuthModule],
+  controllers: [ContentFlagsController],
+  providers: [ValidationService],
+  exports: [ValidationService],
+})
+export class ValidationModule {}

--- a/backend/src/validation/validation.service.ts
+++ b/backend/src/validation/validation.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GoogleGenAI } from '@google/genai';
+import { Firestore, Timestamp, Query } from 'firebase-admin/firestore';
+import { FIRESTORE_CONNECTION, CONTENT_FLAGS_COLLECTION, LESSONS_COLLECTION } from '../firebase/firebase.module';
+import { ApilogService } from '../apilog/apilog.service';
+import { ValidationResult, ContentFlag } from '../types';
+import { buildValidationPrompt } from '../prompts/validation.prompts';
+
+@Injectable()
+export class ValidationService implements OnModuleInit {
+  private readonly logger = new Logger(ValidationService.name);
+  private client: GoogleGenAI;
+  private modelName: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly apilogService: ApilogService,
+    @Inject(FIRESTORE_CONNECTION) private readonly db: Firestore,
+  ) {}
+
+  onModuleInit() {
+    const apiKey = this.configService.get<string>('GEMINI_API_KEY');
+    if (!apiKey) throw new Error('GEMINI_API_KEY is not defined');
+    this.modelName = this.configService.get<string>('MODEL_GEMINI_FLASH') || 'gemini-2.0-flash';
+    this.client = new GoogleGenAI({ apiKey });
+  }
+
+  async validateContent(segments: string[], jlptLevel: string, uid: string): Promise<ValidationResult> {
+    const systemPrompt = buildValidationPrompt(jlptLevel);
+    const userMessage = segments.join('\n');
+
+    const logRef = await this.apilogService.startLog({
+      timestamp: Timestamp.now(),
+      route: '/validation/content',
+      status: 'pending',
+      modelUsed: this.modelName,
+      requestData: { userMessage, jlptLevel, segmentCount: segments.length, uid },
+    });
+
+    try {
+      const response = await this.client.models.generateContent({
+        model: this.modelName,
+        contents: [{ parts: [{ text: userMessage }] }],
+        config: {
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: 'OBJECT',
+            properties: {
+              valid: { type: 'BOOLEAN' },
+              violations: {
+                type: 'ARRAY',
+                items: {
+                  type: 'OBJECT',
+                  properties: {
+                    segment: { type: 'STRING' },
+                    detectedLevel: { type: 'STRING' },
+                    type: { type: 'STRING', enum: ['vocab', 'grammar'] },
+                  },
+                  required: ['segment', 'detectedLevel', 'type'],
+                },
+              },
+            },
+            required: ['valid', 'violations'],
+          },
+        },
+      });
+
+      const result = JSON.parse(response.text ?? '{}') as ValidationResult;
+      await this.apilogService.completeLog(logRef, {
+        status: 'success',
+        responseData: { parsedJson: result },
+      });
+      return result;
+    } catch (err) {
+      await this.apilogService.completeLog(logRef, {
+        status: 'error',
+        errorData: { message: (err as Error).message },
+      });
+      throw err;
+    }
+  }
+
+  async flagLesson(
+    kuId: string,
+    kuContent: string,
+    userLevel: string,
+    result: ValidationResult,
+  ): Promise<void> {
+    const now = Timestamp.now();
+
+    await this.db.collection(LESSONS_COLLECTION).doc(kuId).update({
+      'validation.status': result.valid ? 'pass' : 'fail',
+      'validation.checkedAt': now,
+      'validation.violations': result.violations ?? [],
+    });
+
+    if (!result.valid && result.violations?.length) {
+      const flag: Omit<ContentFlag, 'id'> = {
+        kuId,
+        sourceType: 'lesson',
+        sourceId: kuId,
+        kuContent,
+        userLevel,
+        violations: result.violations,
+        status: 'open',
+        createdAt: now,
+      };
+      await this.db.collection(CONTENT_FLAGS_COLLECTION).add(flag);
+      this.logger.warn(`Content flag created for kuId=${kuId} (${result.violations.length} violation(s))`);
+    } else if (result.valid) {
+      await this.resolveOpenFlags(kuId, now);
+    }
+  }
+
+  async flagScenario(
+    scenarioId: string,
+    title: string,
+    userLevel: string,
+    result: ValidationResult,
+  ): Promise<void> {
+    if (!result.valid && result.violations?.length) {
+      const flag: Omit<ContentFlag, 'id'> = {
+        sourceType: 'scenario',
+        sourceId: scenarioId,
+        kuContent: title,
+        userLevel,
+        violations: result.violations,
+        status: 'open',
+        createdAt: Timestamp.now(),
+      };
+      await this.db.collection(CONTENT_FLAGS_COLLECTION).add(flag);
+      this.logger.warn(`Scenario flag created for id=${scenarioId} (${result.violations.length} violation(s))`);
+    }
+  }
+
+  async createManualFlag(params: {
+    sourceType: 'lesson' | 'scenario';
+    sourceId: string;
+    kuContent: string;
+    userLevel: string;
+    manualNote: string;
+  }): Promise<string> {
+    const flag: Omit<ContentFlag, 'id'> = {
+      sourceType: params.sourceType,
+      sourceId: params.sourceId,
+      kuContent: params.kuContent,
+      userLevel: params.userLevel,
+      violations: [],
+      status: 'open',
+      manualNote: params.manualNote,
+      createdAt: Timestamp.now(),
+    };
+    const ref = await this.db.collection(CONTENT_FLAGS_COLLECTION).add(flag);
+    return ref.id;
+  }
+
+  private async resolveOpenFlags(kuId: string, now: Timestamp): Promise<void> {
+    const openFlags = await this.db.collection(CONTENT_FLAGS_COLLECTION)
+      .where('kuId', '==', kuId)
+      .where('status', '==', 'open')
+      .get();
+    if (!openFlags.empty) {
+      const batch = this.db.batch();
+      openFlags.docs.forEach(doc => batch.update(doc.ref, { status: 'resolved', resolvedAt: now }));
+      await batch.commit();
+      this.logger.log(`Resolved ${openFlags.size} open flag(s) for kuId=${kuId}`);
+    }
+  }
+
+  async getFlags(status?: string): Promise<ContentFlag[]> {
+    let query: Query = this.db.collection(CONTENT_FLAGS_COLLECTION);
+    if (status) {
+      query = query.where('status', '==', status);
+    }
+    query = query.orderBy('createdAt', 'desc').limit(100);
+    const snap = await query.get();
+    return snap.docs.map(doc => ({ id: doc.id, ...doc.data() }) as ContentFlag);
+  }
+
+  async updateFlag(
+    flagId: string,
+    updates: { status: 'resolved' | 'dismissed'; dismissNote?: string },
+  ): Promise<void> {
+    const ref = this.db.collection(CONTENT_FLAGS_COLLECTION).doc(flagId);
+    const payload: Record<string, any> = { status: updates.status };
+    if (updates.status === 'dismissed' && updates.dismissNote) {
+      payload.dismissNote = updates.dismissNote;
+    }
+    if (updates.status === 'resolved') {
+      payload.resolvedAt = Timestamp.now();
+    }
+    await ref.update(payload);
+  }
+}

--- a/frontend/src/app/admin/content-quality/page.tsx
+++ b/frontend/src/app/admin/content-quality/page.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { ContentFlag } from "@/types";
+import { apiFetch } from "@/lib/api-client";
+
+type TabKey = "open" | "resolved";
+
+export default function ContentQualityPage() {
+  const [activeTab, setActiveTab] = useState<TabKey>("open");
+  const [flags, setFlags] = useState<ContentFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actioningId, setActioningId] = useState<string | null>(null);
+  const [dismissNote, setDismissNote] = useState<Record<string, string>>({});
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  const fetchFlags = useCallback(async (status: TabKey) => {
+    setLoading(true);
+    try {
+      const res = await apiFetch(`/api/content-flags?status=${status}`);
+      if (!res.ok) throw new Error("Failed to fetch flags");
+      setFlags(await res.json());
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFlags(activeTab);
+  }, [activeTab, fetchFlags]);
+
+  const handleRegenerate = async (flag: ContentFlag) => {
+    if (!flag.id || !flag.kuId) return;
+    setActioningId(flag.id);
+    try {
+      const res = await apiFetch(`/api/lessons/regenerate/${flag.kuId}`, { method: "POST" });
+      if (!res.ok) throw new Error("Regeneration failed");
+      await fetchFlags(activeTab);
+    } catch (err) {
+      console.error(err);
+      alert("Regeneration failed — check logs.");
+    } finally {
+      setActioningId(null);
+    }
+  };
+
+  const handleUpdateFlag = async (flagId: string, status: "resolved" | "dismissed") => {
+    setActioningId(flagId);
+    try {
+      const body: Record<string, string> = { status };
+      if (status === "dismissed" && dismissNote[flagId]) {
+        body.dismissNote = dismissNote[flagId];
+      }
+      const res = await apiFetch(`/api/content-flags/${flagId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Update failed");
+      setFlags((prev) => prev.filter((f) => f.id !== flagId));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setActioningId(null);
+    }
+  };
+
+  const handleFlagCreated = () => {
+    setShowCreateForm(false);
+    fetchFlags("open");
+    setActiveTab("open");
+  };
+
+  const tabClass = (tab: TabKey) =>
+    `px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+      activeTab === tab
+        ? "border-shodo-ink text-shodo-ink"
+        : "border-transparent text-shodo-ink/40 hover:text-shodo-ink/70"
+    }`;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-shodo-ink">Content Quality</h1>
+        <button
+          onClick={() => setShowCreateForm((v) => !v)}
+          className="px-3 py-1.5 text-sm bg-shodo-ink text-shodo-paper rounded hover:opacity-80 transition-opacity"
+        >
+          {showCreateForm ? "Cancel" : "Flag Content"}
+        </button>
+      </div>
+
+      {showCreateForm && (
+        <CreateFlagForm onCreated={handleFlagCreated} />
+      )}
+
+      <div className="flex border-b border-shodo-ink/10 mb-6">
+        <button className={tabClass("open")} onClick={() => setActiveTab("open")}>
+          Open Flags
+        </button>
+        <button className={tabClass("resolved")} onClick={() => setActiveTab("resolved")}>
+          Resolved
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="text-shodo-ink/50 text-sm">Loading...</p>
+      ) : flags.length === 0 ? (
+        <p className="text-shodo-ink/50 text-sm">No {activeTab} flags.</p>
+      ) : (
+        <div className="space-y-4">
+          {flags.map((flag) => (
+            <FlagRow
+              key={flag.id}
+              flag={flag}
+              isOpen={activeTab === "open"}
+              actioning={actioningId === flag.id}
+              dismissNote={dismissNote[flag.id!] ?? ""}
+              onDismissNoteChange={(note) =>
+                setDismissNote((prev) => ({ ...prev, [flag.id!]: note }))
+              }
+              onRegenerate={() => handleRegenerate(flag)}
+              onDismiss={() => handleUpdateFlag(flag.id!, "dismissed")}
+              onResolve={() => handleUpdateFlag(flag.id!, "resolved")}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create manual flag form
+// ---------------------------------------------------------------------------
+
+function CreateFlagForm({ onCreated }: { onCreated: () => void }) {
+  const [form, setForm] = useState({
+    sourceType: "lesson" as "lesson" | "scenario",
+    sourceId: "",
+    kuContent: "",
+    userLevel: "N4",
+    manualNote: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.sourceId || !form.kuContent || !form.manualNote) {
+      setError("All fields are required.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      const res = await apiFetch("/api/content-flags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("Failed to create flag");
+      onCreated();
+    } catch (err) {
+      console.error(err);
+      setError("Failed to create flag.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    "w-full text-sm border border-shodo-ink/20 rounded px-2 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-shodo-ink/30";
+  const labelClass = "block text-xs font-medium text-shodo-ink/60 mb-1";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-6 p-4 border border-shodo-ink/10 rounded-lg bg-shodo-paper/50 space-y-3"
+    >
+      <p className="text-sm font-medium text-shodo-ink">Flag content for review</p>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className={labelClass}>Source type</label>
+          <select
+            value={form.sourceType}
+            onChange={(e) => setForm((f) => ({ ...f, sourceType: e.target.value as "lesson" | "scenario" }))}
+            className={inputClass}
+          >
+            <option value="lesson">Lesson</option>
+            <option value="scenario">Scenario</option>
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>User level</label>
+          <select
+            value={form.userLevel}
+            onChange={(e) => setForm((f) => ({ ...f, userLevel: e.target.value }))}
+            className={inputClass}
+          >
+            {["N5", "N4", "N3", "N2", "N1"].map((l) => (
+              <option key={l} value={l}>{l}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className={labelClass}>
+          {form.sourceType === "lesson" ? "KU ID (lesson document ID)" : "Scenario ID"}
+        </label>
+        <input
+          type="text"
+          value={form.sourceId}
+          onChange={(e) => setForm((f) => ({ ...f, sourceId: e.target.value }))}
+          placeholder="Firestore document ID"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className={labelClass}>Content label (word, pattern, or scenario title)</label>
+        <input
+          type="text"
+          value={form.kuContent}
+          onChange={(e) => setForm((f) => ({ ...f, kuContent: e.target.value }))}
+          placeholder="e.g. 食べる or Bookshop Scene"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className={labelClass}>Note — describe what needs review</label>
+        <textarea
+          value={form.manualNote}
+          onChange={(e) => setForm((f) => ({ ...f, manualNote: e.target.value }))}
+          rows={2}
+          placeholder="e.g. Context example uses N2 grammar for an N4 learner"
+          className={inputClass}
+        />
+      </div>
+
+      {error && <p className="text-xs text-red-600">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="px-4 py-1.5 text-sm bg-shodo-ink text-shodo-paper rounded hover:opacity-80 disabled:opacity-40 transition-opacity"
+      >
+        {saving ? "Saving..." : "Create Flag"}
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Flag row
+// ---------------------------------------------------------------------------
+
+interface FlagRowProps {
+  flag: ContentFlag;
+  isOpen: boolean;
+  actioning: boolean;
+  dismissNote: string;
+  onDismissNoteChange: (note: string) => void;
+  onRegenerate: () => void;
+  onDismiss: () => void;
+  onResolve: () => void;
+}
+
+function FlagRow({
+  flag,
+  isOpen,
+  actioning,
+  dismissNote,
+  onDismissNoteChange,
+  onRegenerate,
+  onDismiss,
+  onResolve,
+}: FlagRowProps) {
+  const [showDismissInput, setShowDismissInput] = useState(false);
+  const isManual = !flag.violations.length && !!flag.manualNote;
+  const canRegenerate = flag.sourceType === "lesson" && !!flag.kuId;
+
+  return (
+    <div className="border border-shodo-ink/10 rounded-lg p-4 bg-white">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <span className="font-mono text-base text-shodo-ink">{flag.kuContent}</span>
+            <span className="text-xs text-shodo-ink/40">JLPT {flag.userLevel}</span>
+            <span className="text-xs text-shodo-ink/30 uppercase tracking-wide">{flag.sourceType}</span>
+            <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+              isManual ? "bg-amber-100 text-amber-700" : "bg-red-100 text-red-700"
+            }`}>
+              {isManual ? "manual" : flag.status}
+            </span>
+          </div>
+
+          {isManual ? (
+            <p className="mt-1 text-sm text-shodo-ink/70 italic">{flag.manualNote}</p>
+          ) : (
+            <div className="space-y-1 mt-2">
+              {flag.violations.map((v, i) => (
+                <div key={i} className="flex items-center gap-2 text-sm">
+                  <span className="font-mono text-shodo-ink">{v.segment}</span>
+                  <span className="text-xs text-shodo-ink/50">→ {v.detectedLevel}</span>
+                  <span className="text-xs text-shodo-ink/30 italic">{v.type}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {flag.dismissNote && (
+            <p className="mt-2 text-xs text-shodo-ink/50 italic">Note: {flag.dismissNote}</p>
+          )}
+
+          <p className="mt-1.5 text-xs text-shodo-ink/30 font-mono">{flag.sourceId}</p>
+        </div>
+
+        {isOpen && (
+          <div className="flex flex-col gap-2 shrink-0">
+            {canRegenerate && (
+              <button
+                onClick={onRegenerate}
+                disabled={actioning}
+                className="px-3 py-1.5 text-xs bg-shodo-ink text-shodo-paper rounded hover:opacity-80 disabled:opacity-40 transition-opacity"
+              >
+                {actioning ? "..." : "Regenerate"}
+              </button>
+            )}
+            <button
+              onClick={onResolve}
+              disabled={actioning}
+              className="px-3 py-1.5 text-xs border border-shodo-ink/20 text-shodo-ink rounded hover:bg-shodo-ink/5 disabled:opacity-40 transition-colors"
+            >
+              Resolve
+            </button>
+            <button
+              onClick={() => setShowDismissInput((v) => !v)}
+              disabled={actioning}
+              className="px-3 py-1.5 text-xs border border-shodo-ink/10 text-shodo-ink/50 rounded hover:bg-shodo-ink/5 disabled:opacity-40 transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showDismissInput && isOpen && (
+        <div className="mt-3 flex gap-2">
+          <input
+            type="text"
+            placeholder="Reason for dismissal (optional)"
+            value={dismissNote}
+            onChange={(e) => onDismissNoteChange(e.target.value)}
+            className="flex-1 text-xs border border-shodo-ink/20 rounded px-2 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-shodo-ink/30"
+          />
+          <button
+            onClick={onDismiss}
+            disabled={actioning}
+            className="px-3 py-1.5 text-xs bg-shodo-ink/10 text-shodo-ink rounded hover:bg-shodo-ink/20 disabled:opacity-40 transition-colors"
+          >
+            Confirm
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/AvatarMenu.tsx
+++ b/frontend/src/components/AvatarMenu.tsx
@@ -121,6 +121,9 @@ export function AvatarMenu() {
               <Link href="/admin/logs" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
                 API Logs
               </Link>
+              <Link href="/admin/content-quality" className="block px-3 py-2 text-sm text-shodo-ink hover:bg-shodo-ink/5 transition-colors" onClick={() => setOpen(false)}>
+                Content Quality
+              </Link>
             </>
           )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -104,6 +104,12 @@ export interface UserRoot {
   };
 }
 
+export interface LessonValidation {
+  status: 'pending' | 'pass' | 'fail';
+  checkedAt?: Timestamp;
+  violations?: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+}
+
 export interface VocabLesson {
   kuId?: string;
   type: "Vocab";
@@ -116,6 +122,7 @@ export interface VocabLesson {
   meaning_explanation: string;
   reading_explanation: string;
   context_examples?: { sentence: string; translation: string }[];
+  validation?: LessonValidation;
   component_kanji?: {
     kanji: string;
     reading: string;
@@ -234,6 +241,7 @@ export interface GrammarLesson {
   meaning: string;
   formation: string | string[];
   notes: string;
+  validation?: LessonValidation;
   examples: {
     japanese: string;
     english: string;
@@ -482,6 +490,8 @@ export interface UserKnowledgeUnit {
   facet_count: number;
   history?: any[];
   currentStage?: number;
+  /** True if ku.data.jlptLevel > user.preferences.jlptLevel at enrollment time. Above-level items are excluded from ambient generation context. */
+  aboveLevel?: boolean;
 }
 
 export interface FacetStageEntry {
@@ -578,4 +588,21 @@ export interface UserQuestionState {
   questionId: string;
   rejected: boolean;
   consecutiveFailures: number;
+}
+
+// ─── Content validation ───────────────────────────────────────────────────────
+
+export interface ContentFlag {
+  id?: string;
+  kuId?: string;
+  sourceType: 'lesson' | 'facet' | 'scenario';
+  sourceId: string;
+  kuContent: string;
+  userLevel: string;
+  violations: Array<{ segment: string; detectedLevel: string; type: 'vocab' | 'grammar' }>;
+  status: 'open' | 'resolved' | 'dismissed';
+  manualNote?: string;
+  dismissNote?: string;
+  resolvedAt?: Timestamp;
+  createdAt: Timestamp;
 }


### PR DESCRIPTION
## Summary

  Implements a three-layer content level guardrail system to prevent users from being exposed to Japanese vocabulary and
  grammar above their declared JLPT level. The root causes were: a hardcoded N4 complexity cap applied to all users; the
  `get_user_level` AI tool returning a static JLPT schema rather than the user's actual enrolled grammar; Grammar KUs
  routing through the wrong question-generation path; and the `get_grammar_patterns` scenario tool returning the entire
  global corpus rather than enrolled patterns.

  **Prevention** — constraint fixes across all AI generation paths
  **Detection** — post-generation validation that flags violations before they propagate downstream
  **Correction** — admin UI at `/admin/content-quality` and backend endpoints for remediation

  ## Changes

  ### Types (`backend/src/types/index.ts`, `frontend/src/types/index.ts`)
  - `UserKnowledgeUnit.aboveLevel?: boolean` — set at enrollment if `ku.data.jlptLevel > user.preferences.jlptLevel`
  - `LessonValidation` type and `validation?` field on `VocabLesson` and `GrammarLesson`
  - `ContentFlag` type — `sourceType: 'lesson' | 'facet' | 'scenario'`, `kuId` now optional, `manualNote?`
  - `ValidationResult` type (backend-only)

  ### Prevention

  **`aboveLevel` flag at enrollment** (`user-knowledge-units.service.ts`)
  Fetches both the KU and user documents in parallel on enrollment. Computes `aboveLevel` using `JLPT_DIFFICULTY` comparison
   and writes it to the UKU document. `allowedGrammar`, `recordKuEnrolled`, `updateCurriculumNode` are only called for
  in-level items.

  **`get_user_level` tool fix** (`questions.service.ts`)
  Previously returned `getCumulativeGrammar(level)` — a static schema for the entire JLPT level. Now returns `{ jlptLevel,
  allowedGrammar }` where `allowedGrammar` is the user's actual enrolled Grammar KU patterns filtered to `aboveLevel !=
  true`. Prompts already said "use ONLY grammar from the returned schema" — the tool response was the problem, not the
  prompt text.
  
  **Grammar question routing** (`questions.service.ts`, `quiz.prompts.ts`)
  Grammar KUs previously fell through to the vocab/noun-particle path, producing nonsensical questions. Added `if
  (kuData.type === 'Grammar')` branch routing to a new `generateGrammarQuestion` method. Added `buildGrammarQuestionPrompt`
  with two question types (`novel-translation`, `error-correction`); questions are in English, test correct application of
  the pattern, no noun-particle mechanics.
  
  **`get_grammar_patterns` scenario tool** (`scenarios.service.ts`)
  `buildGrammarToolHandlers` now queries `users/{uid}/user-kus` for enrolled Grammar KUs with `aboveLevel != true`,
  batch-fetches the global KU documents, and returns only what the user has actually enrolled in — not the entire global
  corpus at a JLPT level.

  **Dynamic level cap in lesson prompts** (`fragments.ts`, `vocab.prompts.ts`, `grammar.prompts.ts`, `lessons.service.ts`)
  Removed hardcoded `USER_TARGET_LEVEL = 'N4'`. Replaced with `levelConstraint(jlptLevel: string)` function.
  `buildVocabLessonMessage`, `buildVocabCacheContext`, and `buildGrammarLessonMessage` now accept `jlptLevel: string`.
  `generateLesson` fetches `user.preferences.jlptLevel` from Firestore and passes it to both builders. `processBatch`
  fetches the user level once for the shared context cache.
  
  ### Detection

  **`ValidationService` + `ValidationModule`** (`backend/src/validation/`)
  `@Global()` module. Uses Gemini flash model with structured output to check generated Japanese content against the user's
  JLPT level. Returns `ValidationResult { valid, violations[] }`. All calls logged to `api-logs` under
  `/validation/content`.

  **Lesson validation hook** (`lessons.service.ts`)
  Non-blocking `validateAndFlagLesson` fires after every new lesson is stored. Extracts `context_examples[].sentence` for
  Vocab, `examples[].japanese` for Grammar. Writes `lessons/{kuId}.validation.status` + creates a `content-flags` document
  on failure. On subsequent pass (after regeneration), open flags for that KU are auto-resolved.

  **Scenario validation hook** (`scenarios.service.ts`)
  Non-blocking `validateScenario` fires after `generateScenario` and `saveFromTutor`. Checks all `dialogue[].text` lines
  against `difficultyLevel`. Creates a `content-flags` document on failure.

  ### Correction
  
  **Backend endpoints** (`content-flags.controller.ts`, `lessons.controller.ts`)
  - `GET /api/content-flags?status=open|resolved` — list flags (admin-only)
  - `PATCH /api/content-flags/:id` — resolve or dismiss with optional note
  - `POST /api/lessons/regenerate/:kuId` — reset lesson to failed state and re-generate (admin-only)
  
  **Admin UI** (`frontend/src/app/admin/content-quality/page.tsx`)
  Two-tab view (Open / Resolved). Each flag shows the offending content, detected level, violation segments, and source
  type. Automated flags: Regenerate / Resolve / Dismiss actions. Manual flags: amber badge, displays note text, Resolve /
  Dismiss only. Scenario flags: no Regenerate (no equivalent endpoint). "Flag Content" button opens a form to create manual
  flags for any lesson or scenario.
  
  **`CONTENT-QUALITY-GUIDE.md`** (repo root)
  Reference document covering the JLPT-as-curated-path principle, the above-level item policy, how `allowedGrammar` is
  built, what counts as a violation, and the correction decision process.
  

  - [ ] Generate a vocab lesson for an N5 user — confirm context examples do not use N3/N4 grammar patterns
  - [ ] Enroll a Grammar KU, trigger an `AI-Generated-Question` review — confirm the question is in English and tests
  pattern application, not noun-particle mechanics
  - [ ] Check `get_user_level` tool response in API logs for a user — confirm `allowedGrammar` reflects actual enrolled
  grammar, not the full N5 static schema
  - [ ] Enroll an above-level KU and confirm `aboveLevel: true` on the UKU document in Firestore; confirm it is absent from
  `allowedGrammar`
  - [ ] Visit `/admin/content-quality` — confirm the page loads and shows any existing open flags
  - [ ] Manually create a flag via the "Flag Content" form — confirm it appears as an amber manual flag
  - [ ] Regenerate a flagged lesson — confirm the flag disappears on re-generation if the new lesson passes validation
